### PR TITLE
Enhance metrics for DB size and number of entries to support multiple databases and add CORS to metrics endpoints

### DIFF
--- a/cmd/immuadmin/command/stats/controller.go
+++ b/cmd/immuadmin/command/stats/controller.go
@@ -119,17 +119,19 @@ func updatePlot(
 }
 
 func (p *statsController) Render(ms *metrics) {
-	uptime, _ := time.ParseDuration(fmt.Sprintf("%.4fh", ms.db.uptimeHours))
+	db := ms.dbWithMostEntries()
+
+	uptime, _ := time.ParseDuration(fmt.Sprintf("%.4fh", ms.uptimeHours))
 	p.SummaryTable.Rows = [][]string{
 		{"[ImmuDB stats](mod:bold)", fmt.Sprintf("[ at %s](mod:bold)", time.Now().Format("15:04:05"))},
-		{"Database", ms.db.name},
+		{"Database", db.name},
 		{"Uptime", uptime.String()},
-		{"Entries", fmt.Sprintf("%d", ms.db.nbEntries)},
+		{"Entries", fmt.Sprintf("%d", db.nbEntries)},
 		{"No. clients", fmt.Sprintf("%d", ms.nbClients)},
 		{"  active < 1h ago", fmt.Sprintf("%d", len(*ms.clientsActiveDuringLastHour()))},
 	}
 
-	totalSizeS, totalSize := byteCountBinary(ms.db.totalBytes)
+	totalSizeS, totalSize := byteCountBinary(db.totalBytes)
 	updatePlot(
 		p.SizePlot,
 		&p.SizePlotData,

--- a/cmd/immuadmin/command/stats/metrics.go
+++ b/cmd/immuadmin/command/stats/metrics.go
@@ -18,10 +18,13 @@ package stats
 
 import (
 	"fmt"
+	"math"
 	"time"
 
 	dto "github.com/prometheus/client_model/go"
 )
+
+const SystemdbName = "systemdb"
 
 var readers = map[string]bool{
 	"ByIndex":     true,
@@ -70,10 +73,9 @@ type rpcDuration struct {
 }
 
 type dbInfo struct {
-	name        string
-	totalBytes  uint64
-	nbEntries   uint64
-	uptimeHours float64
+	name       string
+	totalBytes uint64
+	nbEntries  uint64
 }
 
 type operations struct {
@@ -97,7 +99,8 @@ type metrics struct {
 	nbClients            int
 	nbRPCsPerClient      map[string]uint64
 	lastMsgAtPerClient   map[string]uint64
-	db                   dbInfo
+	uptimeHours          float64
+	dbs                  map[string]dbInfo
 	memstats             memstats
 }
 
@@ -153,30 +156,56 @@ func (ms *metrics) withClients(metricsFamilies *map[string]*dto.MetricFamily) {
 	}
 }
 
+func getGaugeVecPerLabel(metrics []*dto.Metric, label string, out *map[string]uint64) {
+	for _, m := range metrics {
+		var labelValue string
+		for _, labelPair := range m.GetLabel() {
+			if labelPair.GetName() == "db" {
+				labelValue = labelPair.GetValue()
+				break
+			}
+		}
+		(*out)[labelValue] = uint64(m.GetGauge().GetValue())
+	}
+}
+
 func (ms *metrics) withDBInfo(metricsFamilies *map[string]*dto.MetricFamily) {
-
-	ms.db.name = "data/defaultdb"
-
-	// DB size
-	dbSizeMetricsFams := (*metricsFamilies)["immudb_db_size_bytes"]
-	if dbSizeMetricsFams != nil && len(dbSizeMetricsFams.GetMetric()) > 0 {
-		ms.db.totalBytes =
-			uint64(dbSizeMetricsFams.GetMetric()[0].GetCounter().GetValue())
-	}
-
-	// Number of entries
-	nbEntriesMetricsFams := (*metricsFamilies)["immudb_number_of_stored_entries"]
-	if nbEntriesMetricsFams != nil && len(nbEntriesMetricsFams.GetMetric()) > 0 {
-		ms.db.nbEntries =
-			uint64(nbEntriesMetricsFams.GetMetric()[0].GetCounter().GetValue())
-	}
-
 	// Uptime hours
 	upHoursMetricsFams := (*metricsFamilies)["immudb_uptime_hours"]
 	if upHoursMetricsFams != nil && len(upHoursMetricsFams.GetMetric()) > 0 {
-		ms.db.uptimeHours = upHoursMetricsFams.GetMetric()[0].GetCounter().GetValue()
+		ms.uptimeHours = upHoursMetricsFams.GetMetric()[0].GetCounter().GetValue()
 	}
 
+	// DB sizes
+	dbSizes := make(map[string]uint64)
+	getGaugeVecPerLabel(
+		(*metricsFamilies)["immudb_db_size_bytes"].GetMetric(),
+		"db",
+		&dbSizes)
+
+	// Number of entries
+	nbsEntries := make(map[string]uint64)
+	getGaugeVecPerLabel(
+		(*metricsFamilies)["immudb_number_of_stored_entries"].GetMetric(),
+		"db",
+		&nbsEntries)
+
+	// aggregate all metrics to db info structs
+	dbInfos := make(map[string]dbInfo, int(math.Max(float64(len(dbSizes)), float64(len(nbsEntries)))))
+	for db, dbSize := range dbSizes {
+		currDBInfo := dbInfos[db]
+		currDBInfo.name = db
+		currDBInfo.totalBytes = dbSize
+		dbInfos[db] = currDBInfo
+	}
+	for db, nbEntries := range nbsEntries {
+		currDBInfo := dbInfos[db]
+		currDBInfo.name = db
+		currDBInfo.nbEntries = nbEntries
+		dbInfos[db] = currDBInfo
+	}
+
+	ms.dbs = dbInfos
 }
 
 func (ms *metrics) withDuration(metricsFamilies *map[string]*dto.MetricFamily) {
@@ -236,6 +265,18 @@ func (ms *metrics) withMemStats(metricsFamilies *map[string]*dto.MetricFamily) {
 	if stackInUseMetric := (*metricsFamilies)["go_memstats_stack_inuse_bytes"]; stackInUseMetric != nil {
 		ms.memstats.stackInUseBytes = uint64(*stackInUseMetric.GetMetric()[0].GetGauge().Value)
 	}
+}
+
+func (ms *metrics) dbWithMostEntries() dbInfo {
+	var db dbInfo
+	for _, currentDB := range ms.dbs {
+		if (len(db.name) == 0 || currentDB.nbEntries > db.nbEntries) &&
+			// skip system db
+			currentDB.name != SystemdbName {
+			db = currentDB
+		}
+	}
+	return db
 }
 
 func byteCountBinary(b uint64) (string, float64) {

--- a/cmd/immuadmin/command/stats/show.go
+++ b/cmd/immuadmin/command/stats/show.go
@@ -64,17 +64,19 @@ func ShowMetricsAsText(w io.Writer, serverAddress string) error {
 		return err
 	}
 
+	db := ms.dbWithMostEntries()
+
 	const labelLength = 27
 	const strPattern = "%-*s:\t%s\n"
 	const intPattern = "%-*s:\t%d\n"
 
 	// print DB info
-	fmt.Fprintf(w, strPattern, labelLength, "Database path", ms.db.name)
-	uptime, _ := time.ParseDuration(fmt.Sprintf("%.4fh", ms.db.uptimeHours))
+	fmt.Fprintf(w, strPattern, labelLength, "Database", db.name)
+	uptime, _ := time.ParseDuration(fmt.Sprintf("%.4fh", ms.uptimeHours))
 	fmt.Fprintf(w, strPattern, labelLength, "Uptime", uptime)
-	fmt.Fprintf(w, intPattern, labelLength, "Number of entries", ms.db.nbEntries)
-	totalSizeS, _ := byteCountBinary(ms.db.totalBytes)
-	fmt.Fprintf(w, strPattern, labelLength, "DB size", totalSizeS)
+	fmt.Fprintf(w, intPattern, labelLength, "Entries", db.nbEntries)
+	totalSizeS, _ := byteCountBinary(db.totalBytes)
+	fmt.Fprintf(w, strPattern, labelLength, "Size", totalSizeS)
 
 	// print clients
 	fmt.Fprintf(w, intPattern, labelLength, "Number of clients", ms.nbClients)

--- a/pkg/server/metrics_funcs.go
+++ b/pkg/server/metrics_funcs.go
@@ -17,32 +17,89 @@ limitations under the License.
 package server
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
 )
 
-func (s *ImmuServer) metricFuncDefaultDBRecordsCounter() float64 {
-	ic, err := s.dbList.GetByIndex(DefaultDbIndex).CurrentState()
-	if err != nil {
-		return 0
-	}
-	return float64(ic.GetTxId())
-}
-
 func (s *ImmuServer) metricFuncServerUptimeCounter() float64 {
 	return time.Since(startedAt).Hours()
 }
 
-func (s *ImmuServer) metricFuncDefaultDBSize() float64 {
-	var defaultDBDirSizeBytes int64 = 0
-	readSize := func(path string, file os.FileInfo, err error) error {
-		if !file.IsDir() {
-			defaultDBDirSizeBytes += file.Size()
+// returns the specified directory's size in bytes
+func dirSize(dir string) (int64, error) {
+	var dirSizeBytes int64 = 0
+	addSizeIfNotDir := func(path string, file os.FileInfo, err error) error {
+		if err != nil {
+			return err
 		}
+		if file.IsDir() {
+			return nil
+		}
+		dirSizeBytes += file.Size()
 		return nil
 	}
-	defaultDBPath := filepath.Join(s.Options.Dir, s.Options.defaultDbName)
-	filepath.Walk(defaultDBPath, readSize)
-	return float64(defaultDBDirSizeBytes)
+	if err := filepath.Walk(dir, addSizeIfNotDir); err != nil {
+		return 0, fmt.Errorf(
+			"error walking dir %s to read it's size: %v", dir, err)
+	}
+	return dirSizeBytes, nil
+}
+
+func (s *ImmuServer) metricFuncComputeDBSizes() (dbSizes map[string]float64) {
+	dbSizes = make(map[string]float64)
+
+	for i := 0; i < s.dbList.Length(); i++ {
+		db := s.dbList.GetByIndex(int64(i))
+		dbName := db.GetOptions().GetDbName()
+		dbSize, err := dirSize(filepath.Join(s.Options.Dir, dbName))
+		if err != nil {
+			s.Logger.Errorf("error updating db size metric for db %s: %v", dbName, err)
+			continue
+		}
+		dbSizes[dbName] = float64(dbSize)
+	}
+
+	// add systemdb
+	sysDBName := s.sysDb.GetOptions().GetDbName()
+	sysDBSize, err := dirSize(filepath.Join(s.Options.Dir, sysDBName))
+	if err != nil {
+		s.Logger.Errorf("error updating db size metric for system db %s: %v", sysDBName, err)
+	} else {
+
+		dbSizes[sysDBName] = float64(sysDBSize)
+	}
+
+	return
+}
+
+func (s *ImmuServer) metricFuncComputeDBEntries() (nbEntriesPerDB map[string]float64) {
+	nbEntriesPerDB = make(map[string]float64)
+
+	for i := 0; i < s.dbList.Length(); i++ {
+		db := s.dbList.GetByIndex(int64(i))
+		dbName := db.GetOptions().GetDbName()
+		state, err := db.CurrentState()
+		if err != nil {
+			s.Logger.Errorf(
+				"error getting current state of db %s to update the number of entries metric: %v",
+				dbName, err)
+			continue
+		}
+		nbEntriesPerDB[dbName] = float64(state.GetTxId())
+	}
+
+	// add systemdb
+	sysDBName := s.sysDb.GetOptions().GetDbName()
+	state, err := s.sysDb.CurrentState()
+	if err != nil {
+		s.Logger.Errorf(
+			"error getting current state of system db %s to update the number of entries metric: %v",
+			sysDBName, err)
+	} else {
+		nbEntriesPerDB[sysDBName] = float64(state.GetTxId())
+	}
+
+	return
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -187,7 +187,7 @@ func (s *ImmuServer) Initialize() error {
 	s.GrpcServer = grpc.NewServer(grpcSrvOpts...)
 	schema.RegisterImmuServiceServer(s.GrpcServer, s)
 	grpc_prometheus.Register(s.GrpcServer)
-	
+
 	return err
 }
 
@@ -258,9 +258,9 @@ func (s *ImmuServer) setUpMetricsServer() error {
 	s.metricsServer = StartMetrics(
 		s.Options.MetricsBind(),
 		s.Logger,
-		s.metricFuncDefaultDBRecordsCounter,
 		s.metricFuncServerUptimeCounter,
-		s.metricFuncDefaultDBSize,
+		s.metricFuncComputeDBSizes,
+		s.metricFuncComputeDBEntries,
 	)
 	return nil
 }


### PR DESCRIPTION
closes #730 
Examples from the response of the `/metrics` endpoint:

---

- [x] DB sizes
```bash
# HELP immudb_db_size_bytes Database size in bytes.
# TYPE immudb_db_size_bytes gauge
immudb_db_size_bytes{db="cnlcdata"} 61044
immudb_db_size_bytes{db="cnlcinternalledger"} 20600
immudb_db_size_bytes{db="cnlcsyslogledger"} 2156
immudb_db_size_bytes{db="defaultdb"} 20612
immudb_db_size_bytes{db="lcledgeronekkgeln"} 107992
immudb_db_size_bytes{db="systemdb"} 11158
```
⚠️ The db sizes are **NOT** the actual size that is occupied on the disk. I tried to do it, initially, but it only worked on Linux (using `Fstat` from golang.org/x/sys package). I already spent to much time trying to find out how to do it in a cross-platform way, so i resorted to the same approach that is on `master` which uses `os.FileInfo.Size()`.

---

- [x] Number of entries
```bash
# HELP immudb_number_of_stored_entries Number of key-value entries currently stored by the database.
# TYPE immudb_number_of_stored_entries gauge
immudb_number_of_stored_entries{db="cnlcdata"} 34
immudb_number_of_stored_entries{db="cnlcinternalledger"} 0
immudb_number_of_stored_entries{db="cnlcsyslogledger"} 0
immudb_number_of_stored_entries{db="defaultdb"} 0
immudb_number_of_stored_entries{db="lcledgeronekkgeln"} 111
immudb_number_of_stored_entries{db="systemdb"} 11
```
⚠️ The number of entries are actually the latest transaction ID of each database, as i am not aware of any other (better) way of "counting" all entries.

---

- [x] Update `immuadmin stats` command to correctly handle the new metrics format above (both for the default graphical mode and the `--text` mode).
⚠️ Instead of the _defaultdb_, the `stats` command now shows data for the database which has the most entries (i.e. it's assuming that that one is the one which would be of most interest for the user). In the future we should enhance it to show stats for the specified db - e.g. with a new flag `--db`.

- [x] I've also added CORS to metrics endpoints in a separate commit c15b64042101db0eaa3996a14ba7b320eb405f51 (i closed the separate PR #757 that i created for that)