### PR TITLE
chore: github workflow to run stress_tool

### DIFF
--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -1,0 +1,33 @@
+name: immudb Stress
+on:
+  push:
+    branches:
+    - '**'
+  pull_request:
+    branches:
+    - '**'
+
+jobs:
+  stress-build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Setup runner for Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+    - uses: actions/checkout@v1
+    - name: Build stress tool
+      run: |
+        go build embedded/tools/stress_tool.go
+    - name: "| Entries: 1M | Workers: 20  | Batch: 1k | Batches: 50 |"
+      run: |
+        rm -rf data
+        ./stress_tool -mode auto -committers 20 -kvCount 1000 -txCount 50 -txRead -synced
+    - name: "| Entries: 1M | Workers: 50  | Batch: 1k | Batches: 20 |"
+      run: |
+        rm -rf data
+        ./stress_tool -mode auto -committers 50 -kvCount 1000 -txCount 20 -txRead -synced
+    - name: "| Entries: 1M | Workers: 100 | Batch: 1k | Batches: 10 |"
+      run: |
+        rm -rf data
+        ./stress_tool -mode auto -committers 100 -kvCount 1000 -txCount 10 -txRead -synced

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -1,8 +1,5 @@
 name: immudb Stress
 on:
-  push:
-    branches:
-    - '**'
   pull_request:
     branches:
     - '**'


### PR DESCRIPTION
This PR adds a workflow to run the stress tools on the same table as our README benchmarks.

It would add an additional layer of safety to detect problems in the store.