### PR TITLE
Support for INSERT INTO

### DIFF
--- a/embedded/cache/lru_cache.go
+++ b/embedded/cache/lru_cache.go
@@ -18,6 +18,7 @@ package cache
 import (
 	"container/list"
 	"errors"
+	"sync"
 )
 
 var ErrIllegalArguments = errors.New("illegal arguments")
@@ -27,6 +28,8 @@ type LRUCache struct {
 	data    map[interface{}]*entry
 	lruList *list.List
 	size    int
+
+	mutex sync.Mutex
 }
 
 type entry struct {
@@ -47,6 +50,9 @@ func NewLRUCache(size int) (*LRUCache, error) {
 }
 
 func (c *LRUCache) Put(key interface{}, value interface{}) (rkey interface{}, rvalue interface{}, err error) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
 	if key == nil || value == nil {
 		return nil, nil, ErrIllegalArguments
 	}
@@ -78,6 +84,9 @@ func (c *LRUCache) Put(key interface{}, value interface{}) (rkey interface{}, rv
 }
 
 func (c *LRUCache) Get(key interface{}) (interface{}, error) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
 	if key == nil {
 		return nil, ErrIllegalArguments
 	}
@@ -93,10 +102,16 @@ func (c *LRUCache) Get(key interface{}) (interface{}, error) {
 }
 
 func (c *LRUCache) Size() int {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
 	return c.size
 }
 
 func (c *LRUCache) Apply(fun func(k interface{}, v interface{}) error) error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
 	for k, e := range c.data {
 		err := fun(k, e.value)
 		if err != nil {

--- a/embedded/sql/aggregated_values.go
+++ b/embedded/sql/aggregated_values.go
@@ -138,10 +138,6 @@ func (v *MinValue) Value() interface{} {
 }
 
 func (v *MinValue) Compare(val TypedValue) (int, error) {
-	if val.Type() != val.Type() {
-		return 0, ErrNotComparableValues
-	}
-
 	return v.val.Compare(val)
 }
 
@@ -149,10 +145,6 @@ func (v *MinValue) updateWith(val TypedValue) error {
 	if v.val == nil {
 		v.val = val
 		return nil
-	}
-
-	if val.Type() != val.Type() {
-		return ErrNotComparableValues
 	}
 
 	cmp, err := v.val.Compare(val)
@@ -189,10 +181,6 @@ func (v *MaxValue) Value() interface{} {
 }
 
 func (v *MaxValue) Compare(val TypedValue) (int, error) {
-	if val.Type() != val.Type() {
-		return 0, ErrNotComparableValues
-	}
-
 	return v.val.Compare(val)
 }
 
@@ -200,10 +188,6 @@ func (v *MaxValue) updateWith(val TypedValue) error {
 	if v.val == nil {
 		v.val = val
 		return nil
-	}
-
-	if val.Type() != val.Type() {
-		return ErrNotComparableValues
 	}
 
 	cmp, err := v.val.Compare(val)

--- a/embedded/sql/aggregated_values_test.go
+++ b/embedded/sql/aggregated_values_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2021 CodeNotary, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCountValue(t *testing.T) {
+	cval := &CountValue{}
+	require.Equal(t, "", cval.Selector())
+	require.False(t, cval.ColBounded())
+
+	err := cval.updateWith(&Bool{val: true})
+	require.NoError(t, err)
+
+	require.Equal(t, IntegerType, cval.Type())
+
+	_, err = cval.Compare(&Bool{val: true})
+	require.Equal(t, ErrNotComparableValues, err)
+
+	cmp, err := cval.Compare(&Number{val: 1})
+	require.NoError(t, err)
+	require.Equal(t, 0, cmp)
+
+	err = cval.updateWith(&Bool{val: true})
+	require.NoError(t, err)
+
+	cmp, err = cval.Compare(&Number{val: 1})
+	require.NoError(t, err)
+	require.Equal(t, 1, cmp)
+
+	cmp, err = cval.Compare(&Number{val: 3})
+	require.NoError(t, err)
+	require.Equal(t, -1, cmp)
+}
+
+func TestSumValue(t *testing.T) {
+	cval := &SumValue{sel: "db1.table1.amount"}
+	require.Equal(t, "db1.table1.amount", cval.Selector())
+	require.True(t, cval.ColBounded())
+
+	err := cval.updateWith(&Number{val: 1})
+	require.NoError(t, err)
+
+	require.Equal(t, IntegerType, cval.Type())
+
+	_, err = cval.Compare(&Bool{val: true})
+	require.Equal(t, ErrNotComparableValues, err)
+
+	cmp, err := cval.Compare(&Number{val: 1})
+	require.NoError(t, err)
+	require.Equal(t, 0, cmp)
+
+	err = cval.updateWith(&Bool{val: true})
+	require.Equal(t, ErrNotComparableValues, err)
+
+	err = cval.updateWith(&Number{val: 10})
+	require.NoError(t, err)
+
+	cmp, err = cval.Compare(&Number{val: 10})
+	require.NoError(t, err)
+	require.Equal(t, 1, cmp)
+
+	cmp, err = cval.Compare(&Number{val: 12})
+	require.NoError(t, err)
+	require.Equal(t, -1, cmp)
+}
+
+func TestMinValue(t *testing.T) {
+	cval := &MinValue{sel: "db1.table1.amount"}
+	require.Equal(t, "db1.table1.amount", cval.Selector())
+	require.True(t, cval.ColBounded())
+
+	err := cval.updateWith(&Number{val: 10})
+	require.NoError(t, err)
+
+	require.Equal(t, IntegerType, cval.Type())
+
+	cmp, err := cval.Compare(&Number{val: 10})
+	require.NoError(t, err)
+	require.Equal(t, 0, cmp)
+
+	_, err = cval.Compare(&Bool{val: true})
+	require.Equal(t, ErrNotComparableValues, err)
+
+	err = cval.updateWith(&Bool{val: true})
+	require.Equal(t, ErrNotComparableValues, err)
+
+	err = cval.updateWith(&Number{val: 2})
+	require.NoError(t, err)
+
+	cmp, err = cval.Compare(&Number{val: 2})
+	require.NoError(t, err)
+	require.Equal(t, 0, cmp)
+
+	cmp, err = cval.Compare(&Number{val: 4})
+	require.NoError(t, err)
+	require.Equal(t, -1, cmp)
+}
+
+func TestMaxValue(t *testing.T) {
+	cval := &MaxValue{sel: "db1.table1.amount"}
+	require.Equal(t, "db1.table1.amount", cval.Selector())
+	require.True(t, cval.ColBounded())
+
+	err := cval.updateWith(&Number{val: 10})
+	require.NoError(t, err)
+
+	require.Equal(t, IntegerType, cval.Type())
+
+	cmp, err := cval.Compare(&Number{val: 10})
+	require.NoError(t, err)
+	require.Equal(t, 0, cmp)
+
+	_, err = cval.Compare(&Bool{val: true})
+	require.Equal(t, ErrNotComparableValues, err)
+
+	err = cval.updateWith(&Bool{val: true})
+	require.Equal(t, ErrNotComparableValues, err)
+
+	err = cval.updateWith(&Number{val: 2})
+	require.NoError(t, err)
+
+	cmp, err = cval.Compare(&Number{val: 2})
+	require.NoError(t, err)
+	require.Equal(t, 1, cmp)
+
+	cmp, err = cval.Compare(&Number{val: 11})
+	require.NoError(t, err)
+	require.Equal(t, -1, cmp)
+}
+
+func TestAVGValue(t *testing.T) {
+	cval := &AVGValue{sel: "db1.table1.amount"}
+	require.Equal(t, "db1.table1.amount", cval.Selector())
+	require.True(t, cval.ColBounded())
+
+	err := cval.updateWith(&Number{val: 10})
+	require.NoError(t, err)
+
+	require.Equal(t, IntegerType, cval.Type())
+
+	cmp, err := cval.Compare(&Number{val: 10})
+	require.NoError(t, err)
+	require.Equal(t, 0, cmp)
+
+	_, err = cval.Compare(&Bool{val: true})
+	require.Equal(t, ErrNotComparableValues, err)
+
+	err = cval.updateWith(&Bool{val: true})
+	require.Equal(t, ErrNotComparableValues, err)
+
+	err = cval.updateWith(&Number{val: 2})
+	require.NoError(t, err)
+
+	cmp, err = cval.Compare(&Number{val: 6})
+	require.NoError(t, err)
+	require.Equal(t, 0, cmp)
+
+	cmp, err = cval.Compare(&Number{val: 7})
+	require.NoError(t, err)
+	require.Equal(t, -1, cmp)
+}

--- a/embedded/sql/cond_row_reader.go
+++ b/embedded/sql/cond_row_reader.go
@@ -67,6 +67,11 @@ func (cr *conditionalRowReader) Read() (*Row, error) {
 			return nil, err
 		}
 
+		nval, isNull := r.(*NullValue)
+		if isNull && nval.Type() == BooleanType {
+			continue
+		}
+
 		satisfies, boolExp := r.(*Bool)
 		if !boolExp {
 			return nil, ErrInvalidCondition

--- a/embedded/sql/engine.go
+++ b/embedded/sql/engine.go
@@ -109,7 +109,7 @@ func (e *Engine) loadCatalog() error {
 	e.catalog = nil
 
 	lastTxID, _ := e.catalogStore.Alh()
-	err := e.catalogStore.WaitForIndexingUpto(lastTxID)
+	err := e.catalogStore.WaitForIndexingUpto(lastTxID, nil)
 	if err != nil {
 		return err
 	}
@@ -501,17 +501,6 @@ func (e *Engine) unmapIndexedRow(mkey []byte) (dbID, tableID, colID uint64, encV
 	off += len(encPKVal)
 
 	return
-}
-
-func existKey(key []byte, st *store.ImmuStore) (bool, error) {
-	_, _, _, err := st.Get([]byte(key))
-	if err == nil {
-		return true, nil
-	}
-	if err != store.ErrKeyNotFound {
-		return false, err
-	}
-	return false, nil
 }
 
 func (e *Engine) mapKey(mappingPrefix string, encValues ...[]byte) []byte {

--- a/embedded/sql/engine_test.go
+++ b/embedded/sql/engine_test.go
@@ -31,13 +31,13 @@ const sqlPrefix = 2
 var prefix = []byte{sqlPrefix}
 
 func TestCreateDatabase(t *testing.T) {
-	catalogStore, err := store.Open("catalog", store.DefaultOptions())
+	catalogStore, err := store.Open("catalog_create_db", store.DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("catalog")
+	defer os.RemoveAll("catalog_create_db")
 
-	dataStore, err := store.Open("sqldata", store.DefaultOptions())
+	dataStore, err := store.Open("sqldata_create_db", store.DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("sqldata")
+	defer os.RemoveAll("sqldata_create_db")
 
 	engine, err := NewEngine(catalogStore, dataStore, prefix)
 	require.NoError(t, err)
@@ -53,13 +53,13 @@ func TestCreateDatabase(t *testing.T) {
 }
 
 func TestUseDatabase(t *testing.T) {
-	catalogStore, err := store.Open("catalog", store.DefaultOptions())
+	catalogStore, err := store.Open("catalog_use_db", store.DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("catalog")
+	defer os.RemoveAll("catalog_use_db")
 
-	dataStore, err := store.Open("sqldata", store.DefaultOptions())
+	dataStore, err := store.Open("sqldata_use_db", store.DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("sqldata")
+	defer os.RemoveAll("sqldata_use_db")
 
 	engine, err := NewEngine(catalogStore, dataStore, prefix)
 	require.NoError(t, err)
@@ -79,13 +79,13 @@ func TestUseDatabase(t *testing.T) {
 }
 
 func TestCreateTable(t *testing.T) {
-	catalogStore, err := store.Open("catalog", store.DefaultOptions())
+	catalogStore, err := store.Open("catalog_create_table", store.DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("catalog")
+	defer os.RemoveAll("catalog_create_table")
 
-	dataStore, err := store.Open("sqldata", store.DefaultOptions())
+	dataStore, err := store.Open("sqldata_create_table", store.DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("sqldata")
+	defer os.RemoveAll("sqldata_create_table")
 
 	engine, err := NewEngine(catalogStore, dataStore, prefix)
 	require.NoError(t, err)
@@ -113,13 +113,13 @@ func TestCreateTable(t *testing.T) {
 }
 
 func TestCreateIndex(t *testing.T) {
-	catalogStore, err := store.Open("catalog", store.DefaultOptions())
+	catalogStore, err := store.Open("catalog_create_index", store.DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("catalog")
+	defer os.RemoveAll("catalog_create_index")
 
-	dataStore, err := store.Open("sqldata", store.DefaultOptions())
+	dataStore, err := store.Open("sqldata_create_index", store.DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("sqldata")
+	defer os.RemoveAll("sqldata_create_index")
 
 	engine, err := NewEngine(catalogStore, dataStore, prefix)
 	require.NoError(t, err)
@@ -173,14 +173,14 @@ func TestCreateIndex(t *testing.T) {
 	require.Len(t, table.indexes, 2)
 }
 
-func TestInsertInto(t *testing.T) {
-	catalogStore, err := store.Open("catalog", store.DefaultOptions())
+func TestUpsertInto(t *testing.T) {
+	catalogStore, err := store.Open("catalog_upsert", store.DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("catalog")
+	defer os.RemoveAll("catalog_upsert")
 
-	dataStore, err := store.Open("sqldata", store.DefaultOptions())
+	dataStore, err := store.Open("sqldata_upsert", store.DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("sqldata")
+	defer os.RemoveAll("sqldata_upsert")
 
 	engine, err := NewEngine(catalogStore, dataStore, prefix)
 	require.NoError(t, err)
@@ -223,13 +223,13 @@ func TestInsertInto(t *testing.T) {
 }
 
 func TestTransactions(t *testing.T) {
-	catalogStore, err := store.Open("catalog", store.DefaultOptions())
+	catalogStore, err := store.Open("catalog_tx", store.DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("catalog")
+	defer os.RemoveAll("catalog_tx")
 
-	dataStore, err := store.Open("sqldata", store.DefaultOptions())
+	dataStore, err := store.Open("sqldata_tx", store.DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("sqldata")
+	defer os.RemoveAll("sqldata_tx")
 
 	engine, err := NewEngine(catalogStore, dataStore, prefix)
 	require.NoError(t, err)
@@ -253,13 +253,13 @@ func TestTransactions(t *testing.T) {
 }
 
 func TestUseSnapshot(t *testing.T) {
-	catalogStore, err := store.Open("catalog", store.DefaultOptions())
+	catalogStore, err := store.Open("catalog_snap", store.DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("catalog")
+	defer os.RemoveAll("catalog_snap")
 
-	dataStore, err := store.Open("sqldata", store.DefaultOptions())
+	dataStore, err := store.Open("sqldata_snap", store.DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("sqldata")
+	defer os.RemoveAll("sqldata_snap")
 
 	engine, err := NewEngine(catalogStore, dataStore, prefix)
 	require.NoError(t, err)
@@ -304,13 +304,13 @@ func TestUseSnapshot(t *testing.T) {
 }
 
 func TestQuery(t *testing.T) {
-	catalogStore, err := store.Open("catalog", store.DefaultOptions())
+	catalogStore, err := store.Open("catalog_q", store.DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("catalog")
+	defer os.RemoveAll("catalog_q")
 
-	dataStore, err := store.Open("sqldata", store.DefaultOptions())
+	dataStore, err := store.Open("sqldata_q", store.DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("sqldata")
+	defer os.RemoveAll("sqldata_q")
 
 	engine, err := NewEngine(catalogStore, dataStore, prefix)
 	require.NoError(t, err)
@@ -334,7 +334,14 @@ func TestQuery(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	r, err := engine.QueryStmt(fmt.Sprintf("SELECT t1.id AS id, ts, title, payload, active FROM (table1 AS t1) WHERE id >= 0 LIMIT %d AS table1", rowCount), nil)
+	r, err := engine.QueryStmt("SELECT id1 FROM table1", nil)
+	require.NoError(t, err)
+
+	row, err := r.Read()
+	require.Equal(t, ErrColumnDoesNotExist, err)
+	require.Nil(t, row)
+
+	r, err = engine.QueryStmt(fmt.Sprintf("SELECT t1.id AS id, ts, title, payload, active FROM (table1 AS t1) WHERE id >= 0 LIMIT %d AS table1", rowCount), nil)
 	require.NoError(t, err)
 
 	colsBySel, err := r.colsBySelector()
@@ -361,6 +368,9 @@ func TestQuery(t *testing.T) {
 		encPayload := []byte(fmt.Sprintf("blob%d", i))
 		require.Equal(t, []byte(encPayload), row.Values[EncodeSelector("", "db1", "table1", "payload")].Value())
 	}
+
+	_, err = r.Read()
+	require.Equal(t, ErrNoMoreRows, err)
 
 	err = r.Close()
 	require.NoError(t, err)
@@ -439,13 +449,13 @@ func TestQuery(t *testing.T) {
 }
 
 func TestQueryWithNullables(t *testing.T) {
-	catalogStore, err := store.Open("catalog", store.DefaultOptions())
+	catalogStore, err := store.Open("catalog_nullable", store.DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("catalog")
+	defer os.RemoveAll("catalog_nullable")
 
-	dataStore, err := store.Open("sqldata", store.DefaultOptions())
+	dataStore, err := store.Open("sqldata_nullable", store.DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("sqldata")
+	defer os.RemoveAll("sqldata_nullable")
 
 	engine, err := NewEngine(catalogStore, dataStore, prefix)
 	require.NoError(t, err)
@@ -483,7 +493,7 @@ func TestQueryWithNullables(t *testing.T) {
 		require.Less(t, uint64(start), row.Values[EncodeSelector("", "db1", "table1", "ts")].Value())
 		require.Equal(t, uint64(i), row.Values[EncodeSelector("", "db1", "table1", "id")].Value())
 		require.Equal(t, fmt.Sprintf("title%d", i), row.Values[EncodeSelector("", "db1", "table1", "title")].Value())
-		require.Equal(t, &NullValue{}, row.Values[EncodeSelector("", "db1", "table1", "active")])
+		require.Equal(t, &NullValue{t: BooleanType}, row.Values[EncodeSelector("", "db1", "table1", "active")])
 	}
 
 	err = r.Close()
@@ -491,13 +501,13 @@ func TestQueryWithNullables(t *testing.T) {
 }
 
 func TestOrderBy(t *testing.T) {
-	catalogStore, err := store.Open("catalog", store.DefaultOptions())
+	catalogStore, err := store.Open("catalog_orderby", store.DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("catalog")
+	defer os.RemoveAll("catalog_orderby")
 
-	dataStore, err := store.Open("sqldata", store.DefaultOptions())
+	dataStore, err := store.Open("sqldata_orderby", store.DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("sqldata")
+	defer os.RemoveAll("sqldata_orderby")
 
 	engine, err := NewEngine(catalogStore, dataStore, prefix)
 	require.NoError(t, err)
@@ -588,13 +598,13 @@ func TestOrderBy(t *testing.T) {
 }
 
 func TestQueryWithRowFiltering(t *testing.T) {
-	catalogStore, err := store.Open("catalog", store.DefaultOptions())
+	catalogStore, err := store.Open("catalog_where", store.DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("catalog")
+	defer os.RemoveAll("catalog_where")
 
-	dataStore, err := store.Open("sqldata", store.DefaultOptions())
+	dataStore, err := store.Open("sqldata_where", store.DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("sqldata")
+	defer os.RemoveAll("sqldata_where")
 
 	engine, err := NewEngine(catalogStore, dataStore, prefix)
 	require.NoError(t, err)
@@ -695,13 +705,13 @@ func TestQueryWithRowFiltering(t *testing.T) {
 }
 
 func TestAggregations(t *testing.T) {
-	catalogStore, err := store.Open("catalog", store.DefaultOptions())
+	catalogStore, err := store.Open("catalog_agg", store.DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("catalog")
+	defer os.RemoveAll("catalog_agg")
 
-	dataStore, err := store.Open("sqldata", store.DefaultOptions())
+	dataStore, err := store.Open("sqldata_agg", store.DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("sqldata")
+	defer os.RemoveAll("sqldata_agg")
 
 	engine, err := NewEngine(catalogStore, dataStore, prefix)
 	require.NoError(t, err)
@@ -761,13 +771,13 @@ func TestAggregations(t *testing.T) {
 }
 
 func TestGroupByHaving(t *testing.T) {
-	catalogStore, err := store.Open("catalog", store.DefaultOptions())
+	catalogStore, err := store.Open("catalog_having", store.DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("catalog")
+	defer os.RemoveAll("catalog_having")
 
-	dataStore, err := store.Open("sqldata", store.DefaultOptions())
+	dataStore, err := store.Open("sqldata_having", store.DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("sqldata")
+	defer os.RemoveAll("sqldata_having")
 
 	engine, err := NewEngine(catalogStore, dataStore, prefix)
 	require.NoError(t, err)
@@ -798,7 +808,31 @@ func TestGroupByHaving(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	r, err := engine.QueryStmt("SELECT active, COUNT() as c, MIN(age), MAX(age), AVG(age), SUM(age) FROM table1 GROUP BY active HAVING COUNT() <= SUM(age) AND MIN(age) <= MAX(age) AND AVG(age) <= MAX(age) AND MAX(age) < SUM(age) AND AVG(age) >= MIN(age) AND SUM(age) > 0 ORDER BY active DESC", nil)
+	r, err := engine.QueryStmt("SELECT active, COUNT(), SUM(age1) FROM table1 WHERE active != null GROUP BY active HAVING AVG(age) >= MIN(age)", nil)
+	require.NoError(t, err)
+
+	_, err = r.Read()
+	require.Equal(t, ErrColumnDoesNotExist, err)
+
+	r, err = engine.QueryStmt("SELECT active, COUNT(), SUM(age1) FROM table1 WHERE AVG(age) >= MIN(age) GROUP BY active", nil)
+	require.NoError(t, err)
+
+	r, err = engine.QueryStmt("SELECT active, COUNT(id) FROM table1 GROUP BY active", nil)
+	require.NoError(t, err)
+
+	_, err = r.Read()
+	require.Equal(t, ErrLimitedCount, err)
+
+	r, err = engine.QueryStmt("SELECT active, COUNT() FROM table1 GROUP BY active HAVING AVG(age) >= MIN(age1)", nil)
+	require.NoError(t, err)
+
+	_, err = r.Read()
+	require.Equal(t, ErrColumnDoesNotExist, err)
+
+	r, err = engine.QueryStmt("SELECT active, COUNT() as c, MIN(age), MAX(age), AVG(age), SUM(age) FROM table1 GROUP BY active HAVING COUNT() <= SUM(age) AND MIN(age) <= MAX(age) AND AVG(age) <= MAX(age) AND MAX(age) < SUM(age) AND AVG(age) >= MIN(age) AND SUM(age) > 0 ORDER BY active DESC", nil)
+	require.NoError(t, err)
+
+	_, err = r.(*closerRowReader).rowReader.(*projectedRowReader).rowReader.Columns()
 	require.NoError(t, err)
 
 	for i := 0; i < 2; i++ {
@@ -825,13 +859,13 @@ func TestGroupByHaving(t *testing.T) {
 }
 
 func TestJoins(t *testing.T) {
-	catalogStore, err := store.Open("catalog", store.DefaultOptions())
+	catalogStore, err := store.Open("catalog_innerjoin", store.DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("catalog")
+	defer os.RemoveAll("catalog_innerjoin")
 
-	dataStore, err := store.Open("sqldata", store.DefaultOptions())
+	dataStore, err := store.Open("sqldata_innerjoin", store.DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("sqldata")
+	defer os.RemoveAll("sqldata_innerjoin")
 
 	engine, err := NewEngine(catalogStore, dataStore, prefix)
 	require.NoError(t, err)
@@ -919,13 +953,13 @@ func TestJoins(t *testing.T) {
 }
 
 func TestNestedJoins(t *testing.T) {
-	catalogStore, err := store.Open("catalog", store.DefaultOptions())
+	catalogStore, err := store.Open("catalog_nestedjoins", store.DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("catalog")
+	defer os.RemoveAll("catalog_nestedjoins")
 
-	dataStore, err := store.Open("sqldata", store.DefaultOptions())
+	dataStore, err := store.Open("sqldata_nestedjoins", store.DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("sqldata")
+	defer os.RemoveAll("sqldata_nestedjoins")
 
 	engine, err := NewEngine(catalogStore, dataStore, prefix)
 	require.NoError(t, err)
@@ -982,13 +1016,13 @@ func TestNestedJoins(t *testing.T) {
 }
 
 func TestReOpening(t *testing.T) {
-	catalogStore, err := store.Open("catalog", store.DefaultOptions())
+	catalogStore, err := store.Open("catalog_reopening", store.DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("catalog")
+	defer os.RemoveAll("catalog_reopening")
 
-	dataStore, err := store.Open("sqldata", store.DefaultOptions())
+	dataStore, err := store.Open("sqldata_reopening", store.DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("sqldata")
+	defer os.RemoveAll("sqldata_reopening")
 
 	engine, err := NewEngine(catalogStore, dataStore, prefix)
 	require.NoError(t, err)
@@ -1039,13 +1073,13 @@ func TestReOpening(t *testing.T) {
 }
 
 func TestSubQuery(t *testing.T) {
-	catalogStore, err := store.Open("catalog", store.DefaultOptions())
+	catalogStore, err := store.Open("catalog_subq", store.DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("catalog")
+	defer os.RemoveAll("catalog_subq")
 
-	dataStore, err := store.Open("sqldata", store.DefaultOptions())
+	dataStore, err := store.Open("sqldata_subq", store.DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("sqldata")
+	defer os.RemoveAll("sqldata_subq")
 
 	engine, err := NewEngine(catalogStore, dataStore, prefix)
 	require.NoError(t, err)
@@ -1083,6 +1117,27 @@ func TestSubQuery(t *testing.T) {
 		require.Equal(t, uint64(i), row.Values[EncodeSelector("", "db1", "table2", "id")].Value())
 		require.Equal(t, fmt.Sprintf("title%d", i), row.Values[EncodeSelector("", "db1", "table2", "t")].Value())
 	}
+
+	err = r.Close()
+	require.NoError(t, err)
+
+	_, _, err = engine.ExecStmt("UPSERT INTO table1 (id, title) VALUES (0, 'title0')", nil, true)
+	require.NoError(t, err)
+
+	r, err = engine.QueryStmt("SELECT id, title, active FROM (SELECT id, title, active FROM table1) WHERE active", nil)
+	require.NoError(t, err)
+
+	_, err = r.Read()
+	require.NoError(t, err)
+
+	err = r.Close()
+	require.NoError(t, err)
+
+	r, err = engine.QueryStmt("SELECT id, title, active FROM (SELECT id, title, active FROM table1) WHERE title", nil)
+	require.NoError(t, err)
+
+	_, err = r.Read()
+	require.Equal(t, ErrInvalidCondition, err)
 
 	err = r.Close()
 	require.NoError(t, err)

--- a/embedded/sql/grouped_row_reader.go
+++ b/embedded/sql/grouped_row_reader.go
@@ -30,10 +30,6 @@ type groupedRowReader struct {
 }
 
 func (e *Engine) newGroupedRowReader(rowReader RowReader, selectors []Selector, groupBy []*ColSelector) (*groupedRowReader, error) {
-	if len(selectors) == 0 {
-		return nil, ErrIllegalArguments
-	}
-
 	return &groupedRowReader{
 		e:         e,
 		rowReader: rowReader,

--- a/embedded/sql/parser.go
+++ b/embedded/sql/parser.go
@@ -44,6 +44,7 @@ var reservedWords = map[string]int{
 	"ALTER":       ALTER,
 	"ADD":         ADD,
 	"COLUMN":      COLUMN,
+	"INSERT":      INSERT,
 	"UPSERT":      UPSERT,
 	"INTO":        INTO,
 	"VALUES":      VALUES,

--- a/embedded/sql/proj_row_reader.go
+++ b/embedded/sql/proj_row_reader.go
@@ -32,10 +32,6 @@ type projectedRowReader struct {
 }
 
 func (e *Engine) newProjectedRowReader(rowReader RowReader, tableAlias string, selectors []Selector, limit uint64) (*projectedRowReader, error) {
-	if len(selectors) == 0 {
-		return nil, ErrIllegalArguments
-	}
-
 	return &projectedRowReader{
 		e:          e,
 		rowReader:  rowReader,
@@ -154,8 +150,7 @@ func (pr *projectedRowReader) Read() (*Row, error) {
 
 		val, ok := row.Values[encSel]
 		if !ok {
-			// TODO (jeroiraz): typed nullables not yet fully supported
-			val = &NullValue{}
+			return nil, ErrColumnDoesNotExist
 		}
 
 		if pr.tableAlias != "" {

--- a/embedded/sql/row_reader.go
+++ b/embedded/sql/row_reader.go
@@ -207,6 +207,10 @@ func (r *rawRowReader) Read() (row *Row, err error) {
 
 	values := make(map[string]TypedValue, len(r.table.GetColsByID()))
 
+	for _, col := range r.table.colsByName {
+		values[EncodeSelector("", r.table.db.name, r.tableAlias, col.colName)] = &NullValue{t: col.colType}
+	}
+
 	voff := 0
 
 	cols := int(binary.BigEndian.Uint32(v[voff:]))

--- a/embedded/sql/sql_grammar.y
+++ b/embedded/sql/sql_grammar.y
@@ -60,7 +60,7 @@ func setResult(l yyLexer, stmts []SQLStmt) {
 
 %token CREATE USE DATABASE SNAPSHOT SINCE UP TO TABLE INDEX ON ALTER ADD COLUMN PRIMARY KEY
 %token BEGIN TRANSACTION COMMIT
-%token UPSERT INTO VALUES
+%token INSERT UPSERT INTO VALUES
 %token SELECT DISTINCT FROM BEFORE TX JOIN HAVING WHERE GROUP BY LIMIT ORDER ASC DESC AS
 %token NOT LIKE EXISTS
 %token NULL
@@ -206,6 +206,11 @@ opt_since:
 
 
 dmlstmt:
+    INSERT INTO tableRef '(' ids ')' VALUES rows
+    {
+        $$ = &UpsertIntoStmt{isInsert: true, tableRef: $3, cols: $5, rows: $8}
+    }
+|
     UPSERT INTO tableRef '(' ids ')' VALUES rows
     {
         $$ = &UpsertIntoStmt{tableRef: $3, cols: $5, rows: $8}

--- a/embedded/sql/sql_parser.go
+++ b/embedded/sql/sql_parser.go
@@ -62,41 +62,42 @@ const KEY = 57360
 const BEGIN = 57361
 const TRANSACTION = 57362
 const COMMIT = 57363
-const UPSERT = 57364
-const INTO = 57365
-const VALUES = 57366
-const SELECT = 57367
-const DISTINCT = 57368
-const FROM = 57369
-const BEFORE = 57370
-const TX = 57371
-const JOIN = 57372
-const HAVING = 57373
-const WHERE = 57374
-const GROUP = 57375
-const BY = 57376
-const LIMIT = 57377
-const ORDER = 57378
-const ASC = 57379
-const DESC = 57380
-const AS = 57381
-const NOT = 57382
-const LIKE = 57383
-const EXISTS = 57384
-const NULL = 57385
-const JOINTYPE = 57386
-const NUMOP = 57387
-const LOP = 57388
-const CMPOP = 57389
-const IDENTIFIER = 57390
-const TYPE = 57391
-const NUMBER = 57392
-const VARCHAR = 57393
-const BOOLEAN = 57394
-const BLOB = 57395
-const AGGREGATE_FUNC = 57396
-const ERROR = 57397
-const STMT_SEPARATOR = 57398
+const INSERT = 57364
+const UPSERT = 57365
+const INTO = 57366
+const VALUES = 57367
+const SELECT = 57368
+const DISTINCT = 57369
+const FROM = 57370
+const BEFORE = 57371
+const TX = 57372
+const JOIN = 57373
+const HAVING = 57374
+const WHERE = 57375
+const GROUP = 57376
+const BY = 57377
+const LIMIT = 57378
+const ORDER = 57379
+const ASC = 57380
+const DESC = 57381
+const AS = 57382
+const NOT = 57383
+const LIKE = 57384
+const EXISTS = 57385
+const NULL = 57386
+const JOINTYPE = 57387
+const NUMOP = 57388
+const LOP = 57389
+const CMPOP = 57390
+const IDENTIFIER = 57391
+const TYPE = 57392
+const NUMBER = 57393
+const VARCHAR = 57394
+const BOOLEAN = 57395
+const BLOB = 57396
+const AGGREGATE_FUNC = 57397
+const ERROR = 57398
+const STMT_SEPARATOR = 57399
 
 var yyToknames = [...]string{
 	"$end",
@@ -120,6 +121,7 @@ var yyToknames = [...]string{
 	"BEGIN",
 	"TRANSACTION",
 	"COMMIT",
+	"INSERT",
 	"UPSERT",
 	"INTO",
 	"VALUES",
@@ -175,129 +177,135 @@ var yyExca = [...]int{
 
 const yyPrivate = 57344
 
-const yyLast = 212
+const yyLast = 222
 
 var yyAct = [...]int{
 
-	181, 34, 51, 114, 131, 6, 116, 65, 74, 57,
-	85, 117, 66, 119, 126, 36, 7, 47, 173, 124,
-	165, 120, 121, 122, 123, 35, 126, 70, 163, 146,
-	118, 151, 125, 120, 121, 122, 123, 136, 137, 138,
-	109, 168, 44, 99, 125, 167, 45, 98, 48, 105,
-	91, 54, 161, 143, 143, 71, 132, 67, 142, 76,
-	61, 55, 53, 3, 18, 92, 62, 54, 180, 172,
-	49, 90, 148, 89, 93, 160, 176, 36, 115, 107,
-	88, 48, 83, 35, 96, 2, 78, 94, 97, 16,
-	9, 17, 19, 136, 137, 138, 136, 102, 104, 50,
-	33, 36, 108, 136, 30, 138, 31, 128, 147, 144,
-	75, 127, 111, 45, 106, 75, 95, 82, 81, 72,
-	69, 140, 141, 56, 45, 43, 40, 38, 37, 68,
-	87, 139, 182, 183, 64, 52, 153, 156, 154, 150,
-	157, 158, 159, 170, 171, 135, 113, 101, 162, 164,
-	134, 103, 4, 166, 77, 59, 58, 22, 9, 12,
-	13, 110, 29, 63, 20, 129, 12, 13, 79, 14,
-	145, 60, 175, 178, 179, 174, 14, 15, 39, 28,
-	42, 8, 184, 46, 15, 185, 23, 9, 26, 27,
-	152, 24, 25, 177, 169, 112, 133, 100, 86, 84,
-	41, 21, 32, 149, 130, 155, 80, 73, 11, 10,
+	189, 36, 54, 138, 121, 6, 123, 137, 69, 78,
+	60, 90, 70, 124, 7, 126, 133, 50, 84, 38,
+	181, 131, 173, 127, 128, 129, 130, 37, 133, 171,
+	154, 74, 125, 159, 132, 127, 128, 129, 130, 144,
+	145, 146, 115, 46, 48, 176, 132, 104, 51, 175,
+	47, 105, 104, 111, 169, 57, 103, 151, 75, 96,
+	151, 71, 139, 150, 80, 66, 64, 58, 56, 3,
+	19, 97, 65, 57, 188, 95, 52, 94, 180, 156,
+	98, 38, 168, 51, 93, 87, 88, 37, 184, 101,
+	2, 82, 113, 102, 17, 99, 18, 20, 122, 144,
+	145, 146, 9, 108, 110, 53, 38, 144, 114, 146,
+	32, 155, 33, 135, 152, 117, 112, 79, 134, 100,
+	85, 35, 86, 76, 79, 47, 140, 73, 59, 148,
+	149, 47, 45, 42, 40, 39, 144, 92, 147, 190,
+	191, 161, 68, 55, 178, 164, 158, 162, 179, 165,
+	166, 167, 72, 143, 120, 107, 170, 142, 172, 4,
+	174, 109, 81, 62, 61, 23, 9, 12, 13, 12,
+	13, 118, 116, 31, 30, 67, 21, 14, 136, 14,
+	183, 186, 187, 182, 8, 15, 16, 15, 16, 83,
+	192, 9, 49, 193, 63, 24, 153, 41, 29, 44,
+	25, 26, 27, 28, 160, 185, 177, 119, 141, 106,
+	91, 89, 43, 22, 34, 157, 163, 77, 11, 10,
 	5, 1,
 }
 var yyPact = [...]int{
 
-	5, -1000, 162, 5, -1000, 6, 5, -1000, 144, 131,
-	-1000, -1000, 180, 182, 168, 139, -1000, -1000, 5, -1000,
-	5, 29, -1000, 80, 79, 165, 78, 172, 77, 76,
-	162, 155, 43, 96, -1000, 3, 10, -1000, 2, 75,
-	-1000, 128, 126, 156, 1, 9, -1000, 142, 5, -2,
-	29, -1000, 72, -33, 71, 67, 0, -1000, 125, 36,
-	152, 70, 69, -1000, 155, 86, -1000, 65, 96, -1000,
-	-1000, -10, 8, 18, -1000, 38, 68, 34, -1000, 67,
-	-13, -1000, -1000, -1000, 115, -1000, 86, 121, 128, -11,
-	-1000, -1000, 66, 62, -1000, -20, -1000, -1000, 137, 64,
-	113, -29, -1000, -2, 96, -1000, -1000, 147, -1000, -1000,
-	-3, -1000, 119, 111, 48, 90, -1000, -29, -29, -1,
-	-1000, -1000, -1000, -1000, -6, 61, -1000, 157, -31, 60,
-	16, -1000, -17, 100, -29, 53, -29, -29, -29, 24,
-	58, -8, 133, -32, -1000, -29, -1000, -40, -3, -15,
-	-1000, -5, 108, 110, 48, 13, -1000, -1000, 58, 51,
-	-1000, -1000, -42, -1000, 48, -1000, -1000, -1000, -17, 96,
-	26, 53, 53, -1000, -1000, -1000, -1000, 12, 95, -1000,
-	53, -1000, -1000, -1000, 95, -1000,
+	10, -1000, 165, 10, -1000, 11, 10, -1000, 156, 138,
+	-1000, -1000, 189, 196, 187, 150, 149, -1000, -1000, 10,
+	-1000, 10, 32, -1000, 86, 85, 184, 84, 191, 83,
+	82, 82, 165, 163, 48, 103, -1000, 8, 15, -1000,
+	7, 79, -1000, 135, 133, 179, 6, 14, 5, -1000,
+	154, 10, 1, 32, -1000, 78, -30, 74, 68, 4,
+	-1000, 132, 40, 173, 71, 73, 71, -1000, 163, 92,
+	-1000, 76, 103, -1000, -1000, -2, 13, 23, -1000, 45,
+	70, 38, -1000, 68, -5, -1000, -1000, -10, -1000, 122,
+	-1000, 92, 130, 135, -8, -1000, -1000, 67, 75, -1000,
+	-19, -1000, -1000, 147, 66, 146, 120, -28, -1000, 1,
+	103, -1000, -1000, 160, -1000, -1000, 2, -1000, 2, 125,
+	118, 53, 96, -1000, -28, -28, 3, -1000, -1000, -1000,
+	-1000, -3, 65, -1000, 183, -31, 62, 22, -1000, -16,
+	22, 104, -28, 57, -28, -28, -28, 30, 61, -7,
+	140, -32, -1000, -28, -1000, -39, 2, -12, -1000, 0,
+	108, 113, 53, 21, -1000, -1000, 61, 90, -1000, -1000,
+	-41, -1000, 53, -1000, -1000, -1000, -16, 103, 37, 57,
+	57, -1000, -1000, -1000, -1000, 17, 101, -1000, 57, -1000,
+	-1000, -1000, 101, -1000,
 }
 var yyPgo = [...]int{
 
-	0, 211, 152, 17, 210, 16, 209, 208, 5, 207,
-	8, 206, 205, 204, 4, 203, 6, 78, 202, 1,
-	201, 7, 12, 200, 9, 199, 10, 198, 3, 197,
-	196, 195, 194, 2, 193, 190, 0, 85,
+	0, 221, 159, 17, 220, 14, 219, 218, 5, 217,
+	9, 18, 216, 7, 3, 215, 6, 98, 214, 1,
+	213, 8, 12, 212, 10, 211, 11, 210, 4, 209,
+	208, 207, 206, 2, 205, 204, 0, 90,
 }
 var yyR1 = [...]int{
 
 	0, 1, 2, 2, 2, 37, 37, 4, 4, 5,
 	5, 3, 3, 6, 6, 6, 6, 6, 6, 23,
-	23, 7, 13, 13, 14, 11, 11, 12, 12, 15,
-	15, 16, 16, 16, 16, 16, 16, 16, 9, 9,
-	10, 8, 20, 20, 18, 18, 17, 17, 17, 19,
-	19, 19, 21, 21, 21, 22, 22, 24, 24, 25,
-	25, 26, 26, 27, 29, 29, 31, 31, 30, 30,
-	32, 32, 35, 35, 34, 34, 36, 36, 36, 33,
-	33, 28, 28, 28, 28, 28, 28, 28, 28, 28,
+	23, 7, 7, 13, 13, 14, 11, 11, 12, 12,
+	15, 15, 16, 16, 16, 16, 16, 16, 16, 9,
+	9, 10, 8, 20, 20, 18, 18, 17, 17, 17,
+	19, 19, 19, 21, 21, 21, 22, 22, 24, 24,
+	25, 25, 26, 26, 27, 29, 29, 31, 31, 30,
+	30, 32, 32, 35, 35, 34, 34, 36, 36, 36,
+	33, 33, 28, 28, 28, 28, 28, 28, 28, 28,
+	28,
 }
 var yyR2 = [...]int{
 
 	0, 2, 2, 2, 4, 0, 2, 1, 5, 1,
 	1, 2, 3, 3, 3, 4, 10, 7, 6, 0,
-	3, 8, 1, 3, 3, 1, 3, 1, 3, 1,
-	3, 1, 1, 1, 1, 3, 2, 1, 1, 3,
-	2, 12, 0, 1, 2, 4, 1, 3, 4, 1,
-	3, 5, 1, 5, 3, 1, 3, 0, 3, 0,
-	1, 1, 2, 5, 0, 2, 0, 3, 0, 2,
-	0, 2, 0, 3, 2, 4, 0, 1, 1, 0,
-	2, 1, 1, 3, 2, 3, 3, 3, 3, 4,
+	3, 8, 8, 1, 3, 3, 1, 3, 1, 3,
+	1, 3, 1, 1, 1, 1, 3, 2, 1, 1,
+	3, 2, 12, 0, 1, 2, 4, 1, 3, 4,
+	1, 3, 5, 1, 5, 3, 1, 3, 0, 3,
+	0, 1, 1, 2, 5, 0, 2, 0, 3, 0,
+	2, 0, 2, 0, 3, 2, 4, 0, 1, 1,
+	0, 2, 1, 1, 3, 2, 3, 3, 3, 3,
+	4,
 }
 var yyChk = [...]int{
 
-	-1000, -1, -37, 58, -2, -4, -8, -5, 19, 25,
-	-6, -7, 4, 5, 14, 22, -37, -37, 58, -37,
-	20, -20, 26, 6, 11, 12, 6, 7, 11, 23,
-	-37, -37, -18, -17, -19, 54, 48, 48, 48, 13,
-	48, -23, 8, 48, -22, 48, -2, -3, -5, 27,
-	56, -33, 39, 59, 57, 59, 48, -24, 28, 29,
-	15, 59, 57, 21, -37, -21, -22, 59, -17, 48,
-	60, -19, 48, -9, -10, 48, 59, 29, 50, 16,
-	-11, 48, 48, -3, -25, -26, -27, 44, -22, -8,
-	-33, 60, 57, 56, 49, 48, 50, -10, 60, 56,
-	-29, 32, -26, 30, -24, 60, 48, 17, -10, 60,
-	24, 48, -31, 33, -28, -17, -16, 40, 59, 42,
-	50, 51, 52, 53, 48, 61, 43, -21, -33, 18,
-	-13, -14, 59, -30, 31, 34, 45, 46, 47, 41,
-	-28, -28, 59, 59, 48, 13, 60, 48, 56, -15,
-	-16, 48, -35, 36, -28, -12, -19, -28, -28, -28,
-	51, 60, -8, 60, -28, 60, -14, 60, 56, -32,
-	35, 34, 56, 60, -16, -33, 50, -34, -19, -19,
-	56, -36, 37, 38, -19, -36,
+	-1000, -1, -37, 59, -2, -4, -8, -5, 19, 26,
+	-6, -7, 4, 5, 14, 22, 23, -37, -37, 59,
+	-37, 20, -20, 27, 6, 11, 12, 6, 7, 11,
+	24, 24, -37, -37, -18, -17, -19, 55, 49, 49,
+	49, 13, 49, -23, 8, 49, -22, 49, -22, -2,
+	-3, -5, 28, 57, -33, 40, 60, 58, 60, 49,
+	-24, 29, 30, 15, 60, 58, 60, 21, -37, -21,
+	-22, 60, -17, 49, 61, -19, 49, -9, -10, 49,
+	60, 30, 51, 16, -11, 49, 49, -11, -3, -25,
+	-26, -27, 45, -22, -8, -33, 61, 58, 57, 50,
+	49, 51, -10, 61, 57, 61, -29, 33, -26, 31,
+	-24, 61, 49, 17, -10, 61, 25, 49, 25, -31,
+	34, -28, -17, -16, 41, 60, 43, 51, 52, 53,
+	54, 49, 62, 44, -21, -33, 18, -13, -14, 60,
+	-13, -30, 32, 35, 46, 47, 48, 42, -28, -28,
+	60, 60, 49, 13, 61, 49, 57, -15, -16, 49,
+	-35, 37, -28, -12, -19, -28, -28, -28, 52, 61,
+	-8, 61, -28, 61, -14, 61, 57, -32, 36, 35,
+	57, 61, -16, -33, 51, -34, -19, -19, 57, -36,
+	38, 39, -19, -36,
 }
 var yyDef = [...]int{
 
-	5, -2, 0, 5, 1, 5, 5, 7, 0, 42,
-	9, 10, 0, 0, 0, 0, 6, 2, 5, 3,
-	5, 0, 43, 0, 0, 0, 0, 19, 0, 0,
-	6, 0, 0, 79, 46, 0, 49, 13, 0, 0,
-	14, 57, 0, 0, 0, 55, 4, 0, 5, 0,
-	0, 44, 0, 0, 0, 0, 0, 15, 0, 0,
-	0, 0, 0, 8, 11, 59, 52, 0, 79, 80,
-	47, 0, 50, 0, 38, 0, 0, 0, 20, 0,
-	0, 25, 56, 12, 64, 60, 61, 0, 57, 0,
-	45, 48, 0, 0, 40, 0, 58, 18, 0, 0,
-	66, 0, 62, 0, 79, 54, 51, 0, 39, 17,
-	0, 26, 68, 0, 65, 81, 82, 0, 0, 0,
-	31, 32, 33, 34, 49, 0, 37, 0, 0, 0,
-	21, 22, 0, 72, 0, 0, 0, 0, 0, 0,
-	84, 0, 0, 0, 36, 0, 53, 0, 0, 0,
-	29, 0, 70, 0, 69, 67, 27, 83, 87, 88,
-	86, 85, 0, 35, 63, 16, 23, 24, 0, 79,
-	0, 0, 0, 89, 30, 41, 71, 73, 76, 28,
-	0, 74, 77, 78, 76, 75,
+	5, -2, 0, 5, 1, 5, 5, 7, 0, 43,
+	9, 10, 0, 0, 0, 0, 0, 6, 2, 5,
+	3, 5, 0, 44, 0, 0, 0, 0, 19, 0,
+	0, 0, 6, 0, 0, 80, 47, 0, 50, 13,
+	0, 0, 14, 58, 0, 0, 0, 56, 0, 4,
+	0, 5, 0, 0, 45, 0, 0, 0, 0, 0,
+	15, 0, 0, 0, 0, 0, 0, 8, 11, 60,
+	53, 0, 80, 81, 48, 0, 51, 0, 39, 0,
+	0, 0, 20, 0, 0, 26, 57, 0, 12, 65,
+	61, 62, 0, 58, 0, 46, 49, 0, 0, 41,
+	0, 59, 18, 0, 0, 0, 67, 0, 63, 0,
+	80, 55, 52, 0, 40, 17, 0, 27, 0, 69,
+	0, 66, 82, 83, 0, 0, 0, 32, 33, 34,
+	35, 50, 0, 38, 0, 0, 0, 21, 23, 0,
+	22, 73, 0, 0, 0, 0, 0, 0, 85, 0,
+	0, 0, 37, 0, 54, 0, 0, 0, 30, 0,
+	71, 0, 70, 68, 28, 84, 88, 89, 87, 86,
+	0, 36, 64, 16, 24, 25, 0, 80, 0, 0,
+	0, 90, 31, 42, 72, 74, 77, 29, 0, 75,
+	78, 79, 77, 76,
 }
 var yyTok1 = [...]int{
 
@@ -305,9 +313,9 @@ var yyTok1 = [...]int{
 	3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
 	3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
 	3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-	59, 60, 3, 3, 56, 3, 57, 3, 3, 3,
+	60, 61, 3, 3, 57, 3, 58, 3, 3, 3,
 	3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-	3, 3, 3, 3, 61,
+	3, 3, 3, 3, 62,
 }
 var yyTok2 = [...]int{
 
@@ -316,7 +324,7 @@ var yyTok2 = [...]int{
 	22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
 	32, 33, 34, 35, 36, 37, 38, 39, 40, 41,
 	42, 43, 44, 45, 46, 47, 48, 49, 50, 51,
-	52, 53, 54, 55, 58,
+	52, 53, 54, 55, 56, 59,
 }
 var yyTok3 = [...]int{
 	0,
@@ -740,104 +748,109 @@ yydefault:
 	case 21:
 		yyDollar = yyS[yypt-8 : yypt+1]
 		{
-			yyVAL.stmt = &UpsertIntoStmt{tableRef: yyDollar[3].tableRef, cols: yyDollar[5].ids, rows: yyDollar[8].rows}
+			yyVAL.stmt = &UpsertIntoStmt{isInsert: true, tableRef: yyDollar[3].tableRef, cols: yyDollar[5].ids, rows: yyDollar[8].rows}
 		}
 	case 22:
+		yyDollar = yyS[yypt-8 : yypt+1]
+		{
+			yyVAL.stmt = &UpsertIntoStmt{tableRef: yyDollar[3].tableRef, cols: yyDollar[5].ids, rows: yyDollar[8].rows}
+		}
+	case 23:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		{
 			yyVAL.rows = []*RowSpec{yyDollar[1].row}
 		}
-	case 23:
+	case 24:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		{
 			yyVAL.rows = append(yyDollar[1].rows, yyDollar[3].row)
 		}
-	case 24:
+	case 25:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		{
 			yyVAL.row = &RowSpec{Values: yyDollar[2].values}
 		}
-	case 25:
+	case 26:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		{
 			yyVAL.ids = []string{yyDollar[1].id}
 		}
-	case 26:
+	case 27:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		{
 			yyVAL.ids = append(yyDollar[1].ids, yyDollar[3].id)
 		}
-	case 27:
+	case 28:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		{
 			yyVAL.cols = []*ColSelector{yyDollar[1].col}
 		}
-	case 28:
+	case 29:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		{
 			yyVAL.cols = append(yyDollar[1].cols, yyDollar[3].col)
 		}
-	case 29:
+	case 30:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		{
 			yyVAL.values = []ValueExp{yyDollar[1].value}
 		}
-	case 30:
+	case 31:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		{
 			yyVAL.values = append(yyDollar[1].values, yyDollar[3].value)
 		}
-	case 31:
+	case 32:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		{
 			yyVAL.value = &Number{val: yyDollar[1].number}
 		}
-	case 32:
+	case 33:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		{
 			yyVAL.value = &Varchar{val: yyDollar[1].str}
 		}
-	case 33:
+	case 34:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		{
 			yyVAL.value = &Bool{val: yyDollar[1].boolean}
 		}
-	case 34:
+	case 35:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		{
 			yyVAL.value = &Blob{val: yyDollar[1].blob}
 		}
-	case 35:
+	case 36:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		{
 			yyVAL.value = &SysFn{fn: yyDollar[1].id}
 		}
-	case 36:
+	case 37:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		{
 			yyVAL.value = &Param{id: yyDollar[2].id}
 		}
-	case 37:
+	case 38:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		{
 			yyVAL.value = &NullValue{}
 		}
-	case 38:
+	case 39:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		{
 			yyVAL.colsSpec = []*ColSpec{yyDollar[1].colSpec}
 		}
-	case 39:
+	case 40:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		{
 			yyVAL.colsSpec = append(yyDollar[1].colsSpec, yyDollar[3].colSpec)
 		}
-	case 40:
+	case 41:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		{
 			yyVAL.colSpec = &ColSpec{colName: yyDollar[1].id, colType: yyDollar[2].sqlType}
 		}
-	case 41:
+	case 42:
 		yyDollar = yyS[yypt-12 : yypt+1]
 		{
 			yyVAL.stmt = &SelectStmt{
@@ -853,246 +866,246 @@ yydefault:
 				as:        yyDollar[12].id,
 			}
 		}
-	case 42:
+	case 43:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		{
 			yyVAL.distinct = false
 		}
-	case 43:
+	case 44:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		{
 			yyVAL.distinct = true
 		}
-	case 44:
+	case 45:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		{
 			yyDollar[1].sel.setAlias(yyDollar[2].id)
 			yyVAL.sels = []Selector{yyDollar[1].sel}
 		}
-	case 45:
+	case 46:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		{
 			yyDollar[3].sel.setAlias(yyDollar[4].id)
 			yyVAL.sels = append(yyDollar[1].sels, yyDollar[3].sel)
 		}
-	case 46:
+	case 47:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		{
 			yyVAL.sel = yyDollar[1].col
 		}
-	case 47:
+	case 48:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		{
 			yyVAL.sel = &AggColSelector{aggFn: yyDollar[1].aggFn, col: "*"}
 		}
-	case 48:
+	case 49:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		{
 			yyVAL.sel = &AggColSelector{aggFn: yyDollar[1].aggFn, db: yyDollar[3].col.db, table: yyDollar[3].col.table, col: yyDollar[3].col.col}
 		}
-	case 49:
+	case 50:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		{
 			yyVAL.col = &ColSelector{col: yyDollar[1].id}
 		}
-	case 50:
+	case 51:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		{
 			yyVAL.col = &ColSelector{table: yyDollar[1].id, col: yyDollar[3].id}
 		}
-	case 51:
+	case 52:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		{
 			yyVAL.col = &ColSelector{db: yyDollar[1].id, table: yyDollar[3].id, col: yyDollar[5].id}
 		}
-	case 52:
+	case 53:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		{
 			yyVAL.ds = yyDollar[1].tableRef
 		}
-	case 53:
+	case 54:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		{
 			yyDollar[2].tableRef.asBefore = yyDollar[3].number
 			yyDollar[2].tableRef.as = yyDollar[4].id
 			yyVAL.ds = yyDollar[2].tableRef
 		}
-	case 54:
+	case 55:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		{
 			yyVAL.ds = yyDollar[2].stmt.(*SelectStmt)
 		}
-	case 55:
+	case 56:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		{
 			yyVAL.tableRef = &TableRef{table: yyDollar[1].id}
 		}
-	case 56:
+	case 57:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		{
 			yyVAL.tableRef = &TableRef{db: yyDollar[1].id, table: yyDollar[3].id}
 		}
-	case 57:
+	case 58:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		{
 			yyVAL.number = 0
 		}
-	case 58:
+	case 59:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		{
 			yyVAL.number = yyDollar[3].number
 		}
-	case 59:
+	case 60:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		{
 			yyVAL.joins = nil
 		}
-	case 60:
+	case 61:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		{
 			yyVAL.joins = yyDollar[1].joins
 		}
-	case 61:
+	case 62:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		{
 			yyVAL.joins = []*JoinSpec{yyDollar[1].join}
 		}
-	case 62:
+	case 63:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		{
 			yyVAL.joins = append([]*JoinSpec{yyDollar[1].join}, yyDollar[2].joins...)
 		}
-	case 63:
+	case 64:
 		yyDollar = yyS[yypt-5 : yypt+1]
 		{
 			yyVAL.join = &JoinSpec{joinType: yyDollar[1].joinType, ds: yyDollar[3].ds, cond: yyDollar[5].boolExp}
 		}
-	case 64:
+	case 65:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		{
 			yyVAL.boolExp = nil
 		}
-	case 65:
+	case 66:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		{
 			yyVAL.boolExp = yyDollar[2].boolExp
 		}
-	case 66:
+	case 67:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		{
 			yyVAL.cols = nil
 		}
-	case 67:
+	case 68:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		{
 			yyVAL.cols = yyDollar[3].cols
 		}
-	case 68:
+	case 69:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		{
 			yyVAL.boolExp = nil
 		}
-	case 69:
+	case 70:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		{
 			yyVAL.boolExp = yyDollar[2].boolExp
 		}
-	case 70:
+	case 71:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		{
 			yyVAL.number = 0
 		}
-	case 71:
+	case 72:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		{
 			yyVAL.number = yyDollar[2].number
 		}
-	case 72:
+	case 73:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		{
 			yyVAL.ordcols = nil
 		}
-	case 73:
+	case 74:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		{
 			yyVAL.ordcols = yyDollar[3].ordcols
 		}
-	case 74:
+	case 75:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		{
 			yyVAL.ordcols = []*OrdCol{{sel: yyDollar[1].col, cmp: yyDollar[2].opt_ord}}
 		}
-	case 75:
+	case 76:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		{
 			yyVAL.ordcols = append(yyDollar[1].ordcols, &OrdCol{sel: yyDollar[3].col, cmp: yyDollar[4].opt_ord})
 		}
-	case 76:
-		yyDollar = yyS[yypt-0 : yypt+1]
-		{
-			yyVAL.opt_ord = GreaterOrEqualTo
-		}
 	case 77:
-		yyDollar = yyS[yypt-1 : yypt+1]
+		yyDollar = yyS[yypt-0 : yypt+1]
 		{
 			yyVAL.opt_ord = GreaterOrEqualTo
 		}
 	case 78:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		{
-			yyVAL.opt_ord = LowerOrEqualTo
+			yyVAL.opt_ord = GreaterOrEqualTo
 		}
 	case 79:
+		yyDollar = yyS[yypt-1 : yypt+1]
+		{
+			yyVAL.opt_ord = LowerOrEqualTo
+		}
+	case 80:
 		yyDollar = yyS[yypt-0 : yypt+1]
 		{
 			yyVAL.id = ""
 		}
-	case 80:
+	case 81:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		{
 			yyVAL.id = yyDollar[2].id
 		}
-	case 81:
+	case 82:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		{
 			yyVAL.boolExp = yyDollar[1].sel
 		}
-	case 82:
+	case 83:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		{
 			yyVAL.boolExp = yyDollar[1].value
 		}
-	case 83:
+	case 84:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		{
 			yyVAL.boolExp = &NumExp{left: yyDollar[1].boolExp, op: yyDollar[2].numOp, right: yyDollar[3].boolExp}
 		}
-	case 84:
+	case 85:
 		yyDollar = yyS[yypt-2 : yypt+1]
 		{
 			yyVAL.boolExp = &NotBoolExp{exp: yyDollar[2].boolExp}
 		}
-	case 85:
+	case 86:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		{
 			yyVAL.boolExp = yyDollar[2].boolExp
 		}
-	case 86:
+	case 87:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		{
 			yyVAL.boolExp = &LikeBoolExp{sel: yyDollar[1].sel, pattern: yyDollar[3].str}
 		}
-	case 87:
+	case 88:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		{
 			yyVAL.boolExp = &BinBoolExp{op: yyDollar[2].logicOp, left: yyDollar[1].boolExp, right: yyDollar[3].boolExp}
 		}
-	case 88:
+	case 89:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		{
 			yyVAL.boolExp = &CmpBoolExp{op: yyDollar[2].cmpOp, left: yyDollar[1].boolExp, right: yyDollar[3].boolExp}
 		}
-	case 89:
+	case 90:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		{
 			yyVAL.boolExp = &ExistsBoolExp{q: (yyDollar[3].stmt).(*SelectStmt)}

--- a/embedded/sql/stmt.go
+++ b/embedded/sql/stmt.go
@@ -519,12 +519,9 @@ func (n *NullValue) Value() interface{} {
 }
 
 func (n *NullValue) Compare(val TypedValue) (int, error) {
-	// TODO (jeroiraz): typed nullables not yet supported
-	/*
-		if n.t != val.Type() {
-			return 0, ErrNotComparableValues
-		}
-	*/
+	if n.t != "" && val.Type() != "" && n.t != val.Type() {
+		return 0, ErrNotComparableValues
+	}
 
 	_, isNull := val.(*NullValue)
 	if isNull {
@@ -753,7 +750,6 @@ func (p *Param) substitute(params map[string]interface{}) (ValueExp, error) {
 	}
 
 	if val == nil {
-		// TODO (jeroiraz): typed nullables not yet supported
 		return &NullValue{}, nil
 	}
 
@@ -1121,21 +1117,7 @@ func (sel *ColSelector) reduce(catalog *Catalog, row *Row, implicitDB, implicitT
 
 	v, ok := row.Values[EncodeSelector(aggFn, db, table, col)]
 	if !ok {
-		// TODO (jeroiraz): typed nullables not yet supported
-		/*t, err := catalog.GetTableByName(db, table)
-		if err != nil {
-			return nil, err
-		}
-
-		c, err := t.GetColumnByName(col)
-		if err != nil {
-			return nil, err
-		}
-
-		return &NullValue{t: c.colType}, nil
-		*/
-
-		return &NullValue{}, nil
+		return nil, ErrColumnDoesNotExist
 	}
 
 	return v, nil

--- a/embedded/store/immustore.go
+++ b/embedded/store/immustore.go
@@ -411,7 +411,9 @@ func OpenWith(path string, vLogs []appendable.Appendable, txLog, cLog appendable
 		WithCompactionThld(opts.IndexOpts.CompactionThld).
 		WithDelayDuringCompaction(opts.IndexOpts.DelayDuringCompaction)
 
-	store.indexer, err = newIndexer(store, indexDirname, indexOpts, opts.MaxWaitees)
+	indexPath := filepath.Join(store.path, indexDirname)
+
+	store.indexer, err = newIndexer(indexPath, store, indexOpts, opts.MaxWaitees)
 	if err != nil {
 		return nil, err
 	}
@@ -1012,7 +1014,7 @@ func (s *ImmuStore) commitWith(callback func(txID uint64, index KeyIndex) ([]*KV
 		return nil, ErrAlreadyClosed
 	}
 
-	s.indexer.Stop()
+	s.indexer.Pause()
 	defer s.indexer.Resume()
 
 	committedTxID, _, _ := s.commitState()

--- a/embedded/store/immustore.go
+++ b/embedded/store/immustore.go
@@ -468,6 +468,10 @@ func (s *ImmuStore) notify(nType NotificationType, mandatory bool, formattedMess
 	}
 }
 
+func (s *ImmuStore) IndexInfo() uint64 {
+	return s.indexer.Ts()
+}
+
 func (s *ImmuStore) Get(key []byte) (value []byte, tx uint64, hc uint64, err error) {
 	indexedVal, tx, hc, err := s.indexer.Get(key)
 	if err != nil {

--- a/embedded/store/indexer.go
+++ b/embedded/store/indexer.go
@@ -190,6 +190,7 @@ func (idx *indexer) resume() {
 	idx.cancellation = make(chan struct{})
 	go idx.doIndexing()
 	idx.store.notify(Info, true, "Indexing in progress at '%s'", idx.store.path)
+	idx.Resume()
 }
 
 func (idx *indexer) replaceIndex(compactedIndexID uint64) error {
@@ -279,7 +280,7 @@ func (idx *indexer) doIndexing() {
 		idx.runningCond.L.Unlock()
 
 		err = idx.indexSince(lastIndexedTx+1, 10)
-		if err == ErrAlreadyClosed {
+		if err == ErrAlreadyClosed || err == tbtree.ErrAlreadyClosed {
 			return
 		}
 		if err != nil {

--- a/embedded/store/indexer.go
+++ b/embedded/store/indexer.go
@@ -1,0 +1,341 @@
+/*
+Copyright 2021 CodeNotary, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package store
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/codenotary/immudb/embedded/tbtree"
+	"github.com/codenotary/immudb/embedded/watchers"
+)
+
+type indexer struct {
+	store *ImmuStore
+
+	indexPath string
+
+	index        *tbtree.TBtree
+	running      bool
+	closed       bool
+	cancellation chan struct{}
+
+	wHub *watchers.WatchersHub
+
+	compactionMutex sync.Mutex
+	mutex           sync.Mutex
+}
+
+func newIndexer(store *ImmuStore, indexDirname string, indexOpts *tbtree.Options, maxWaitees int) (*indexer, error) {
+	indexPath := filepath.Join(store.path, indexDirname)
+
+	index, err := tbtree.Open(indexPath, indexOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	var wHub *watchers.WatchersHub
+	if maxWaitees > 0 {
+		wHub = watchers.New(0, maxWaitees)
+	}
+
+	return &indexer{
+		store:     store,
+		indexPath: indexPath,
+		index:     index,
+		wHub:      wHub,
+	}, nil
+}
+
+func (idx *indexer) Ts() uint64 {
+	idx.mutex.Lock()
+	defer idx.mutex.Unlock()
+
+	return idx.index.Ts()
+}
+
+func (idx *indexer) Get(key []byte) (value []byte, tx uint64, hc uint64, err error) {
+	idx.mutex.Lock()
+	defer idx.mutex.Unlock()
+
+	if idx.closed {
+		return nil, 0, 0, ErrAlreadyClosed
+	}
+
+	return idx.index.Get(key)
+}
+
+func (idx *indexer) History(key []byte, offset uint64, descOrder bool, limit int) (txs []uint64, err error) {
+	idx.mutex.Lock()
+	defer idx.mutex.Unlock()
+
+	if idx.closed {
+		return nil, ErrAlreadyClosed
+	}
+
+	return idx.index.History(key, offset, descOrder, limit)
+}
+
+func (idx *indexer) Snapshot() (*tbtree.Snapshot, error) {
+	idx.mutex.Lock()
+	defer idx.mutex.Unlock()
+
+	if idx.closed {
+		return nil, ErrAlreadyClosed
+	}
+
+	return idx.index.Snapshot()
+}
+
+func (idx *indexer) SnapshotSince(tx uint64) (*tbtree.Snapshot, error) {
+	idx.mutex.Lock()
+	defer idx.mutex.Unlock()
+
+	if idx.closed {
+		return nil, ErrAlreadyClosed
+	}
+
+	return idx.index.SnapshotSince(tx)
+}
+
+func (idx *indexer) Sync() error {
+	idx.mutex.Lock()
+	defer idx.mutex.Unlock()
+
+	if idx.closed {
+		return ErrAlreadyClosed
+	}
+
+	return idx.index.Sync()
+}
+
+func (idx *indexer) Close() error {
+	idx.compactionMutex.Lock()
+	defer idx.compactionMutex.Unlock()
+
+	idx.mutex.Lock()
+	defer idx.mutex.Unlock()
+
+	if idx.closed {
+		return ErrAlreadyClosed
+	}
+
+	idx.stop()
+
+	idx.wHub.Close()
+
+	idx.closed = true
+
+	return idx.index.Close()
+}
+
+func (idx *indexer) WaitForIndexingUpto(txID uint64, cancellation <-chan struct{}) error {
+	if idx.wHub != nil {
+		return idx.wHub.WaitFor(txID, cancellation)
+	}
+
+	return watchers.ErrMaxWaitessLimitExceeded
+}
+
+func (idx *indexer) CompactIndex() error {
+	idx.compactionMutex.Lock()
+	defer idx.compactionMutex.Unlock()
+
+	compactedIndexID, err := idx.index.CompactIndex()
+	if err != nil {
+		return err
+	}
+
+	idx.mutex.Lock()
+	defer idx.mutex.Unlock()
+
+	if idx.closed {
+		return ErrAlreadyClosed
+	}
+
+	idx.stop()
+	defer idx.resume()
+
+	return idx.replaceIndex(compactedIndexID)
+}
+
+func (idx *indexer) replaceIndex(compactedIndexID uint64) error {
+	opts := idx.index.GetOptions()
+
+	err := idx.index.Close()
+	if err != nil {
+		return err
+	}
+
+	nLogPath := filepath.Join(idx.indexPath, "nodes")
+	err = os.RemoveAll(nLogPath)
+	if err != nil {
+		return err
+	}
+
+	cLogPath := filepath.Join(idx.indexPath, "commit")
+	err = os.RemoveAll(cLogPath)
+	if err != nil {
+		return err
+	}
+
+	cnLogPath := filepath.Join(idx.indexPath, fmt.Sprintf("nodes_%d", compactedIndexID))
+	ccLogPath := filepath.Join(idx.indexPath, fmt.Sprintf("commit_%d", compactedIndexID))
+
+	err = os.Rename(cnLogPath, nLogPath)
+	if err != nil {
+		return err
+	}
+
+	err = os.Rename(ccLogPath, cLogPath)
+	if err != nil {
+		return err
+	}
+
+	index, err := tbtree.Open(idx.indexPath, opts)
+	if err != nil {
+		return err
+	}
+
+	idx.index = index
+	return nil
+}
+
+func (idx *indexer) Resume() error {
+	idx.mutex.Lock()
+	defer idx.mutex.Unlock()
+
+	if idx.closed {
+		return ErrAlreadyClosed
+	}
+
+	idx.resume()
+	return nil
+}
+
+func (idx *indexer) resume() {
+	if !idx.running {
+		idx.cancellation = make(chan struct{})
+		go idx.doIndexing()
+		idx.running = true
+		idx.store.notify(Info, true, "Indexing in progress at '%s'", idx.store.path)
+	}
+}
+
+func (idx *indexer) Stop() error {
+	idx.mutex.Lock()
+	defer idx.mutex.Unlock()
+
+	if idx.closed {
+		return ErrAlreadyClosed
+	}
+
+	idx.stop()
+	return nil
+}
+
+func (idx *indexer) stop() {
+	if idx.running {
+		close(idx.cancellation)
+		idx.running = false
+		idx.store.notify(Info, true, "Indexing gracefully stopped at '%s'", idx.store.path)
+	}
+}
+
+func (idx *indexer) doIndexing() {
+	for {
+		lastIndexedTx := idx.index.Ts()
+
+		if idx.wHub != nil {
+			idx.wHub.DoneUpto(lastIndexedTx)
+		}
+
+		err := idx.store.wHub.WaitFor(lastIndexedTx+1, idx.cancellation)
+		if err == watchers.ErrCancellationRequested || err == watchers.ErrAlreadyClosed {
+			return
+		}
+		if err != nil {
+			idx.store.notify(Error, true, "Indexing failed at '%s' due to error: %v", idx.store.path, err)
+			time.Sleep(60 * time.Second)
+		}
+
+		committedTxID, _, _ := idx.store.commitState()
+
+		txsToIndex := committedTxID - lastIndexedTx
+		idx.store.notify(Info, false, "%d transaction/s to be indexed at '%s'", txsToIndex, idx.store.path)
+
+		err = idx.indexSince(lastIndexedTx+1, 10)
+		if err == ErrAlreadyClosed {
+			return
+		}
+		if err != nil {
+			idx.store.notify(Error, true, "Indexing failed at '%s' due to error: %v", idx.store.path, err)
+			time.Sleep(60 * time.Second)
+		}
+
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func (idx *indexer) indexSince(txID uint64, limit int) error {
+	tx, err := idx.store.fetchAllocTx()
+	if err != nil {
+		return err
+	}
+	defer idx.store.releaseAllocTx(tx)
+
+	txReader, err := idx.store.newTxReader(txID, false, tx)
+	if err == ErrNoMoreEntries {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	for i := 0; i < limit; i++ {
+		tx, err := txReader.Read()
+		if err == ErrNoMoreEntries {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		txEntries := tx.Entries()
+
+		for i, e := range txEntries {
+			var b [szSize + offsetSize + sha256.Size]byte
+			binary.BigEndian.PutUint32(b[:], uint32(e.vLen))
+			binary.BigEndian.PutUint64(b[szSize:], uint64(e.vOff))
+			copy(b[szSize+offsetSize:], e.hVal[:])
+
+			idx.store._kvs[i].K = e.key()
+			idx.store._kvs[i].V = b[:]
+		}
+
+		err = idx.index.BulkInsert(idx.store._kvs[:len(txEntries)])
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/embedded/store/tx.go
+++ b/embedded/store/tx.go
@@ -252,11 +252,12 @@ func (tx *Tx) readFrom(r *appendable.Reader) error {
 }
 
 type TxEntry struct {
-	k    []byte
-	kLen int
-	vLen int
-	hVal [sha256.Size]byte
-	vOff int64
+	k      []byte
+	kLen   int
+	vLen   int
+	hVal   [sha256.Size]byte
+	vOff   int64
+	unique bool
 }
 
 func NewTxEntry(key []byte, vLen int, hVal [sha256.Size]byte, vOff int64) *TxEntry {

--- a/embedded/store/tx_reader.go
+++ b/embedded/store/tx_reader.go
@@ -38,6 +38,10 @@ func (s *ImmuStore) NewTxReader(initialTxID uint64, desc bool, tx *Tx) (*TxReade
 		return nil, ErrAlreadyClosed
 	}
 
+	return s.newTxReader(initialTxID, desc, tx)
+}
+
+func (s *ImmuStore) newTxReader(initialTxID uint64, desc bool, tx *Tx) (*TxReader, error) {
 	if initialTxID == 0 {
 		return nil, ErrIllegalArguments
 	}

--- a/embedded/tools/stress_tool.go
+++ b/embedded/tools/stress_tool.go
@@ -130,10 +130,7 @@ func main() {
 		if *action == "get" {
 			time.Sleep(time.Duration(*waitForIndexing) * time.Millisecond)
 
-			ts, err := immuStore.IndexInfo()
-			if err != nil {
-				panic(err)
-			}
+			ts := immuStore.IndexInfo()
 			fmt.Printf("Index up to %d\r\n", ts)
 
 			snap, err := immuStore.Snapshot()

--- a/pkg/api/schema/row_value.go
+++ b/pkg/api/schema/row_value.go
@@ -33,7 +33,7 @@ func RenderValue(op isSQLValue_Value) string {
 		}
 	case *SQLValue_S:
 		{
-			return fmt.Sprintf("\"%s\"", v.S)
+			return v.S
 		}
 	case *SQLValue_B:
 		{

--- a/pkg/api/schema/row_value.go
+++ b/pkg/api/schema/row_value.go
@@ -33,7 +33,7 @@ func RenderValue(op isSQLValue_Value) string {
 		}
 	case *SQLValue_S:
 		{
-			return v.S
+			return fmt.Sprintf("\"%s\"", v.S)
 		}
 	case *SQLValue_B:
 		{

--- a/pkg/database/all_ops.go
+++ b/pkg/database/all_ops.go
@@ -38,7 +38,7 @@ func (d *db) ExecAll(req *schema.ExecAllRequest) (*schema.TxMetadata, error) {
 	defer d.mutex.Unlock()
 
 	lastTxID, _ := d.st.Alh()
-	err := d.st.WaitForIndexingUpto(lastTxID)
+	err := d.st.WaitForIndexingUpto(lastTxID, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/database/all_ops_test.go
+++ b/pkg/database/all_ops_test.go
@@ -78,7 +78,7 @@ func TestConcurrentCompactIndex(t *testing.T) {
 	ack := make(chan struct{})
 
 	cleanUpFreq := 1 * time.Second
-	cleanUpTimeout := 10 * time.Second
+	cleanUpTimeout := 5 * time.Second
 	execAllTimeout := 1 * time.Second
 
 	go func(ticker *time.Ticker, done <-chan struct{}, ack chan<- struct{}) {
@@ -100,7 +100,7 @@ func TestConcurrentCompactIndex(t *testing.T) {
 		}
 	}(time.NewTicker(cleanUpFreq), done, ack)
 
-	txCount := 100
+	txCount := 10
 	txSize := 32
 
 	for i := 0; i < txCount; i++ {
@@ -125,6 +125,8 @@ func TestConcurrentCompactIndex(t *testing.T) {
 		require.NoError(t, err)
 
 	}
+
+	time.Sleep(3 * time.Second)
 
 	done <- struct{}{}
 	<-ack

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -181,17 +181,7 @@ func NewDb(op *DbOptions, catalogDB DB, log logger.Logger) (DB, error) {
 
 // CompactIndex ...
 func (d *db) CompactIndex() error {
-	d.Logger.Infof("Compacting index '%s'...", d.options.dbName)
-
-	err := d.st.CompactIndex()
-
-	if err == nil {
-		d.Logger.Infof("Index '%s' sucessfully compacted", d.options.dbName)
-	} else {
-		d.Logger.Warningf("Compaction of index '%s' returned: %v", d.options.dbName, err)
-	}
-
-	return err
+	return d.st.CompactIndex()
 }
 
 // Set ...

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -235,7 +235,7 @@ func (d *db) Get(req *schema.KeyRequest) (*schema.Entry, error) {
 		return nil, ErrIllegalArguments
 	}
 
-	err := d.st.WaitForIndexingUpto(req.SinceTx)
+	err := d.st.WaitForIndexingUpto(req.SinceTx, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -456,7 +456,7 @@ func (d *db) VerifiableGet(req *schema.VerifiableGetRequest) (*schema.Verifiable
 
 //GetAll ...
 func (d *db) GetAll(req *schema.KeyListRequest) (*schema.Entries, error) {
-	err := d.st.WaitForIndexingUpto(req.SinceTx)
+	err := d.st.WaitForIndexingUpto(req.SinceTx, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -632,7 +632,7 @@ func (d *db) History(req *schema.HistoryRequest) (*schema.Entries, error) {
 		return nil, ErrMaxKeyScanLimitExceeded
 	}
 
-	err := d.st.WaitForIndexingUpto(req.SinceTx)
+	err := d.st.WaitForIndexingUpto(req.SinceTx, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/database/database_test.go
+++ b/pkg/database/database_test.go
@@ -48,8 +48,9 @@ var kvs = []*schema.KeyValue{
 }
 
 func makeDb() (DB, func()) {
-	catalogDBName := "EdithPiaf_catalog_" + strconv.FormatInt(time.Now().UnixNano(), 10)
-	catalogOptions := DefaultOption().WithDbName(catalogDBName).WithCorruptionChecker(false)
+	rootPath := "data_" + strconv.FormatInt(time.Now().UnixNano(), 10)
+
+	catalogOptions := DefaultOption().WithDbRootPath(rootPath).WithDbName("catalog").WithCorruptionChecker(false)
 	catalogOptions.storeOpts.WithIndexOptions(catalogOptions.storeOpts.IndexOpts.WithCompactionThld(0))
 
 	catalogDB, err := NewDb(catalogOptions, nil, logger.NewSimpleLogger("immudb ", os.Stderr))
@@ -57,8 +58,7 @@ func makeDb() (DB, func()) {
 		log.Fatalf("Error creating Db instance %s", err)
 	}
 
-	dbName := "EdithPiaf" + strconv.FormatInt(time.Now().UnixNano(), 10)
-	options := DefaultOption().WithDbName(dbName).WithCorruptionChecker(false)
+	options := DefaultOption().WithDbRootPath(rootPath).WithDbName("db").WithCorruptionChecker(false)
 	options.storeOpts.WithIndexOptions(options.storeOpts.IndexOpts.WithCompactionThld(0))
 
 	db, err := NewDb(options, catalogDB, logger.NewSimpleLogger("immudb ", os.Stderr))
@@ -70,13 +70,11 @@ func makeDb() (DB, func()) {
 		if err := db.Close(); err != nil {
 			log.Fatal(err)
 		}
-		if err := os.RemoveAll(options.dbRootPath); err != nil {
-			log.Fatal(err)
-		}
 		if err := catalogDB.Close(); err != nil {
 			log.Fatal(err)
 		}
-		if err := os.RemoveAll(catalogOptions.dbRootPath); err != nil {
+
+		if err := os.RemoveAll(rootPath); err != nil {
 			log.Fatal(err)
 		}
 	}

--- a/pkg/database/reference.go
+++ b/pkg/database/reference.go
@@ -40,7 +40,7 @@ func (d *db) SetReference(req *schema.ReferenceRequest) (*schema.TxMetadata, err
 	defer d.mutex.Unlock()
 
 	lastTxID, _ := d.st.Alh()
-	err := d.st.WaitForIndexingUpto(lastTxID)
+	err := d.st.WaitForIndexingUpto(lastTxID, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/database/scan.go
+++ b/pkg/database/scan.go
@@ -40,7 +40,7 @@ func (d *db) Scan(req *schema.ScanRequest) (*schema.Entries, error) {
 	}
 
 	if !req.NoWait {
-		err := d.st.WaitForIndexingUpto(waitUntilTx)
+		err := d.st.WaitForIndexingUpto(waitUntilTx, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/database/sorted_set.go
+++ b/pkg/database/sorted_set.go
@@ -45,7 +45,7 @@ func (d *db) ZAdd(req *schema.ZAddRequest) (*schema.TxMetadata, error) {
 	defer d.mutex.Unlock()
 
 	lastTxID, _ := d.st.Alh()
-	err := d.st.WaitForIndexingUpto(lastTxID)
+	err := d.st.WaitForIndexingUpto(lastTxID, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +119,7 @@ func (d *db) ZScan(req *schema.ZScanRequest) (*schema.ZEntries, error) {
 	}
 
 	if !req.NoWait {
-		err := d.st.WaitForIndexingUpto(waitUntilTx)
+		err := d.st.WaitForIndexingUpto(waitUntilTx, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -113,6 +113,11 @@ func TestServerReOpen(t *testing.T) {
 		t.Fatalf("error loading default database %v", err)
 	}
 
+	err = s.CloseDatabases()
+	if err != nil {
+		t.Fatalf("error closing databases %v", err)
+	}
+
 	s = DefaultServer().WithOptions(serverOptions).(*ImmuServer)
 
 	err = s.loadSystemDatabase(dbRootpath, s.Options.AdminPassword)


### PR DESCRIPTION
This PR introduces changes at the store level in order to provide the functionality needed to implement INSERT INTO statement. Mainly by being able to specify uniqueness constraint to any key-value entry at commit time but also internal changes i.e.  indexing go-routine synchronisation via watchersHub for committed transactions. 

Additionally, this PR increases testing coverage of SQL Engine and includes fixes done during its preparation.

Signed-off-by: Jeronimo Irazabal <jeronimo.irazabal@gmail.com>