### PR TITLE
improvement(pkg/server): avoid recursion on corruption checker

### DIFF
--- a/pkg/server/corruption_checker.go
+++ b/pkg/server/corruption_checker.go
@@ -76,7 +76,16 @@ func NewCorruptionChecker(opt CCOptions, d DatabaseList, l logger.Logger, rg Ran
 // Start start the trust checker loop
 func (s *corruptionChecker) Start(ctx context.Context) (err error) {
 	s.Logger.Debugf("Start scanning ...")
-	return s.checkLevel0(ctx)
+
+	for {
+		err = s.checkLevel0(ctx)
+
+		if err != nil || s.Exit || s.options.singleiteration {
+			return err
+		}
+
+		s.sleep()
+	}
 }
 
 // Stop stop the trust checker loop
@@ -139,12 +148,7 @@ func (s *corruptionChecker) checkLevel0(ctx context.Context) (err error) {
 		}
 	}
 	s.Wg.Done()
-	s.sleep()
-	if !s.Exit && !s.options.singleiteration {
-		if err = s.checkLevel0(ctx); err != nil {
-			return err
-		}
-	}
+
 	return nil
 }
 


### PR DESCRIPTION
Corruption checker is a non-stop validation and as such, it cannot rely on recursive invocations.

Signed-off-by: Jeronimo Irazabal <jeronimo.irazabal@gmail.com>