### PR TITLE
chore(pkg/client): bound reference if atTx is provided in VerifiedSet…

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -999,6 +999,7 @@ func (c *immuClient) VerifiedSetReferenceAt(ctx context.Context, key []byte, ref
 			Key:           key,
 			ReferencedKey: referencedKey,
 			AtTx:          atTx,
+			BoundRef:      atTx > 0,
 		},
 		ProveSinceTx: state.TxId,
 	}


### PR DESCRIPTION
…ReferenceAt

Signed-off-by: Michele Meloni <cleaversdev@gmail.com>