### PR TITLE
Add http annotations to SQL rpc methods

### DIFF
--- a/pkg/api/schema/schema.proto
+++ b/pkg/api/schema/schema.proto
@@ -665,14 +665,29 @@ service ImmuService {
 
 	// SQL
 	rpc SQLExec(SQLExecRequest) returns (SQLExecResult) {
+		option (google.api.http) = {
+			post: "/db/sqlexec"
+			body: "*"
+		};
 	};
 
 	rpc SQLQuery(SQLQueryRequest) returns (SQLQueryResult) {
+		option (google.api.http) = {
+			post: "/db/sqlquery"
+			body: "*"
+		};
 	};
 
 	rpc ListTables(google.protobuf.Empty) returns (SQLQueryResult) {
+		option (google.api.http) = {
+			get: "/db/table/list"
+		};
 	};
 
 	rpc DescribeTable(Table) returns (SQLQueryResult) {
+		option (google.api.http) = {
+			post: "/db/tables"
+			body: "*"
+		};
 	};
 }


### PR DESCRIPTION
This PR adds the missing annotations to expose the SQL methods that are used to generate the gateway

As master also changed the API prefix for those (when @mmeloni updated immugw), I changed those as well so that it will be - easier to merge later.

The idea is to add the REST gw and its options in master, but have ready the SQL end-points in here.