### PR TITLE
build: use hardcoded, manually-bumped version instead of git tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ V_BUILT_BY := $(shell git config user.email)
 V_BUILT_AT := $(shell date +%s)
 V_LDFLAGS_COMMON := -X "github.com/codenotary/immudb/cmd/version.Commit=$(V_COMMIT)" -X "github.com/codenotary/immudb/cmd/version.BuiltBy=$(V_BUILT_BY)" -X "github.com/codenotary/immudb/cmd/version.BuiltAt=$(V_BUILT_AT)"
 
-V_COMMON := $(shell git tag --sort=-version:refname | head -n 1)
+V_COMMON := v$(VERSION)
 V_IMMUCLIENT := $(V_COMMON)
 V_IMMUADMIN := $(V_COMMON)
 V_IMMUDB := $(V_COMMON)


### PR DESCRIPTION
Using the latest git tag proved to be unreliable: the sort order was wrong in `git tag --sort=-version:refname | head -n 1` => the first in the list was RC-2, which is incorrect. We could've sorted by `-creatordate` and that would've worked, but if tags which represent something other than a version would be used in the future, this could still cause problems.
So i decided to just use the manually entered version instead since (it was already present and used in the Makefile, hence it already needs to be manually bumped).