### PR TITLE
Read as before

### DIFF
--- a/embedded/store/immustore.go
+++ b/embedded/store/immustore.go
@@ -61,6 +61,7 @@ var ErrKeyNotFound = tbtree.ErrKeyNotFound
 var ErrTxNotFound = errors.New("tx not found")
 var ErrNoMoreEntries = tbtree.ErrNoMoreEntries
 var ErrIllegalState = tbtree.ErrIllegalState
+var ErrUnexpectedError = errors.New("unexpected error")
 
 var ErrSourceTxNewerThanTargetTx = errors.New("source tx is newer than target tx")
 var ErrLinearProofMaxLenExceeded = errors.New("max linear proof length limit exceeded")

--- a/embedded/store/key_reader.go
+++ b/embedded/store/key_reader.go
@@ -38,7 +38,7 @@ type KeyReaderSpec struct {
 
 // NewReader ...
 func (st *ImmuStore) NewKeyReader(snap *tbtree.Snapshot, spec *KeyReaderSpec) (*KeyReader, error) {
-	if snap == nil {
+	if snap == nil || spec == nil {
 		return nil, ErrIllegalArguments
 	}
 
@@ -120,6 +120,10 @@ func (r *KeyReader) Read() (key []byte, val *ValueRef, tx uint64, hc uint64, err
 	}
 
 	return key, val, tx, hc, nil
+}
+
+func (r *KeyReader) Reset() error {
+	return r.reader.Reset()
 }
 
 func (r *KeyReader) Close() error {

--- a/embedded/store/key_reader_test.go
+++ b/embedded/store/key_reader_test.go
@@ -19,7 +19,6 @@ import (
 	"encoding/binary"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -37,20 +36,18 @@ func TestImmudbStoreReader(t *testing.T) {
 		kvs := make([]*KV, eCount)
 
 		for j := 0; j < eCount; j++ {
-			k := make([]byte, 8)
-			binary.BigEndian.PutUint64(k, uint64(j))
+			var k [8]byte
+			binary.BigEndian.PutUint64(k[:], uint64(j))
 
-			v := make([]byte, 8)
-			binary.BigEndian.PutUint64(v, uint64(i))
+			var v [8]byte
+			binary.BigEndian.PutUint64(v[:], uint64(i))
 
-			kvs[j] = &KV{Key: k, Value: v}
+			kvs[j] = &KV{Key: k[:], Value: v[:]}
 		}
 
-		_, err := immuStore.Commit(kvs, false)
+		_, err := immuStore.Commit(kvs, true)
 		require.NoError(t, err)
 	}
-
-	time.Sleep(1 * time.Second)
 
 	snap, err := immuStore.Snapshot()
 	require.NoError(t, err)
@@ -66,14 +63,81 @@ func TestImmudbStoreReader(t *testing.T) {
 
 	defer reader.Close()
 
-	for {
-		_, v, _, _, err := reader.Read()
-		if err != nil {
-			require.Equal(t, ErrNoMoreEntries, err)
-			break
+	for j := 0; j < eCount; j++ {
+		var k [8]byte
+		binary.BigEndian.PutUint64(k[:], uint64(j))
+
+		var v [8]byte
+		binary.BigEndian.PutUint64(v[:], uint64(txCount-1))
+
+		rk, vref, _, _, err := reader.Read()
+		require.NoError(t, err)
+		require.Equal(t, k[:], rk)
+
+		rv, err := vref.Resolve()
+		require.NoError(t, err)
+		require.Equal(t, v[:], rv)
+	}
+
+	_, _, _, _, err = reader.Read()
+	require.Equal(t, ErrNoMoreEntries, err)
+}
+
+func TestImmudbStoreReaderAsBefore(t *testing.T) {
+	opts := DefaultOptions().WithSynced(false).WithMaxConcurrency(4)
+	immuStore, err := Open("data_store_reader_as_before", opts)
+	require.NoError(t, err)
+	defer os.RemoveAll("data_store_reader_as_before")
+
+	txCount := 100
+	eCount := 100
+
+	for i := 0; i < txCount; i++ {
+		kvs := make([]*KV, eCount)
+
+		for j := 0; j < eCount; j++ {
+			var k [8]byte
+			binary.BigEndian.PutUint64(k[:], uint64(j))
+
+			var v [8]byte
+			binary.BigEndian.PutUint64(v[:], uint64(i))
+
+			kvs[j] = &KV{Key: k[:], Value: v[:]}
 		}
 
-		_, err = v.Resolve()
+		_, err := immuStore.Commit(kvs, true)
+		require.NoError(t, err)
+	}
+
+	snap, err := immuStore.Snapshot()
+	require.NoError(t, err)
+
+	reader, err := immuStore.NewKeyReader(snap, &KeyReaderSpec{})
+	require.NoError(t, err)
+
+	defer reader.Close()
+
+	for i := 0; i < txCount; i++ {
+		for j := 0; j < eCount; j++ {
+			var k [8]byte
+			binary.BigEndian.PutUint64(k[:], uint64(j))
+
+			var v [8]byte
+			binary.BigEndian.PutUint64(v[:], uint64(i))
+
+			rk, vref, _, err := reader.ReadAsBefore(uint64(i + 2))
+			require.NoError(t, err)
+			require.Equal(t, k[:], rk)
+
+			rv, err := vref.Resolve()
+			require.NoError(t, err)
+			require.Equal(t, v[:], rv)
+		}
+
+		_, _, _, _, err = reader.Read()
+		require.Equal(t, ErrNoMoreEntries, err)
+
+		err = reader.Reset()
 		require.NoError(t, err)
 	}
 }

--- a/embedded/store/key_reader_test.go
+++ b/embedded/store/key_reader_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/codenotary/immudb/embedded/tbtree"
 	"github.com/stretchr/testify/require"
 )
 
@@ -62,8 +61,7 @@ func TestImmudbStoreReader(t *testing.T) {
 	_, err = immuStore.NewKeyReader(snap, nil)
 	require.Equal(t, ErrIllegalArguments, err)
 
-	spec := &tbtree.ReaderSpec{}
-	reader, err := immuStore.NewKeyReader(snap, spec)
+	reader, err := immuStore.NewKeyReader(snap, &KeyReaderSpec{})
 	require.NoError(t, err)
 
 	defer reader.Close()

--- a/embedded/tbtree/reader.go
+++ b/embedded/tbtree/reader.go
@@ -40,6 +40,19 @@ type ReaderSpec struct {
 	DescOrder     bool
 }
 
+func (r *Reader) Reset() error {
+	path, startingLeaf, startingOffset, err := r.snapshot.root.findLeafNode(r.seekKey, nil, nil, r.descOrder)
+	if err != nil {
+		return err
+	}
+
+	r.path = path
+	r.leafNode = startingLeaf
+	r.offset = startingOffset
+
+	return nil
+}
+
 func (r *Reader) ReadAsBefore(beforeTs uint64) (key []byte, ts uint64, err error) {
 	if r.closed {
 		return nil, 0, ErrAlreadyClosed

--- a/pkg/database/scan.go
+++ b/pkg/database/scan.go
@@ -18,7 +18,6 @@ package database
 
 import (
 	"github.com/codenotary/immudb/embedded/store"
-	"github.com/codenotary/immudb/embedded/tbtree"
 	"github.com/codenotary/immudb/pkg/api/schema"
 )
 
@@ -71,7 +70,7 @@ func (d *db) Scan(req *schema.ScanRequest) (*schema.Entries, error) {
 
 	r, err := d.st.NewKeyReader(
 		snap,
-		&tbtree.ReaderSpec{
+		&store.KeyReaderSpec{
 			SeekKey:   seekKey,
 			Prefix:    EncodeKey(req.Prefix),
 			DescOrder: req.Desc,
@@ -86,7 +85,7 @@ func (d *db) Scan(req *schema.ScanRequest) (*schema.Entries, error) {
 
 	for {
 		key, _, tx, _, err := r.Read()
-		if err == tbtree.ErrNoMoreEntries {
+		if err == store.ErrNoMoreEntries {
 			break
 		}
 		if err != nil {

--- a/pkg/database/sorted_set.go
+++ b/pkg/database/sorted_set.go
@@ -20,7 +20,6 @@ import (
 	"math"
 
 	"github.com/codenotary/immudb/embedded/store"
-	"github.com/codenotary/immudb/embedded/tbtree"
 	"github.com/codenotary/immudb/pkg/api/schema"
 )
 
@@ -134,7 +133,7 @@ func (d *db) ZScan(req *schema.ZScanRequest) (*schema.ZEntries, error) {
 
 	r, err := d.st.NewKeyReader(
 		snap,
-		&tbtree.ReaderSpec{
+		&store.KeyReaderSpec{
 			SeekKey:       seekKey,
 			Prefix:        prefix,
 			InclusiveSeek: req.InclusiveSeek,


### PR DESCRIPTION
This PR includes a new reader operation `ReadAsBefore(txID)`

This functionality is analogous to traditional key-prefix scanning but ignoring any change occurred since the specified transaction.

Note: This functionality leverages history log on indexing and it does not involve any additional snapshot handling.