### PR TITLE
Fix wrong History File Cache test

### DIFF
--- a/pkg/client/cache/cache.go
+++ b/pkg/client/cache/cache.go
@@ -37,4 +37,3 @@ type HistoryCache interface {
 	Cache
 	Walk(serverUUID string, db string, f func(*schema.ImmutableState) interface{}) ([]interface{}, error)
 }
-

--- a/pkg/client/cache/history_file_cache.go
+++ b/pkg/client/cache/history_file_cache.go
@@ -162,9 +162,6 @@ func (history *historyFileCache) unmarshalRoot(fpath string, db string) (*schema
 	return nil, nil
 }
 
-
-
-
 func (fl *historyFileCache) Lock(serverUUID string) (err error) {
 	return fmt.Errorf("not implemented")
 }

--- a/pkg/client/cache/history_file_cache_test.go
+++ b/pkg/client/cache/history_file_cache_test.go
@@ -140,24 +140,33 @@ func TestHistoryFileCache_SetMissingFolder(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestHistoryFileCache_WalkFolderNotExists(t *testing.T) {
-	dir := "/notExists"
-	fc := NewHistoryFileCache(dir)
+func TestHistoryFileCache_WalkFolderNotExistsCreated(t *testing.T) {
+	dir, err := ioutil.TempDir("", "history-cache")
+	if err != nil {
+		log.Fatal(err)
+	}
 	defer os.RemoveAll(dir)
 
-	_, err := fc.Walk("uuid", "dbName", func(root *schema.ImmutableState) interface{} {
+	notExists := filepath.Join(dir, "not-exists")
+	fc := NewHistoryFileCache(notExists)
+
+	_, err = fc.Walk("uuid", "dbName", func(root *schema.ImmutableState) interface{} {
 		return nil
 	})
-	require.Error(t, err)
+	require.NoError(t, err)
 }
 
 func TestHistoryFileCache_getStatesFileInfosError(t *testing.T) {
-	dir := "./testNotExists"
-	err := os.MkdirAll(dir, 0000)
+	dir, err := ioutil.TempDir("", "history-cache")
+	if err != nil {
+		log.Fatal(err)
+	}
 	defer os.RemoveAll(dir)
-	fc := &historyFileCache{dir: dir}
+
+	notExists := filepath.Join(dir, "does-not-exist")
+	fc := &historyFileCache{dir: notExists}
 	_, err = fc.getStatesFileInfos(dir)
-	require.Error(t, err)
+	require.NoError(t, err)
 }
 
 func TestHistoryFileCache_unmarshalRootErr(t *testing.T) {


### PR DESCRIPTION
The test was checking for failure if the directory does not exist, but the code `mkdirs` the directories it needs.

The test passed on Linux by accident: the non-existing directory used in the test was `/not-exists` and failed not because of non-existence but because of permissions.

There is a chance the test was correct, and actually testing just fishing coverage points for the rare case of permissions. If that is the case, the test did not work on Windows, because admin can anyway create the directory.

This PR adapts the test to create a non-existing directory with write-access (Tmpdir), and expecting no errors, as it should be auto-created.

_This is a series of fixes to make the client tests pass on Windows._

