### PR TITLE
fix: skip loading databases from disk when in memory is requested

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -312,6 +312,10 @@ func (s *ImmuServer) loadDefaultDatabase(dataDir string) error {
 }
 
 func (s *ImmuServer) loadUserDatabases(dataDir string) error {
+	//return early since there is nothing to load
+	if s.Options.GetInMemoryStore() {
+		return nil
+	}
 	var dirs []string
 	//get first level sub directories of data dir
 	err := filepath.Walk(s.Options.Dir, func(path string, info os.FileInfo, err error) error {


### PR DESCRIPTION
closes #369 