### PR TITLE
Feat/pgsqlwire

### DIFF
--- a/pkg/pgsql/server.go
+++ b/pkg/pgsql/server.go
@@ -22,7 +22,7 @@ import (
 )
 
 func main() {
-
+	// todo inject in main server
 	sqlServer := server.New(server.Port("5439"))
 
 	err := sqlServer.Serve()

--- a/pkg/pgsql/server.go
+++ b/pkg/pgsql/server.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2021 CodeNotary, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"github.com/codenotary/immudb/pkg/pgsql/server"
+	"log"
+)
+
+func main() {
+
+	sqlServer := server.New(server.Port("5439"))
+
+	err := sqlServer.Serve()
+
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/pkg/pgsql/server/bmessages/authenticationCleartextPassword.go
+++ b/pkg/pgsql/server/bmessages/authenticationCleartextPassword.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2021 CodeNotary, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bmessages
+
+import (
+	"bytes"
+	"encoding/binary"
+)
+
+func AuthenticationCleartextPassword() []byte {
+	messageType := []byte(`R`)
+	messageLength := make([]byte, 4)
+	message := make([]byte, 4)
+	binary.BigEndian.PutUint32(messageLength, uint32(8))
+	binary.BigEndian.PutUint32(message, uint32(3))
+	return bytes.Join([][]byte{messageType, messageLength, message}, nil)
+}

--- a/pkg/pgsql/server/bmessages/authenticationOk.go
+++ b/pkg/pgsql/server/bmessages/authenticationOk.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2021 CodeNotary, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bmessages
+
+import (
+	"bytes"
+	"encoding/binary"
+)
+
+func AuthenticationOk() []byte {
+	messageType := []byte(`R`)
+	messageLength := make([]byte, 4)
+	message := make([]byte, 4)
+	binary.BigEndian.PutUint32(messageLength, uint32(8))
+	binary.BigEndian.PutUint32(message, uint32(0))
+	return bytes.Join([][]byte{messageType, messageLength, message}, nil)
+}

--- a/pkg/pgsql/server/bmessages/commandComplete.go
+++ b/pkg/pgsql/server/bmessages/commandComplete.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2021 CodeNotary, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bmessages
+
+import (
+	"bytes"
+	"encoding/binary"
+)
+
+func CommandComplete() []byte {
+	messageType := []byte(`C`)
+	message := []byte(`SELECT 1`)
+	message = bytes.Join([][]byte{message, {0}}, nil)
+	selfMessageLength := make([]byte, 4)
+	binary.BigEndian.PutUint32(selfMessageLength, uint32(len(message)+4))
+
+	return bytes.Join([][]byte{messageType, selfMessageLength, message}, nil)
+}

--- a/pkg/pgsql/server/bmessages/dataRow.go
+++ b/pkg/pgsql/server/bmessages/dataRow.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2021 CodeNotary, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bmessages
+
+import (
+	"bytes"
+	"encoding/binary"
+)
+
+func DataRow() []byte {
+	////##-> dataRow
+	// Identifies the message as a data row.
+	// Byte1('D')
+	messageType := []byte(`D`)
+	// Length of message contents in bytes, including self.
+	// Int32
+	selfMessageLength := make([]byte, 4)
+	binary.BigEndian.PutUint32(selfMessageLength, uint32(14))
+	// The number of column values that follow (possibly zero).
+	// Int16
+	columnNumb := make([]byte, 2)
+	binary.BigEndian.PutUint16(columnNumb, uint16(1))
+
+	// Next, the following pair of fields appear for each column:
+	// The length of the column value, in bytes (this count does not include itself). Can be zero. As a special case, -1 indicates a NULL column value. No value bytes follow in the NULL case.
+	// Int32
+	valueLength := make([]byte, 4)
+	binary.BigEndian.PutUint32(valueLength, uint32(4))
+	// The value of the column, in the format indicated by the associated format code. n is the above length.
+	// Byten
+	value := make([]byte, 4)
+	binary.BigEndian.PutUint32(value, uint32(1))
+
+	return bytes.Join([][]byte{messageType, selfMessageLength, columnNumb, valueLength, value}, nil)
+}

--- a/pkg/pgsql/server/bmessages/readyForQuery.go
+++ b/pkg/pgsql/server/bmessages/readyForQuery.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2021 CodeNotary, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bmessages
+
+import (
+	"bytes"
+	"encoding/binary"
+)
+
+func ReadyForQuery() []byte {
+	messageType := []byte(`Z`)
+	message := make([]byte, 4)
+	idle := []byte(`I`)
+	binary.BigEndian.PutUint32(message, uint32(5))
+	return bytes.Join([][]byte{messageType, message, idle}, nil)
+}

--- a/pkg/pgsql/server/bmessages/rowDescription.go
+++ b/pkg/pgsql/server/bmessages/rowDescription.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2021 CodeNotary, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bmessages
+
+import (
+	"bytes"
+	"encoding/binary"
+	"github.com/codenotary/immudb/pkg/pgsql/server/pgmeta"
+)
+
+func RowDescription() []byte {
+	////##-> dataRowDescription
+	//Byte1('T')
+	messageType := []byte(`T`)
+
+	// Specifies the number of fields in a row (can be zero).
+	// Int16
+	fieldNumb := make([]byte, 2)
+	binary.BigEndian.PutUint16(fieldNumb, uint16(1))
+	// The field name.
+	// String
+	fieldName := []byte(`first`)
+	fieldName = bytes.Join([][]byte{fieldName, {0}}, nil)
+	// If the field can be identified as a column of a specific table, the object ID of the table; otherwise zero.
+	// Int32
+	id := make([]byte, 4)
+	binary.BigEndian.PutUint32(id, uint32(0))
+	// If the field can be identified as a column of a specific table, the attribute number of the column; otherwise zero.
+	// Int16
+	attributeNumber := make([]byte, 2)
+	binary.BigEndian.PutUint16(attributeNumber, uint16(0))
+	// The object ID of the field's data type.
+	// Int32
+	objectId := make([]byte, 4)
+	binary.BigEndian.PutUint32(objectId, uint32(pgmeta.PgTypeMap["text"]))
+	// The data type size (see pg_type.typlen). Note that negative values denote variable-width types.
+	// For a fixed-size type, typlen is the number of bytes in the internal representation of the type. But for a variable-length type, typlen is negative. -1 indicates a “varlena” type (one that has a length word), -2 indicates a null-terminated C string.
+	// Int16
+	dataTypeSize := make([]byte, 2)
+	binary.BigEndian.PutUint16(dataTypeSize, uint16(4))
+	// The type modifier (see pg_attribute.atttypmod). The meaning of the modifier is type-specific.
+	// atttypmod records type-specific data supplied at table creation time (for example, the maximum length of a varchar column). It is passed to type-specific input functions and length coercion functions. The value will generally be -1 for types that do not need atttypmod.
+	// Int32
+	typeModifier := make([]byte, 4)
+	tm := int32(-1)
+	binary.BigEndian.PutUint32(typeModifier, uint32(tm))
+	// The format code being used for the field. Currently will be zero (text) or one (binary). In a RowDescription returned from the statement variant of Describe, the format code is not yet known and will always be zero.
+	// Int16
+	formatCode := make([]byte, 2)
+	binary.BigEndian.PutUint16(formatCode, uint16(0))
+
+	// Length of message contents in bytes, including self.
+	// Int32
+	rowDescMessageLengthB := make([]byte, 4)
+	rowDescMessageLength := 4 + 2 + len(fieldName) + 4 + 2 + 4 + 2 + 4 + 2 //fn6
+	binary.BigEndian.PutUint32(rowDescMessageLengthB, uint32(rowDescMessageLength))
+
+	return bytes.Join([][]byte{messageType, rowDescMessageLengthB, fieldNumb, fieldName, id, attributeNumber, objectId, dataTypeSize, typeModifier, formatCode}, nil)
+}

--- a/pkg/pgsql/server/errors.go
+++ b/pkg/pgsql/server/errors.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2021 CodeNotary, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import "errors"
+
+var ErrUnknowMessageType = errors.New("found an unknown message type on the wire")

--- a/pkg/pgsql/server/fmessages/passwordMessage.go
+++ b/pkg/pgsql/server/fmessages/passwordMessage.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2021 CodeNotary, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fmessages
+
+type PasswordMsg struct {
+	secret string
+}
+
+func ParsePasswordMsg(payload []byte) PasswordMsg {
+	password := payload[:len(payload)-1] //-1 A null-terminated string
+	return PasswordMsg{secret: string(password)}
+}
+
+func (pw *PasswordMsg) GetSecret() string {
+	return pw.secret
+}

--- a/pkg/pgsql/server/fmessages/query.go
+++ b/pkg/pgsql/server/fmessages/query.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2021 CodeNotary, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fmessages
+
+type QueryMsg struct {
+	statements string
+}
+
+func ParseQueryMsg(payload []byte) QueryMsg {
+	msg := payload[:len(payload)-1] //-1 A null-terminated string
+	return QueryMsg{statements: string(msg)}
+}
+
+func (q *QueryMsg) GetStatements() string {
+	return q.statements
+}

--- a/pkg/pgsql/server/message.go
+++ b/pkg/pgsql/server/message.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2021 CodeNotary, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"encoding/binary"
+	"net"
+)
+
+var Mtypes = map[byte]mtype{
+	'Q': "query",
+	'T': "rowDescription",
+	'D': "dataRow",
+	'C': "commandComplete",
+	'Z': "readyForQuery",
+	'R': "cleartextPassword",
+	'p': "PasswordMessage",
+	'U': "unknown",
+}
+
+type mtype string
+
+type rawMessage struct {
+	t       byte
+	payload []byte
+}
+
+type startupMessage struct {
+	payload []byte
+}
+
+type messageReader struct {
+	conn net.Conn
+}
+
+type MessageReader interface {
+	ReadStartUpMessage() (*startupMessage, error)
+	ReadRawMessage() (*rawMessage, error)
+	WriteMessage(func() []byte) (int, error)
+}
+
+func NewMessageReader(conn net.Conn) *messageReader {
+	return &messageReader{conn: conn}
+}
+
+func (r *messageReader) ReadRawMessage() (*rawMessage, error) {
+	t := make([]byte, 1)
+	if _, err := r.conn.Read(t); err != nil {
+		return nil, err
+	}
+	if _, ok := Mtypes[t[0]]; !ok {
+		return nil, ErrUnknowMessageType
+	}
+
+	lb := make([]byte, 4)
+	if _, err := r.conn.Read(lb); err != nil {
+		return nil, err
+	}
+	l := binary.BigEndian.Uint32(lb)
+	payload := make([]byte, l-4)
+	if _, err := r.conn.Read(payload); err != nil {
+		return nil, err
+	}
+
+	return &rawMessage{
+		t:       t[0],
+		payload: payload,
+	}, nil
+}
+
+func (r *messageReader) ReadStartUpMessage() (*startupMessage, error) {
+	lb := make([]byte, 4)
+	if _, err := r.conn.Read(lb); err != nil {
+		return nil, err
+	}
+	protocolVersion := make([]byte, 4)
+	if _, err := r.conn.Read(protocolVersion); err != nil {
+		return nil, err
+	}
+	connString := make([]byte, binary.BigEndian.Uint32(lb)-4)
+	if _, err := r.conn.Read(connString); err != nil {
+		return nil, err
+	}
+
+	return &startupMessage{
+		payload: connString,
+	}, nil
+}
+
+func (r *messageReader) WriteMessage(f func() []byte) (int, error) {
+	return r.conn.Write(f())
+}

--- a/pkg/pgsql/server/options.go
+++ b/pkg/pgsql/server/options.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2021 CodeNotary, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"github.com/codenotary/immudb/pkg/logger"
+)
+
+type Option func(s *srv)
+
+func Host(c string) Option {
+	return func(args *srv) {
+		args.Host = c
+	}
+}
+
+func Port(port string) Option {
+	return func(args *srv) {
+		args.Port = port
+	}
+}
+
+func Logger(logger logger.Logger) Option {
+	return func(args *srv) {
+		args.Logger = logger
+	}
+}

--- a/pkg/pgsql/server/pgmeta/pg_type.go
+++ b/pkg/pgsql/server/pgmeta/pg_type.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2021 CodeNotary, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pgmeta
+
+var PgTypeMap = map[string]int{
+	"bool":  16,
+	"bytea": 17,
+	"char":  18,
+	"int8":  20,
+	"int2":  21,
+	"int4":  23,
+	"text":  25,
+	"oid":   26,
+}

--- a/pkg/pgsql/server/requestHandler.go
+++ b/pkg/pgsql/server/requestHandler.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2021 CodeNotary, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"net"
+)
+
+func (s *srv) handleRequest(conn net.Conn) error {
+	ss := s.SessionFactory.NewSession(conn, s.Logger)
+
+	//startupMessage
+	err := ss.HandleStartup()
+	if err != nil {
+		return err
+	}
+
+	err = ss.HandleSimpleQueries()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/pgsql/server/server.go
+++ b/pkg/pgsql/server/server.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2021 CodeNotary, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"github.com/codenotary/immudb/pkg/logger"
+	"net"
+	"os"
+)
+
+type srv struct {
+	SessionFactory SessionFactory
+	Logger         logger.Logger
+	Host           string
+	Port           string
+}
+
+type Server interface {
+	Serve() error
+}
+
+func New(setters ...Option) *srv {
+
+	// Default Options
+	cli := &srv{
+		SessionFactory: NewSessionFactory(),
+		Host:           "localhost",
+		Port:           "5432",
+		Logger:         logger.NewSimpleLogger("sqlSrv", os.Stderr),
+	}
+
+	for _, setter := range setters {
+		setter(cli)
+	}
+
+	return cli
+}
+
+func (s *srv) Serve() error {
+	l, err := net.Listen("tcp", s.Host+":"+s.Port)
+	if err != nil {
+		return err
+	}
+	defer l.Close()
+
+	for {
+		conn, err := l.Accept()
+		if err != nil {
+			return err
+		}
+		go s.handleRequest(conn)
+	}
+}

--- a/pkg/pgsql/server/session.go
+++ b/pkg/pgsql/server/session.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2021 CodeNotary, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"github.com/codenotary/immudb/pkg/logger"
+	bm "github.com/codenotary/immudb/pkg/pgsql/server/bmessages"
+	fm "github.com/codenotary/immudb/pkg/pgsql/server/fmessages"
+	"net"
+)
+
+type session struct {
+	conn net.Conn
+	log  logger.Logger
+	mr   MessageReader
+}
+
+type Session interface {
+	HandleStartup() error
+	HandleSimpleQueries() error
+}
+
+func NewSession(c net.Conn, log logger.Logger) *session {
+	return &session{conn: c, log: log, mr: NewMessageReader(c)}
+}
+
+func (s *session) HandleStartup() error {
+	connString, err := s.mr.ReadStartUpMessage()
+	if err != nil {
+		println(connString)
+	}
+
+	if _, err := s.mr.WriteMessage(bm.AuthenticationCleartextPassword); err != nil {
+		return err
+	}
+	msg, err := s.NextMessage()
+	if err != nil {
+		return err
+	}
+	if pw, ok := msg.(fm.PasswordMsg); ok {
+		if pw.GetSecret() == "pass" {
+			if _, err := s.mr.WriteMessage(bm.AuthenticationOk); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (s *session) HandleSimpleQueries() error {
+	for true {
+		if _, err := s.mr.WriteMessage(bm.ReadyForQuery); err != nil {
+			return err
+		}
+		msg, err := s.NextMessage()
+		if err != nil {
+			return err
+		}
+		query, ok := msg.(fm.QueryMsg)
+		if !ok {
+			s.log.Errorf("not a query")
+		}
+		println(query.GetStatements())
+
+		if _, err := s.mr.WriteMessage(bm.RowDescription); err != nil {
+			return err
+		}
+		if _, err := s.mr.WriteMessage(bm.DataRow); err != nil {
+			return err
+		}
+		if _, err := s.mr.WriteMessage(bm.CommandComplete); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *session) NextMessage() (interface{}, error) {
+	msg, err := s.mr.ReadRawMessage()
+	if err != nil {
+		return nil, err
+	}
+	return s.parseRawMessage(msg), nil
+}
+
+func (s *session) parseRawMessage(msg *rawMessage) interface{} {
+	switch msg.t {
+	case 'p':
+		return fm.ParsePasswordMsg(msg.payload)
+	case 'Q':
+		return fm.ParseQueryMsg(msg.payload)
+	}
+	return nil
+}

--- a/pkg/pgsql/server/sessionFactory.go
+++ b/pkg/pgsql/server/sessionFactory.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2021 CodeNotary, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"github.com/codenotary/immudb/pkg/logger"
+	"net"
+)
+
+type sessionFactory struct {
+}
+
+type SessionFactory interface {
+	NewSession(conn net.Conn, log logger.Logger) Session
+}
+
+func NewSessionFactory() sessionFactory {
+	return sessionFactory{}
+}
+
+func (sm sessionFactory) NewSession(conn net.Conn, log logger.Logger) Session {
+	return NewSession(conn, log)
+}


### PR DESCRIPTION
This PR add  postgresql compatible protocol end-point.  
Protocol is described [here](https://www.postgresql.org/docs/current/protocol.html)  



Following the main implementation step:
- [x] connectionHandler
- [ ] sessionHandler
- [ ] start-up message handler
- [ ] simple query handler
- [ ] error handler
- [ ] primitives to read/write messages on the wire

