### PR TITLE
Scans running over fully up-to-date snapshots as default behaviour

### DIFF
--- a/pkg/database/all_ops_test.go
+++ b/pkg/database/all_ops_test.go
@@ -269,8 +269,7 @@ func TestExecAllOps(t *testing.T) {
 	}
 
 	zScanOpt := &schema.ZScanRequest{
-		Set:     []byte(`mySet`),
-		SinceTx: 10,
+		Set: []byte(`mySet`),
 	}
 	zList, err := db.ZScan(zScanOpt)
 	require.NoError(t, err)

--- a/pkg/database/scan.go
+++ b/pkg/database/scan.go
@@ -24,6 +24,9 @@ import (
 
 //Scan ...
 func (d *db) Scan(req *schema.ScanRequest) (*schema.Entries, error) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
 	if req == nil {
 		return nil, store.ErrIllegalArguments
 	}
@@ -44,9 +47,6 @@ func (d *db) Scan(req *schema.ScanRequest) (*schema.Entries, error) {
 			return nil, err
 		}
 	}
-
-	d.mutex.Lock()
-	defer d.mutex.Unlock()
 
 	limit := req.Limit
 

--- a/pkg/database/scan_test.go
+++ b/pkg/database/scan_test.go
@@ -37,7 +37,6 @@ func TestStoreScan(t *testing.T) {
 		Prefix:  []byte(`a`),
 		Limit:   MaxKeyScanLimit + 1,
 		Desc:    true,
-		SinceTx: meta.Id,
 	}
 
 	_, err = db.Scan(&scanOptions)
@@ -48,7 +47,6 @@ func TestStoreScan(t *testing.T) {
 		Prefix:  []byte(`a`),
 		Limit:   0,
 		Desc:    true,
-		SinceTx: meta.Id,
 	}
 
 	list, err = db.Scan(&scanOptions)
@@ -64,7 +62,6 @@ func TestStoreScan(t *testing.T) {
 		Prefix:  nil,
 		Limit:   0,
 		Desc:    false,
-		SinceTx: meta.Id,
 	}
 
 	list1, err1 := db.Scan(&scanOptions1)
@@ -76,7 +73,6 @@ func TestStoreScan(t *testing.T) {
 	require.Equal(t, list1.Entries[1].Value, []byte(`item3`))
 	require.Equal(t, list1.Entries[2].Key, []byte(`bbb`))
 	require.Equal(t, list1.Entries[2].Value, []byte(`item2`))
-
 }
 
 func TestStoreScanPrefix(t *testing.T) {

--- a/pkg/database/sorted_set_test.go
+++ b/pkg/database/sorted_set_test.go
@@ -78,9 +78,8 @@ func TestStoreIndexExists(t *testing.T) {
 	require.NotEmptyf(t, reference3, "Should not be empty")
 
 	zscanOpts := &schema.ZScanRequest{
-		Set:     []byte(`firstIndex`),
-		SinceTx: reference3.Id,
-		Limit:   MaxKeyScanLimit + 1,
+		Set:   []byte(`firstIndex`),
+		Limit: MaxKeyScanLimit + 1,
 	}
 
 	_, err = db.ZScan(zscanOpts)
@@ -89,8 +88,7 @@ func TestStoreIndexExists(t *testing.T) {
 	//try to retrieve directly the value or full scan to debug
 
 	zscanOpts1 := &schema.ZScanRequest{
-		Set:     []byte(`firstIndex`),
-		SinceTx: reference3.Id,
+		Set: []byte(`firstIndex`),
 	}
 
 	itemList1, err := db.ZScan(zscanOpts1)


### PR DESCRIPTION
This PR changes default parameters when scanning keys by prefix and sorted-sets, default parameters will make use of a fully up-to-date snapshot.

If older snapshots can be used (or reused) `sinceTx=TxID` can be specified as a requirement for the index state

Signed-off-by: Jeronimo Irazabal <jeronimo.irazabal@gmail.com>