### PR TITLE
fix(pkg/client/cache): fix lock file cache issue on windows

### DIFF
--- a/pkg/client/cache/cache.go
+++ b/pkg/client/cache/cache.go
@@ -16,13 +16,20 @@ limitations under the License.
 
 package cache
 
-import "github.com/codenotary/immudb/pkg/api/schema"
+import (
+	"errors"
+	"github.com/codenotary/immudb/pkg/api/schema"
+)
+
+var ErrCacheNotLocked = errors.New("cache is not locked")
+var ErrCacheAlreadyLocked = errors.New("cache is already locked")
 
 // Cache the cache interface
 type Cache interface {
 	Get(serverUUID, db string) (*schema.ImmutableState, error)
 	Set(serverUUID, db string, state *schema.ImmutableState) error
-	GetLocker(serverUUID string) Locker
+	Lock(serverUUID string) error
+	Unlock() error
 }
 
 // HistoryCache the history cache interface
@@ -31,7 +38,3 @@ type HistoryCache interface {
 	Walk(serverUUID string, db string, f func(*schema.ImmutableState) interface{}) ([]interface{}, error)
 }
 
-type Locker interface {
-	Lock() error
-	Unlock() error
-}

--- a/pkg/client/cache/file_cache.go
+++ b/pkg/client/cache/file_cache.go
@@ -33,7 +33,7 @@ import (
 const STATE_FN = ".state-"
 
 type fileCache struct {
-	Dir string
+	Dir       string
 	stateFile *lockedfile.File
 }
 
@@ -96,24 +96,23 @@ func (w *fileCache) Set(serverUUID string, db string, state *schema.ImmutableSta
 	}
 	output := bytes.Join(lines, []byte("\n"))
 
-	_, err = w.stateFile.WriteAt( output, 0)
+	_, err = w.stateFile.WriteAt(output, 0)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-
 func (w *fileCache) Lock(serverUUID string) (err error) {
-	if w.stateFile != nil {
-		return ErrCacheAlreadyLocked
-	}
-	w.stateFile, err = lockedfile.OpenFile(w.getStateFilePath(serverUUID), os.O_RDWR | os.O_CREATE, 0755)
+	w.stateFile, err = lockedfile.OpenFile(w.getStateFilePath(serverUUID), os.O_RDWR|os.O_CREATE, 0755)
 	return err
 }
 
 func (w *fileCache) Unlock() (err error) {
-	return w.stateFile.Close()
+	if w.stateFile != nil {
+		return w.stateFile.Close()
+	}
+	return nil
 }
 
 func (w *fileCache) getStateFilePath(UUID string) string {

--- a/pkg/client/cache/file_cache.go
+++ b/pkg/client/cache/file_cache.go
@@ -17,13 +17,13 @@ limitations under the License.
 package cache
 
 import (
+	"bufio"
+	"bytes"
 	"encoding/base64"
-	"fmt"
-	"io/ioutil"
+	"github.com/rogpeppe/go-internal/lockedfile"
+	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/rogpeppe/go-internal/lockedfile"
 
 	"github.com/codenotary/immudb/pkg/api/schema"
 	"github.com/golang/protobuf/proto"
@@ -34,6 +34,7 @@ const STATE_FN = ".state-"
 
 type fileCache struct {
 	Dir string
+	stateFile *lockedfile.File
 }
 
 // NewFileCache returns a new file cache
@@ -41,15 +42,14 @@ func NewFileCache(dir string) Cache {
 	return &fileCache{Dir: dir}
 }
 
-func (w *fileCache) Get(serverUUID, db string) (*schema.ImmutableState, error) {
-	fn := filepath.Join(w.Dir, string(getRootFileName([]byte(STATE_FN), []byte(serverUUID))))
-
-	raw, err := ioutil.ReadFile(fn)
-	if err != nil {
-		return nil, err
+func (w *fileCache) Get(serverUUID string, db string) (*schema.ImmutableState, error) {
+	if w.stateFile == nil {
+		return nil, ErrCacheNotLocked
 	}
-	lines := strings.Split(string(raw), "\n")
-	for _, line := range lines {
+	scanner := bufio.NewScanner(w.stateFile)
+	scanner.Split(bufio.ScanLines)
+	for scanner.Scan() {
+		line := scanner.Text()
 		if strings.Contains(line, db+":") {
 			r := strings.Split(line, ":")
 			if r[1] == "" {
@@ -69,64 +69,53 @@ func (w *fileCache) Get(serverUUID, db string) (*schema.ImmutableState, error) {
 	return nil, ErrPrevStateNotFound
 }
 
-func (w *fileCache) Set(serverUUID, db string, state *schema.ImmutableState) error {
+func (w *fileCache) Set(serverUUID string, db string, state *schema.ImmutableState) error {
+	if w.stateFile == nil {
+		return ErrCacheNotLocked
+	}
 	raw, err := proto.Marshal(state)
 	if err != nil {
 		return err
 	}
-	fn := filepath.Join(w.Dir, string(getRootFileName([]byte(STATE_FN), []byte(serverUUID))))
 
-	input, _ := ioutil.ReadFile(fn)
-	lines := strings.Split(string(input), "\n")
-
-	newState := db + ":" + base64.StdEncoding.EncodeToString(raw) + "\n"
+	newState := db + ":" + base64.StdEncoding.EncodeToString(raw)
 	var exists bool
-	for i, line := range lines {
+
+	scanner := bufio.NewScanner(w.stateFile)
+	scanner.Split(bufio.ScanLines)
+	var lines [][]byte
+	for scanner.Scan() {
+		line := scanner.Text()
 		if strings.Contains(line, db+":") {
 			exists = true
-			lines[i] = newState
+			lines = append(lines, []byte(newState))
 		}
 	}
 	if !exists {
-		lines = append(lines, newState)
+		lines = append(lines, []byte(newState))
 	}
-	output := strings.Join(lines, "\n")
+	output := bytes.Join(lines, []byte("\n"))
 
-	if err = ioutil.WriteFile(fn, []byte(output), 0644); err != nil {
+	_, err = w.stateFile.WriteAt( output, 0)
+	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func getRootFileName(prefix []byte, serverUUID []byte) []byte {
-	l1 := len(prefix)
-	l2 := len(serverUUID)
-	var fn = make([]byte, l1+l2)
-	copy(fn[:], STATE_FN)
-	copy(fn[l1:], serverUUID)
-	return fn
-}
 
-func (w *fileCache) GetLocker(serverUUID string) Locker {
-	fn := filepath.Join(w.Dir, string(getRootFileName([]byte(STATE_FN), []byte(serverUUID))))
-	fm := lockedfile.MutexAt(fn)
-	return &FileLocker{lm: fm}
-}
-
-type FileLocker struct {
-	lm         *lockedfile.Mutex
-	unlockFunc func()
-}
-
-func (fl *FileLocker) Lock() (err error) {
-	fl.unlockFunc, err = fl.lm.Lock()
+func (w *fileCache) Lock(serverUUID string) (err error) {
+	if w.stateFile != nil {
+		return ErrCacheAlreadyLocked
+	}
+	w.stateFile, err = lockedfile.OpenFile(w.getStateFilePath(serverUUID), os.O_RDWR | os.O_CREATE, 0755)
 	return err
 }
 
-func (fl *FileLocker) Unlock() (err error) {
-	if fl.unlockFunc == nil {
-		return fmt.Errorf("try to lock a not locked file")
-	}
-	fl.unlockFunc()
-	return nil
+func (w *fileCache) Unlock() (err error) {
+	return w.stateFile.Close()
+}
+
+func (w *fileCache) getStateFilePath(UUID string) string {
+	return filepath.Join(w.Dir, STATE_FN+UUID)
 }

--- a/pkg/client/cache/file_cache_test.go
+++ b/pkg/client/cache/file_cache_test.go
@@ -21,7 +21,7 @@ func TestNewFileCache(t *testing.T) {
 	os.RemoveAll(dirname)
 }
 
-func TestFileCacheSet(t *testing.T) {
+func TestFileCacheSetError(t *testing.T) {
 	dirname, err := ioutil.TempDir("", "example")
 	if err != nil {
 		log.Fatal(err)
@@ -32,7 +32,24 @@ func TestFileCacheSet(t *testing.T) {
 		TxHash:    []byte(`hash`),
 		Signature: nil,
 	})
-	require.Nil(t, err)
+	require.Error(t, err)
+	os.RemoveAll(dirname)
+}
+
+func TestFileCacheSet(t *testing.T) {
+	dirname, err := ioutil.TempDir("", "example")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fc := NewFileCache(dirname)
+	err = fc.Lock("uuid")
+	require.NoError(t, err)
+	err = fc.Set("uuid", "dbName", &schema.ImmutableState{
+		TxId:      0,
+		TxHash:    []byte(`hash`),
+		Signature: nil,
+	})
+	require.NoError(t, err)
 	os.RemoveAll(dirname)
 }
 
@@ -42,6 +59,8 @@ func TestFileCacheGet(t *testing.T) {
 		log.Fatal(err)
 	}
 	fc := NewFileCache(dirname)
+	err = fc.Lock("uuid")
+	require.NoError(t, err)
 	err = fc.Set("uuid", "dbName", &schema.ImmutableState{
 		TxId:      0,
 		TxHash:    []byte(`hash`),

--- a/pkg/client/cache/history_file_cache.go
+++ b/pkg/client/cache/history_file_cache.go
@@ -162,16 +162,13 @@ func (history *historyFileCache) unmarshalRoot(fpath string, db string) (*schema
 	return nil, nil
 }
 
-func (history *historyFileCache) GetLocker(serverUUID string) Locker {
-	return &HistoryLocker{}
-}
 
-type HistoryLocker struct{}
 
-func (fl *HistoryLocker) Lock() (err error) {
+
+func (fl *historyFileCache) Lock(serverUUID string) (err error) {
 	return fmt.Errorf("not implemented")
 }
 
-func (fl *HistoryLocker) Unlock() (err error) {
+func (fl *historyFileCache) Unlock() (err error) {
 	return fmt.Errorf("not implemented")
 }

--- a/pkg/client/cache/inmemory_cache.go
+++ b/pkg/client/cache/inmemory_cache.go
@@ -60,16 +60,10 @@ func (imc *inMemoryCache) Set(serverUUID, db string, state *schema.ImmutableStat
 	return nil
 }
 
-func (imc *inMemoryCache) GetLocker(serverUUID string) Locker {
-	return &InMemoryLocker{}
-}
-
-type InMemoryLocker struct{}
-
-func (fl *InMemoryLocker) Lock() (err error) {
+func (fl *inMemoryCache) Lock(serverUUID string) (err error) {
 	return fmt.Errorf("not implemented")
 }
 
-func (fl *InMemoryLocker) Unlock() (err error) {
+func (fl *inMemoryCache) Unlock() (err error) {
 	return fmt.Errorf("not implemented")
 }

--- a/pkg/client/cache/inmemory_cache_test.go
+++ b/pkg/client/cache/inmemory_cache_test.go
@@ -54,15 +54,10 @@ func TestInMemoryCache(t *testing.T) {
 	_, err = imc.Get("server1", "unknownDb")
 	require.Error(t, err)
 
-	locker := imc.GetLocker("server1")
-	require.NotNil(t, locker)
-
-	err = locker.Lock()
+	err = imc.Lock("server1")
 	require.Error(t, err)
 
-	err = locker.Unlock()
+	err = imc.Unlock()
 	require.Error(t, err)
-	
-	require.NotNil(t, locker)
 
 }

--- a/pkg/client/state/state_service.go
+++ b/pkg/client/state/state_service.go
@@ -39,7 +39,6 @@ type stateService struct {
 	cache         cache.Cache
 	serverUUID    string
 	logger        logger.Logger
-	l             cache.Locker
 	sync.RWMutex
 }
 
@@ -63,7 +62,6 @@ func NewStateService(cache cache.Cache,
 		cache:         cache,
 		logger:        logger,
 		serverUUID:    serverUUID,
-		l:             cache.GetLocker(serverUUID),
 	}, nil
 }
 
@@ -99,9 +97,9 @@ func (r *stateService) SetState(db string, state *schema.ImmutableState) error {
 }
 
 func (r *stateService) CacheLock() error {
-	return r.l.Lock()
+	return r.cache.Lock(r.serverUUID)
 }
 
 func (r *stateService) CacheUnlock() error {
-	return r.l.Unlock()
+	return r.cache.Unlock()
 }


### PR DESCRIPTION
In order to make possible that client sdk can be run by multiple processes on same state file it was introduced a file lock solution.
We detected unexpected beahviour on windows (lock fail) and this PR replace completely the previous implementation.
Instead of a mutex (that make not possible to write on a locked file) we use lockfile primitive. 
lockfile.Openfile is used to acquire the lock, and close to release and the locked file object pointer is keep in memory during operations.