### PR TITLE
feat: increase default store max value length to 32MB

### DIFF
--- a/pkg/server/options.go
+++ b/pkg/server/options.go
@@ -93,7 +93,7 @@ func DefaultStoreOptions() *store.Options {
 		WithIndexOptions(indexOptions).
 		WithMaxLinearProofLen(0).
 		WithMaxConcurrency(10).
-		WithMaxValueLen(1 << 20)
+		WithMaxValueLen(32 << 20)
 }
 
 // WithDir sets dir


### PR DESCRIPTION
Signed-off-by: Valentin Padurean (Ogg) <912518+padurean@users.noreply.github.com>