### PR TITLE
fix(embedded/tbtree): sync GetTs to prevent data races

### DIFF
--- a/embedded/tbtree/tbtree.go
+++ b/embedded/tbtree/tbtree.go
@@ -507,6 +507,9 @@ func (t *TBtree) Get(key []byte) (value []byte, ts uint64, err error) {
 }
 
 func (t *TBtree) GetTs(key []byte, limit int64) (ts []uint64, err error) {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
 	if t.closed {
 		return nil, ErrAlreadyClosed
 	}


### PR DESCRIPTION
Signed-off-by: Jeronimo Irazabal <jeronimo.irazabal@gmail.com>