### PR TITLE
Re-enable client mock

### DIFF
--- a/cmd/immuclient/immuc/login_errors_test.go
+++ b/cmd/immuclient/immuc/login_errors_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 
 package immuc
 
-/*
 import (
 	"context"
 	"errors"
@@ -300,4 +299,4 @@ func TestLoginAndUserCommandsErrors(t *testing.T) {
 	_, err = ic.SetUserPermission(args)
 	require.Equal(t, errChangePermission, err)
 }
-*/
+

--- a/pkg/client/clienttest/immuclient_mock.go
+++ b/pkg/client/clienttest/immuclient_mock.go
@@ -106,7 +106,7 @@ func (icm *ImmuClientMock) Logout(ctx context.Context) error {
 }
 
 // VerifiedGet ...
-func (icm *ImmuClientMock) VerifiedGet(ctx context.Context, key []byte, opts ...grpc.CallOption) (*schema.Entry, error) {
+func (icm *ImmuClientMock) VerifiedGet(ctx context.Context, key []byte) (*schema.Entry, error) {
 	return icm.VerifiedGetF(ctx, key)
 }
 


### PR DESCRIPTION
Client mock was disabled. Probably because the APIs changed. This is an attempt to re-enable it.