### PR TITLE
Fix immudb and immugw version and mangen commands errors

### DIFF
--- a/cmd/helper/config.go
+++ b/cmd/helper/config.go
@@ -17,12 +17,13 @@ limitations under the License.
 package helper
 
 import (
+	"os"
+	"strings"
+
 	service "github.com/codenotary/immudb/cmd/immuclient/service/constants"
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"os"
-	"strings"
 )
 
 // Options cmd options
@@ -59,10 +60,9 @@ func (c *Config) Init(name string) error {
 	return nil
 }
 
+// LoadConfig loads the config file (if any) and initializes the config
 func (c *Config) LoadConfig(cmd *cobra.Command) (err error) {
-	if c.CfgFn, err = cmd.Flags().GetString("config"); err != nil {
-		return err
-	}
+	c.CfgFn, _ = cmd.Flags().GetString("config")
 	if err = c.Init(c.Name); err != nil {
 		if !strings.Contains(err.Error(), "Not Found") {
 			return err

--- a/cmd/helper/config_test.go
+++ b/cmd/helper/config_test.go
@@ -17,14 +17,15 @@ limitations under the License.
 package helper
 
 import (
-	"github.com/mitchellh/go-homedir"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"log"
 	"os"
 	"testing"
+
+	"github.com/mitchellh/go-homedir"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestOptions_InitConfig(t *testing.T) {
@@ -85,7 +86,7 @@ func TestConfig_LoadError(t *testing.T) {
 	assert.NotNil(t, address)
 	cmd := cobra.Command{}
 	err := o.LoadConfig(&cmd)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 }
 
 func TestConfig_LoadError2(t *testing.T) {

--- a/cmd/immuadmin/command/backup_test.go
+++ b/cmd/immuadmin/command/backup_test.go
@@ -20,13 +20,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/codenotary/immudb/cmd/helper"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"io/ioutil"
 	stdos "os"
 	"path/filepath"
 	"testing"
+
+	"github.com/codenotary/immudb/cmd/helper"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/codenotary/immudb/cmd/cmdtest"
 	"github.com/codenotary/immudb/pkg/api/schema"
@@ -854,5 +855,5 @@ func TestCommandlineBck_ConfigChainErr(t *testing.T) {
 	cc := c.ConfigChain(f)
 
 	err := cc(cmd, []string{})
-	assert.Error(t, err)
+	assert.NoError(t, err)
 }

--- a/cmd/immuadmin/command/commandline_test.go
+++ b/cmd/immuadmin/command/commandline_test.go
@@ -19,9 +19,10 @@ package immuadmin
 import (
 	"context"
 	"errors"
+	"testing"
+
 	"github.com/codenotary/immudb/cmd/helper"
 	"github.com/stretchr/testify/assert"
-	"testing"
 
 	"github.com/codenotary/immudb/pkg/client/clienttest"
 	"github.com/stretchr/testify/require"
@@ -138,5 +139,5 @@ func TestCommandline_ConfigChainErr(t *testing.T) {
 	cc := c.ConfigChain(f)
 
 	err := cc(cmd, []string{})
-	assert.Error(t, err)
+	assert.NoError(t, err)
 }

--- a/cmd/immuclient/audit/auditor_test.go
+++ b/cmd/immuclient/audit/auditor_test.go
@@ -56,7 +56,7 @@ func TestInitAgent(t *testing.T) {
 	_, err = ad.InitAgent()
 	os.RemoveAll(pidPath)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "invalid duration X")
+	require.Contains(t, err.Error(), "invalid duration")
 	os.Unsetenv("audit-agent-interval")
 
 	auditPassword := viper.GetString("audit-password")

--- a/cmd/immuclient/command/commandline_test.go
+++ b/cmd/immuclient/command/commandline_test.go
@@ -17,9 +17,10 @@ limitations under the License.
 package immuclient
 
 import (
+	"testing"
+
 	"github.com/codenotary/immudb/cmd/helper"
 	"github.com/stretchr/testify/assert"
-	"testing"
 
 	"github.com/spf13/cobra"
 )
@@ -60,5 +61,5 @@ func TestCommandline_ConfigChainErr(t *testing.T) {
 	cc := c.ConfigChain(f)
 
 	err := cc(cmd, []string{})
-	assert.Error(t, err)
+	assert.NoError(t, err)
 }

--- a/cmd/immudb/command/commandline_test.go
+++ b/cmd/immudb/command/commandline_test.go
@@ -17,10 +17,11 @@ limitations under the License.
 package immudb
 
 import (
+	"testing"
+
 	"github.com/codenotary/immudb/cmd/helper"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestCommandline_Immudb(t *testing.T) {
@@ -58,5 +59,5 @@ func TestCommandline_ConfigChainErr(t *testing.T) {
 	cc := c.ConfigChain(f)
 
 	err := cc(cmd, []string{})
-	assert.Error(t, err)
+	assert.NoError(t, err)
 }

--- a/cmd/immugw/command/commandline_test.go
+++ b/cmd/immugw/command/commandline_test.go
@@ -17,9 +17,10 @@ limitations under the License.
 package immugw
 
 import (
+	"testing"
+
 	"github.com/codenotary/immudb/cmd/helper"
 	"github.com/stretchr/testify/assert"
-	"testing"
 
 	"github.com/spf13/cobra"
 )
@@ -49,5 +50,5 @@ func TestCommandline_ConfigChainErr(t *testing.T) {
 	cc := c.ConfigChain(f)
 
 	err := cc(cmd, []string{})
-	assert.Error(t, err)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
Without this change, while _**immuclient**_ and _**immuadmin**_ still worked as expected, _**immudb**_ and _**immugw**_ `version` and `mangen` commands (and possibly other ones too) are throwing the following error:
```
./immugw version
Error: flag accessed but not defined: config
Usage:
  immugw version [flags]

Flags:
  -h, --help   help for version

flag accessed but not defined: config
```