### PR TITLE
Misc coverage improvements

### DIFF
--- a/embedded/appendable/multiapp/multi_app_test.go
+++ b/embedded/appendable/multiapp/multi_app_test.go
@@ -234,6 +234,10 @@ func TestMultiAppEdgeCases(t *testing.T) {
 	_, err = a.ReadAt([]byte{}, 0)
 	require.Equal(t, ErrIllegalArguments, err)
 
+	err = a.Copy("multi_app_test.go")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not a directory")
+
 	err = a.Close()
 	require.NoError(t, err)
 

--- a/embedded/appendable/singleapp/single_app_test.go
+++ b/embedded/appendable/singleapp/single_app_test.go
@@ -381,4 +381,10 @@ func TestSingleAppCantCreateFile(t *testing.T) {
 	_, err = Open(filepath.Join(dir, "exists"), DefaultOptions())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "exists")
+
+	app, err := Open(filepath.Join(dir, "valid"), DefaultOptions())
+	require.NoError(t, err)
+	err = app.Copy(filepath.Join(dir, "exists"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exists")
 }

--- a/embedded/appendable/singleapp/single_app_test.go
+++ b/embedded/appendable/singleapp/single_app_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/binary"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/codenotary/immudb/embedded/appendable"
@@ -370,4 +371,14 @@ func TestSingleAppLZWCompression(t *testing.T) {
 
 	err = a.Close()
 	require.NoError(t, err)
+}
+
+func TestSingleAppCantCreateFile(t *testing.T) {
+	dir, err := ioutil.TempDir(os.TempDir(), "singleapp")
+	defer os.RemoveAll(dir)
+	os.Mkdir(filepath.Join(dir, "exists"), 0644)
+
+	_, err = Open(filepath.Join(dir, "exists"), DefaultOptions())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exists")
 }

--- a/embedded/appendable/singleapp/single_app_test.go
+++ b/embedded/appendable/singleapp/single_app_test.go
@@ -82,6 +82,11 @@ func TestSingleApp(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []byte{7, 8, 9, 10}, bs)
 
+	n , err = a.ReadAt(bs, 1000)
+	require.Error(t, err)
+	require.Equal(t, n, 0)
+	require.Contains(t, err.Error(), "EOF")
+
 	err = a.Sync()
 	require.NoError(t, err)
 

--- a/pkg/client/cache/history_file_cache_test.go
+++ b/pkg/client/cache/history_file_cache_test.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -58,7 +59,6 @@ func TestNewHistoryFileCacheSet(t *testing.T) {
 
 	_, err = fc.Get("uuid1", "dbName")
 	require.Nil(t, err)
-
 }
 
 func TestNewHistoryFileCacheGet(t *testing.T) {
@@ -112,6 +112,23 @@ func TestHistoryFileCache_SetError(t *testing.T) {
 
 	err = fc.Set("uuid", "dbName", nil)
 	require.Error(t, err)
+}
+
+func TestHistoryFileCache_GetError(t *testing.T) {
+	dir, err := ioutil.TempDir("", "example")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fc := NewHistoryFileCache(dir)
+	defer os.RemoveAll(dir)
+
+	// create a dummy file so that the cache can't create the directory
+	// automatically
+	err = ioutil.WriteFile(filepath.Join(dir, "exists"), []byte("data"), 0644)
+	require.NoError(t, err)
+	_, err = fc.Get("exists", "dbName")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exists")
 }
 
 func TestHistoryFileCache_SetMissingFolder(t *testing.T) {

--- a/pkg/client/cache/inmemory_cache_test.go
+++ b/pkg/client/cache/inmemory_cache_test.go
@@ -53,4 +53,16 @@ func TestInMemoryCache(t *testing.T) {
 	require.Error(t, err)
 	_, err = imc.Get("server1", "unknownDb")
 	require.Error(t, err)
+
+	locker := imc.GetLocker("server1")
+	require.NotNil(t, locker)
+
+	err = locker.Lock()
+	require.Error(t, err)
+
+	err = locker.Unlock()
+	require.Error(t, err)
+	
+	require.NotNil(t, locker)
+
 }

--- a/pkg/client/streams.go
+++ b/pkg/client/streams.go
@@ -117,6 +117,9 @@ func (c *immuClient) StreamGet(ctx context.Context, k *schema.KeyRequest) (*sche
 	}
 
 	gs, err := c.streamGet(ctx, k)
+	if err != nil {
+		return nil, err
+	}
 
 	kvr := c.StreamServiceFactory.NewKvStreamReceiver(c.StreamServiceFactory.NewMsgReceiver(gs))
 

--- a/pkg/client/streams.go
+++ b/pkg/client/streams.go
@@ -89,10 +89,6 @@ func (c *immuClient) streamExecAll(ctx context.Context) (schema.ImmuService_Stre
 
 // StreamSet set an array of *stream.KeyValue in immudb streaming contents on a fixed size channel
 func (c *immuClient) StreamSet(ctx context.Context, kvs []*stream.KeyValue) (*schema.TxMetadata, error) {
-	if !c.IsConnected() {
-		return nil, ErrNotConnected
-	}
-
 	s, err := c.streamSet(ctx)
 	if err != nil {
 		return nil, err
@@ -112,10 +108,6 @@ func (c *immuClient) StreamSet(ctx context.Context, kvs []*stream.KeyValue) (*sc
 
 // StreamGet get an *schema.Entry from immudb with a stream
 func (c *immuClient) StreamGet(ctx context.Context, k *schema.KeyRequest) (*schema.Entry, error) {
-	if !c.IsConnected() {
-		return nil, ErrNotConnected
-	}
-
 	gs, err := c.streamGet(ctx, k)
 	if err != nil {
 		return nil, err
@@ -434,10 +426,6 @@ func (c *immuClient) StreamScan(ctx context.Context, req *schema.ScanRequest) (*
 }
 
 func (c *immuClient) StreamZScan(ctx context.Context, req *schema.ZScanRequest) (*schema.ZEntries, error) {
-	if !c.IsConnected() {
-		return nil, ErrNotConnected
-	}
-
 	gs, err := c.streamZScan(ctx, req)
 	if err != nil {
 		return nil, err
@@ -462,10 +450,6 @@ func (c *immuClient) StreamZScan(ctx context.Context, req *schema.ZScanRequest) 
 }
 
 func (c *immuClient) StreamHistory(ctx context.Context, req *schema.HistoryRequest) (*schema.Entries, error) {
-	if !c.IsConnected() {
-		return nil, ErrNotConnected
-	}
-
 	gs, err := c.streamHistory(ctx, req)
 	if err != nil {
 		return nil, err
@@ -498,10 +482,6 @@ func (c *immuClient) StreamHistory(ctx context.Context, req *schema.HistoryReque
 }
 
 func (c *immuClient) StreamExecAll(ctx context.Context, req *stream.ExecAllRequest) (*schema.TxMetadata, error) {
-	if !c.IsConnected() {
-		return nil, ErrNotConnected
-	}
-
 	s, err := c.streamExecAll(ctx)
 	if err != nil {
 		return nil, err

--- a/pkg/streamutils/files.go
+++ b/pkg/streamutils/files.go
@@ -12,11 +12,12 @@ import (
 func GetKeyValuesFromFiles(filenames ...string) ([]*stream.KeyValue, error) {
 	var kvs []*stream.KeyValue
 	for _, fn := range filenames {
-		f, err := os.Open(fn)
+		fs, err := os.Stat(fn)
 		if err != nil {
 			return nil, err
 		}
-		fs, err := os.Stat(fn)
+
+		f, err := os.Open(fn)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/streamutils/files_test.go
+++ b/pkg/streamutils/files_test.go
@@ -1,0 +1,31 @@
+package streamutils
+
+import (
+	"github.com/stretchr/testify/require"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestStreamUtilsFiles(t *testing.T) {
+	tmpdir, err := ioutil.TempDir(os.TempDir(), "streamutils")
+	defer os.RemoveAll(tmpdir)
+
+	// stat will fail
+	_, err = GetKeyValuesFromFiles(filepath.Join(tmpdir, "non-existant"))
+	require.Error(t, err)
+
+	unreadable := filepath.Join(tmpdir, "dir")
+	os.Mkdir(unreadable, 200)
+	// open will fail
+	_, err = GetKeyValuesFromFiles(unreadable)
+	require.Error(t, err)
+
+	valid := filepath.Join(tmpdir, "data")
+	err = ioutil.WriteFile(valid, []byte("content"), 0644)
+	require.NoError(t, err)
+	kvs, err := GetKeyValuesFromFiles(valid)
+	require.NoError(t, err)
+	require.Len(t, kvs, 1)
+}


### PR DESCRIPTION
* Add test for streamutils (100%)
* Streams: Remove some duplicate ErrNotConnected handling, which prevents tests from reaching error handling
  * The Verified methods stay as before, as the Verification happens before the connection checks
* A few coverage improvements for pkg/client/cache (file creation)
* A few coverage improvements for embedded/appendable (file creation)