### PR TITLE
fix: readme typo and mascot placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,17 @@ Don't forget to ⭐ this repo if you like immudb!
 
 ---
 
+<img align="right" src="img/immudb-mascot-small.png" width="256px"/>
+
 immudb is a key-value database with built-in cryptographic proof and verification. It can track changes in sensitive data and the integrity of the history will be protected by the clients, without the need to trust the server.
 
 Traditional database transactions and logs are hard to scale and are mutable, so there is no way to know for sure if your data has been compromised. immudb is immutable. You can add new versions of existing records, but never change or delete records. This lets you store critical data without fear of it being changed silently.
 
-Data stored in immudb is cryptographically coherent and verifiable, just like blockchains, but without all the complexity. Unlike blockchains, immudb can handle millions of transactions per second, and can be used both as a lightweight service or embedded in your application as a library."
+Data stored in immudb is cryptographically coherent and verifiable, just like blockchains, but without all the complexity. Unlike blockchains, immudb can handle millions of transactions per second, and can be used both as a lightweight service or embedded in your application as a library.
 
 Companies use immudb to protect credit card transactions and to secure processes by storing digital certificates and checksums.
 
-<img align="right" src="img/immudb-mascot-small.png" width="256px"/>
+
 
 ### Tech specs
 


### PR DESCRIPTION
Unnecessary quotation mark and incorrect placement of mascot due to less content