### PR TITLE
chore(pkg/server): max recv msg size is set to 32M

### DIFF
--- a/pkg/server/options.go
+++ b/pkg/server/options.go
@@ -72,7 +72,7 @@ func DefaultOptions() *Options {
 		MTLs:                false,
 		MTLsOptions:         &MTLsOptions{},
 		auth:                true,
-		MaxRecvMsgSize:      1024 * 1024 * 4, // 4Mb
+		MaxRecvMsgSize:      1024 * 1024 * 32, // 32Mb
 		NoHistograms:        false,
 		Detached:            false,
 		CorruptionCheck:     true,


### PR DESCRIPTION
Signed-off-by: Michele Meloni <cleaversdev@gmail.com>