### PR TITLE
fix: code format for multiple files to comply with Go coding standards

### DIFF
--- a/cmd/immuclient/immuclient.go
+++ b/cmd/immuclient/immuclient.go
@@ -68,7 +68,7 @@ Environment variables:
 		DisableAutoGenTag: true,
 	}
 	commands := []*cobra.Command{
-		&cobra.Command{
+		{
 			Use:     "login username \"password\"",
 			Short:   fmt.Sprintf("Login using the specified username and \"password\" (username is \"%s\")", auth.AdminUser.Username),
 			Aliases: []string{"l"},
@@ -97,7 +97,7 @@ Environment variables:
 			},
 			Args: cobra.ExactArgs(2),
 		},
-		&cobra.Command{
+		{
 			Use:     "current",
 			Short:   "Return the last merkle tree root and index stored locally",
 			Aliases: []string{"crt"},
@@ -115,7 +115,7 @@ Environment variables:
 			},
 			Args: cobra.ExactArgs(0),
 		},
-		&cobra.Command{
+		{
 			Use:     "getByIndex",
 			Short:   "Return an element by index",
 			Aliases: []string{"bi"},
@@ -137,7 +137,7 @@ Environment variables:
 			},
 			Args: cobra.ExactArgs(1),
 		},
-		&cobra.Command{
+		{
 			Use:     "logout",
 			Aliases: []string{"x"},
 			RunE: func(cmd *cobra.Command, args []string) error {
@@ -147,7 +147,7 @@ Environment variables:
 			},
 			Args: cobra.NoArgs,
 		},
-		&cobra.Command{
+		{
 			Use:     "get key",
 			Short:   "Get item having the specified key",
 			Aliases: []string{"g"},
@@ -170,7 +170,7 @@ Environment variables:
 			},
 			Args: cobra.ExactArgs(1),
 		},
-		&cobra.Command{
+		{
 			Use:     "rawsafeget key",
 			Short:   "Get item having the specified key, without parsing structured values",
 			Aliases: []string{"rg"},
@@ -229,7 +229,7 @@ Environment variables:
 			},
 			Args: cobra.ExactArgs(1),
 		},
-		&cobra.Command{
+		{
 			Use:     "rawsafeset key",
 			Short:   "Set item having the specified key, without setup structured values",
 			Aliases: []string{"rs"},
@@ -295,7 +295,7 @@ Environment variables:
 			},
 			Args: cobra.ExactArgs(2),
 		},
-		&cobra.Command{
+		{
 			Use:     "safeget key",
 			Short:   "Get and verify item having the specified key",
 			Aliases: []string{"sg"},
@@ -318,7 +318,7 @@ Environment variables:
 			},
 			Args: cobra.ExactArgs(1),
 		},
-		&cobra.Command{
+		{
 			Use:     "set key value",
 			Short:   "Add new item having the specified key and value",
 			Aliases: []string{"s"},
@@ -363,7 +363,7 @@ Environment variables:
 			},
 			Args: cobra.ExactArgs(2),
 		},
-		&cobra.Command{
+		{
 			Use:     "safeset key value",
 			Short:   "Add and verify new item having the specified key and value",
 			Aliases: []string{"ss"},
@@ -408,7 +408,7 @@ Environment variables:
 			},
 			Args: cobra.ExactArgs(2),
 		},
-		&cobra.Command{
+		{
 			Use:     "reference refkey key",
 			Short:   "Add new reference to an existing key",
 			Aliases: []string{"r"},
@@ -447,7 +447,7 @@ Environment variables:
 			},
 			Args: cobra.MinimumNArgs(1),
 		},
-		&cobra.Command{
+		{
 			Use:     "safereference refkey key",
 			Short:   "Add and verify new reference to an existing key",
 			Aliases: []string{"sr"},
@@ -486,7 +486,7 @@ Environment variables:
 			},
 			Args: cobra.MinimumNArgs(1),
 		},
-		&cobra.Command{
+		{
 			Use:     "zadd setname score key",
 			Short:   "Add new key with score to a new or existing sorted set",
 			Aliases: []string{"za"},
@@ -527,7 +527,7 @@ Environment variables:
 			},
 			Args: cobra.MinimumNArgs(3),
 		},
-		&cobra.Command{
+		{
 			Use:     "safezadd setname score key",
 			Short:   "Add and verify new key with score to a new or existing sorted set",
 			Aliases: []string{"sza"},
@@ -568,7 +568,7 @@ Environment variables:
 			},
 			Args: cobra.MinimumNArgs(3),
 		},
-		&cobra.Command{
+		{
 			Use:     "zscan setname",
 			Short:   "Iterate over a sorted set",
 			Aliases: []string{"zscn"},
@@ -593,7 +593,7 @@ Environment variables:
 			},
 			Args: cobra.ExactArgs(1),
 		},
-		&cobra.Command{
+		{
 			Use:     "iscan pagenumber pagesize",
 			Short:   "Iterate over all elements by insertion order",
 			Aliases: []string{"iscn"},
@@ -622,7 +622,7 @@ Environment variables:
 			},
 			Args: cobra.ExactArgs(2),
 		},
-		&cobra.Command{
+		{
 			Use:     "scan prefix",
 			Short:   "Iterate over keys having the specified prefix",
 			Aliases: []string{"scn"},
@@ -648,7 +648,7 @@ Environment variables:
 			},
 			Args: cobra.ExactArgs(1),
 		},
-		&cobra.Command{
+		{
 			Use:     "count prefix",
 			Short:   "Count keys having the specified prefix",
 			Aliases: []string{"cnt"},
@@ -671,7 +671,7 @@ Environment variables:
 			},
 			Args: cobra.ExactArgs(1),
 		},
-		&cobra.Command{
+		{
 			Use:     "inclusion index",
 			Short:   "Check if specified index is included in the current tree",
 			Aliases: []string{"i"},
@@ -726,7 +726,7 @@ root: %x at index: %d
 			},
 			Args: cobra.MinimumNArgs(1),
 		},
-		&cobra.Command{
+		{
 			Use:     "check-consistency index hash",
 			Short:   "Check consistency for the specified index and hash",
 			Aliases: []string{"c"},
@@ -768,7 +768,7 @@ secondRoot: %x at index: %d
 			},
 			Args: cobra.MinimumNArgs(2),
 		},
-		&cobra.Command{
+		{
 			Use:     "history key",
 			Short:   "Fetch history for the item having the specified key",
 			Aliases: []string{"h"},
@@ -794,7 +794,7 @@ secondRoot: %x at index: %d
 			},
 			Args: cobra.ExactArgs(1),
 		},
-		&cobra.Command{
+		{
 			Use:     "ping",
 			Short:   "Ping to check if server connection is alive",
 			Aliases: []string{"p"},
@@ -813,7 +813,7 @@ secondRoot: %x at index: %d
 			},
 			Args: cobra.NoArgs,
 		},
-		&cobra.Command{
+		{
 			Use:     "dump [filename]",
 			Short:   "Save a database dump to the specified filename (optional)",
 			Aliases: []string{"b"},

--- a/pkg/client/batch_request.go
+++ b/pkg/client/batch_request.go
@@ -30,7 +30,7 @@ type BatchRequest struct {
 
 func (b *BatchRequest) toKVList() (*schema.KVList, error) {
 	list := &schema.KVList{}
-	for i, _ := range b.Keys {
+	for i := range b.Keys {
 		key, err := ioutil.ReadAll(b.Keys[i])
 		if err != nil {
 			return nil, err

--- a/pkg/client/timestamp/default.go
+++ b/pkg/client/timestamp/default.go
@@ -20,12 +20,12 @@ import (
 	"time"
 )
 
-type tdefault struct {}
+type tdefault struct{}
 
 func NewTdefault() (TsGenerator, error) {
 	return &tdefault{}, nil
 }
 
-func (w *tdefault) Now() (time.Time) {
+func (w *tdefault) Now() time.Time {
 	return time.Now()
 }

--- a/pkg/client/timestamp/ntp.go
+++ b/pkg/client/timestamp/ntp.go
@@ -26,13 +26,13 @@ type ntp struct {
 }
 
 func NewNtp() (TsGenerator, error) {
-	r, err :=  s.Query("0.beevik-ntp.pool.ntp.org")
-	if err!= nil {
+	r, err := s.Query("0.beevik-ntp.pool.ntp.org")
+	if err != nil {
 		return nil, err
 	}
 	return &ntp{r}, nil
 }
 
-func (w *ntp) Now() (time.Time) {
+func (w *ntp) Now() time.Time {
 	return time.Now().Add(w.r.ClockOffset)
 }

--- a/pkg/client/timestamp/tsgenerator.go
+++ b/pkg/client/timestamp/tsgenerator.go
@@ -19,5 +19,5 @@ package timestamp
 import "time"
 
 type TsGenerator interface {
-	Now() (time.Time)
+	Now() time.Time
 }

--- a/pkg/client/timestamp_service.go
+++ b/pkg/client/timestamp_service.go
@@ -22,7 +22,7 @@ import (
 )
 
 type TimestampService interface {
-	GetTime() (time.Time)
+	GetTime() time.Time
 }
 
 type timestampService struct {
@@ -33,6 +33,6 @@ func NewTimestampService(ts timestamp.TsGenerator) TimestampService {
 	return &timestampService{ts}
 }
 
-func (r *timestampService) GetTime() (time.Time) {
+func (r *timestampService) GetTime() time.Time {
 	return r.ts.Now()
 }

--- a/pkg/store/safe_test.go
+++ b/pkg/store/safe_test.go
@@ -96,7 +96,7 @@ func TestStoreSafeGet(t *testing.T) {
 	// second item with prev root
 	prevRoot := safeItem.Proof.NewRoot()
 	safeItem, err = st.SafeGet(schema.SafeGetOptions{
-			Key: []byte(`second`),
+		Key: []byte(`second`),
 		RootIndex: &schema.Index{
 			Index: prevRoot.Index,
 		},
@@ -153,7 +153,7 @@ func TestStoreSafeReference(t *testing.T) {
 		opts := schema.SafeReferenceOptions{
 			Ro: &schema.ReferenceOptions{
 				Reference: []byte(strconv.FormatUint(n, 10)),
-				Key:        firstKey,
+				Key:       firstKey,
 			},
 			RootIndex: &schema.Index{
 				Index: root.Index,
@@ -197,7 +197,7 @@ func TestStoreSafeGetOnSafeReference(t *testing.T) {
 	// first item, no prev root
 	ref1 := schema.SafeReferenceOptions{
 		Ro: &schema.ReferenceOptions{
-			Reference:firstTag,
+			Reference: firstTag,
 			Key:       firstKey,
 		},
 	}
@@ -212,8 +212,8 @@ func TestStoreSafeGetOnSafeReference(t *testing.T) {
 
 	ref2 := schema.SafeReferenceOptions{
 		Ro: &schema.ReferenceOptions{
-			Reference:secondTag,
-			Key:      firstKey,
+			Reference: secondTag,
+			Key:       firstKey,
 		},
 		RootIndex: &schema.Index{
 			Index: proof.Index,
@@ -231,7 +231,7 @@ func TestStoreSafeGetOnSafeReference(t *testing.T) {
 
 	// first item by first tag , no prev root
 	firstItem1, err := st.SafeGet(schema.SafeGetOptions{
-		Key:firstTag,
+		Key: firstTag,
 		RootIndex: &schema.Index{
 			Index: proof2.Index,
 		},
@@ -249,7 +249,7 @@ func TestStoreSafeGetOnSafeReference(t *testing.T) {
 
 	// get first item by second tag with most fresh root
 	firstItem2, err := st.SafeGet(schema.SafeGetOptions{
-			Key: secondTag,
+		Key: secondTag,
 		RootIndex: &schema.Index{
 			Index: proof2.Index,
 		},


### PR DESCRIPTION
There is a long list of improvements to make the code more readable and standard according to Go idioms. This pull-request is the first contribution to the project and so I want to keep it simple to familiarize myself with the contribution guidelines and branch management. Depending on how the discussion goes and if these changes are merged, I will continue sending more pull-requests of trivial things like ineffectual variable assignments, misaligned struct types, redundant statements, etc. Later when I am more familiar with the code I will contribute new features.

    find . -type f -name "*.go" -exec gofmt -s -w {} \;