### PR TITLE
improve SDK UX on handling immudb illegal state

### DIFF
--- a/cmd/immuclient/immuclienttest/helper.go
+++ b/cmd/immuclient/immuclienttest/helper.go
@@ -69,6 +69,10 @@ func NewClientTest(pr helper.PasswordReader, tkns client.TokenService) *clientTe
 	}
 }
 
+func (ct *clientTest) WithOptions(opts *client.Options) *clientTest {
+	ct.Options = *opts
+	return ct
+}
 func (c *clientTest) Connect(dialer servertest.BuffDialer) {
 	dialOptions := []grpc.DialOption{
 		grpc.WithContextDialer(dialer), grpc.WithInsecure(),

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -184,6 +184,7 @@ func NewImmuClient(options *Options) (c ImmuClient, err error) {
 	ctx := context.Background()
 
 	c = DefaultClient()
+	c.WithOptions(options)
 	l := logger.NewSimpleLogger("immuclient", os.Stderr)
 	c.WithLogger(l)
 	c.WithTokenService(options.Tkns.WithTokenFileName(options.TokenFileName))
@@ -303,6 +304,7 @@ func (c *immuClient) SetupDialOptions(options *Options) *[]grpc.DialOption {
 	if c.serverSigningPubKey != nil {
 		uic = append(uic, c.SignatureVerifierInterceptor)
 	}
+	uic = append(uic, c.IllegalStateHandlerInterceptor)
 
 	if options.Auth && c.Tkns != nil {
 		token, err := c.Tkns.GetToken()

--- a/pkg/client/errors.go
+++ b/pkg/client/errors.go
@@ -24,7 +24,8 @@ import (
 var (
 	ErrIllegalArguments = errors.New("illegal arguments")
 
-	ErrAlreadyConnected  = errors.New("already connected")
-	ErrNotConnected      = errors.New("not connected")
-	ErrHealthCheckFailed = errors.New("health check failed")
+	ErrAlreadyConnected   = errors.New("already connected")
+	ErrNotConnected       = errors.New("not connected")
+	ErrHealthCheckFailed  = errors.New("health check failed")
+	ErrServerStateIsOlder = errors.New("server state is older than the client one")
 )

--- a/pkg/client/errors.go
+++ b/pkg/client/errors.go
@@ -18,6 +18,8 @@ package client
 
 import (
 	"errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // Errors related to Client connection and health check
@@ -28,4 +30,11 @@ var (
 	ErrNotConnected       = errors.New("not connected")
 	ErrHealthCheckFailed  = errors.New("health check failed")
 	ErrServerStateIsOlder = errors.New("server state is older than the client one")
+)
+
+// Server errors mapping
+var (
+	ErrSrvIllegalArguments   = status.Error(codes.InvalidArgument, "illegal arguments")
+	ErrSrvIllegalState       = status.Error(codes.InvalidArgument, "illegal state")
+	ErrSrvEmptyAdminPassword = status.Error(codes.InvalidArgument, "Admin password cannot be empty")
 )

--- a/pkg/client/illegal_state_handler_interceptor.go
+++ b/pkg/client/illegal_state_handler_interceptor.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2021 CodeNotary, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"errors"
+	"github.com/codenotary/immudb/pkg/server"
+	"strings"
+
+	"google.golang.org/grpc"
+)
+
+// IllegalStateHandlerInterceptor improve UX on SDK adding more context when immudb returns an illegal state error message on Verifiable* methods
+func (c *immuClient) IllegalStateHandlerInterceptor(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	err := invoker(ctx, method, req, reply, cc, opts...)
+	if err != nil && strings.Contains(method, "Verifiable") {
+		if errors.Is(err, server.ErrIllegalState) {
+			serverState, err := c.CurrentState(ctx)
+			if err != nil {
+				return err
+			}
+			localState, err := c.StateService.GetState(ctx, serverState.Db)
+			if err != nil {
+				return err
+			}
+			if localState.TxId > serverState.TxId {
+				return ErrServerStateIsOlder
+			}
+		}
+	}
+	return err
+}

--- a/pkg/client/illegal_state_handler_interceptor.go
+++ b/pkg/client/illegal_state_handler_interceptor.go
@@ -19,7 +19,6 @@ package client
 import (
 	"context"
 	"errors"
-	"github.com/codenotary/immudb/pkg/server"
 	"strings"
 
 	"google.golang.org/grpc"
@@ -29,7 +28,7 @@ import (
 func (c *immuClient) IllegalStateHandlerInterceptor(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 	err := invoker(ctx, method, req, reply, cc, opts...)
 	if err != nil && strings.Contains(method, "Verifiable") {
-		if errors.Is(err, server.ErrIllegalState) {
+		if errors.Is(err, ErrSrvIllegalState) {
 			serverState, err := c.CurrentState(ctx)
 			if err != nil {
 				return err

--- a/pkg/server/error_mapper_interceptor.go
+++ b/pkg/server/error_mapper_interceptor.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2021 CodeNotary, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+	"google.golang.org/grpc"
+)
+
+// ErrorMapperStream map standard errors in gRPC errors
+func ErrorMapperStream(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	err := handler(srv, ss)
+	return mapServerError(err)
+}
+
+// ErrorMapper map standard errors in gRPC errors
+func ErrorMapper(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	m, err := handler(ctx, req)
+	return m, mapServerError(err)
+}

--- a/pkg/server/errors.go
+++ b/pkg/server/errors.go
@@ -1,0 +1,24 @@
+package server
+
+import (
+	"github.com/codenotary/immudb/embedded/store"
+	"github.com/codenotary/immudb/pkg/database"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var (
+	ErrIllegalArguments   = status.Error(codes.InvalidArgument, database.ErrIllegalArguments.Error())
+	ErrIllegalState       = status.Error(codes.InvalidArgument, database.ErrIllegalState.Error())
+	ErrEmptyAdminPassword = status.Error(codes.InvalidArgument, "Admin password cannot be empty")
+)
+
+func mapServerError(err error) error {
+	switch err {
+	case store.ErrIllegalState:
+		return ErrIllegalState
+	case store.ErrIllegalArguments:
+		return ErrIllegalArguments
+	}
+	return err
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -59,9 +59,6 @@ const (
 	KeyPrefixUser = iota + 1
 )
 
-var ErrEmptyAdminPassword = fmt.Errorf("Admin password cannot be empty")
-var ErrIllegalArguments = fmt.Errorf("Illegal arguments")
-
 var startedAt time.Time
 
 var immudbTextLogo = " _                               _ _     \n" +
@@ -170,11 +167,13 @@ func (s *ImmuServer) Initialize() error {
 	uuidContext := NewUUIDContext(s.UUID)
 
 	uis := []grpc.UnaryServerInterceptor{
+		ErrorMapper, // converts errors in gRPC ones. Need to be the first
 		uuidContext.UUIDContextSetter,
 		grpc_prometheus.UnaryServerInterceptor,
 		auth.ServerUnaryInterceptor,
 	}
 	sss := []grpc.StreamServerInterceptor{
+		ErrorMapperStream, // converts errors in gRPC ones. Need to be the first
 		uuidContext.UUIDStreamContextSetter,
 		grpc_prometheus.StreamServerInterceptor,
 		auth.ServerStreamInterceptor,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -224,7 +224,7 @@ func (s *ImmuServer) Start() (err error) {
 	}()
 
 	s.mux.Unlock()
-	<-s.Quit
+	<-s.quit
 
 	return err
 }
@@ -445,7 +445,7 @@ func (s *ImmuServer) Stop() error {
 
 	s.Logger.Infof("Stopping immudb:\n%v", s.Options)
 
-	defer func() { s.Quit <- struct{}{} }()
+	defer func() { s.quit <- struct{}{} }()
 
 	if !s.Options.usingCustomListener {
 		s.GrpcServer.Stop()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -225,7 +225,7 @@ func (s *ImmuServer) Start() (err error) {
 	}()
 
 	s.mux.Unlock()
-	<-s.quit
+	<-s.Quit
 
 	return err
 }
@@ -446,7 +446,7 @@ func (s *ImmuServer) Stop() error {
 
 	s.Logger.Infof("Stopping immudb:\n%v", s.Options)
 
-	defer func() { s.quit <- struct{}{} }()
+	defer func() { s.Quit <- struct{}{} }()
 
 	if !s.Options.usingCustomListener {
 		s.GrpcServer.Stop()

--- a/pkg/server/servertest/server_mock.go
+++ b/pkg/server/servertest/server_mock.go
@@ -18,7 +18,6 @@ package servertest
 
 import (
 	"context"
-
 	"github.com/codenotary/immudb/pkg/api/schema"
 	"github.com/codenotary/immudb/pkg/server"
 	"github.com/golang/protobuf/ptypes/empty"
@@ -246,4 +245,8 @@ func (s *ServerMock) getDbIndexFromCtx(ctx context.Context, methodname string) (
 
 func (s *ServerMock) Stop() error {
 	return s.srv.Stop()
+}
+
+func (s *ServerMock) Initialize() error {
+	return s.srv.Initialize()
 }

--- a/pkg/server/servertest/server_mock.go
+++ b/pkg/server/servertest/server_mock.go
@@ -243,3 +243,7 @@ func (s *ServerMock) SetActiveUser(ctx context.Context, req *schema.SetActiveUse
 func (s *ServerMock) getDbIndexFromCtx(ctx context.Context, methodname string) (int64, error) {
 	return s.GetDbIndexFromCtx(ctx, methodname)
 }
+
+func (s *ServerMock) Stop() error {
+	return s.srv.Stop()
+}

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -59,7 +59,7 @@ type ImmuServer struct {
 	GrpcServer          *grpc.Server
 	UUID                xid.ID
 	Pid                 PIDFile
-	Quit                chan struct{}
+	quit                chan struct{}
 	databasenameToIndex map[string]int64
 	userdata            *usernameToUserdataMap
 	multidbmode         bool
@@ -78,7 +78,7 @@ func DefaultServer() *ImmuServer {
 		dbList:               NewDatabaseList(),
 		Logger:               logger.NewSimpleLogger("immudb ", os.Stderr),
 		Options:              DefaultOptions(),
-		Quit:                 make(chan struct{}),
+		quit:                 make(chan struct{}),
 		databasenameToIndex:  make(map[string]int64),
 		userdata:             &usernameToUserdataMap{Userdata: make(map[string]*auth.User)},
 		GrpcServer:           grpc.NewServer(),

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -59,7 +59,7 @@ type ImmuServer struct {
 	GrpcServer          *grpc.Server
 	UUID                xid.ID
 	Pid                 PIDFile
-	quit                chan struct{}
+	Quit                chan struct{}
 	databasenameToIndex map[string]int64
 	userdata            *usernameToUserdataMap
 	multidbmode         bool
@@ -78,7 +78,7 @@ func DefaultServer() *ImmuServer {
 		dbList:               NewDatabaseList(),
 		Logger:               logger.NewSimpleLogger("immudb ", os.Stderr),
 		Options:              DefaultOptions(),
-		quit:                 make(chan struct{}),
+		Quit:                 make(chan struct{}),
 		databasenameToIndex:  make(map[string]int64),
 		userdata:             &usernameToUserdataMap{Userdata: make(map[string]*auth.User)},
 		GrpcServer:           grpc.NewServer(),


### PR DESCRIPTION
This PR aims to improve UX on client SDK when immudb returns an illegal state error message.
Inside an error handler interceptor when illegal state is found the local state is checked and compared with the server one.
If the server one is older (like after a restore) the information is explained to the client

Signed-off-by: Michele Meloni <cleaversdev@gmail.com>

