### PR TITLE
fix: tlsConfig semantics changed when no TLS configured

### DIFF
--- a/cmd/immudb/command/tls_config.go
+++ b/cmd/immudb/command/tls_config.go
@@ -25,7 +25,7 @@ import (
 )
 
 func setUpTLS(pkey, cert, ca string, mtls bool) (*tls.Config, error) {
-	c := &tls.Config{}
+	var c *tls.Config
 
 	if cert != "" && pkey != "" {
 		certs, err := tls.LoadX509KeyPair(cert, pkey)

--- a/pkg/pgsql/server/ssl_handshake.go
+++ b/pkg/pgsql/server/ssl_handshake.go
@@ -21,7 +21,7 @@ import (
 )
 
 func (s *session) handshake() error {
-	if len(s.tlsConfig.Certificates) == 0 {
+	if s.tlsConfig == nil || len(s.tlsConfig.Certificates) == 0 {
 		return ErrSSLNotSupported
 	}
 	tlsConn := tls.Server(s.mr.Connection(), s.tlsConfig)

--- a/pkg/server/webserver.go
+++ b/pkg/server/webserver.go
@@ -30,7 +30,7 @@ func StartWebServer(addr string, tlsConfig *tls.Config, s schema.ImmuServiceServ
 
 	go func() {
 		var err error
-		if tlsConfig != nil {
+		if tlsConfig != nil && len(tlsConfig.Certificates) > 0 {
 			l.Infof("Web API server enabled on %s/api (https)", addr)
 			err = httpServer.ListenAndServeTLS("", "")
 		} else {

--- a/pkg/server/webserver_test.go
+++ b/pkg/server/webserver_test.go
@@ -18,45 +18,77 @@ package server
 
 import (
 	"crypto/tls"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"net/http"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
+	"time"
 )
 
 func TestStartWebServerHTTP(t *testing.T) {
 	options := DefaultOptions()
 	server := DefaultServer().WithOptions(options).(*ImmuServer)
 
-	webServer, err := StartWebServer(
-		"0.0.0.0:8080",
-		nil,
-		server,
-		&mockLogger{})
-	defer webServer.Close()
-
-	assert.IsType(t, &http.Server{}, webServer)
-	assert.Nil(t, webServer.TLSConfig)
-	assert.Nil(t, err)
-}
-
-func TestStartWebServerHTTPS(t *testing.T) {
-	options := DefaultOptions()
 	tlsConfig := &tls.Config{
 		Certificates: []tls.Certificate{},
-		ClientAuth: tls.VerifyClientCertIfGiven,
+		ClientAuth:   tls.VerifyClientCertIfGiven,
 	}
-
-	server := DefaultServer().WithOptions(options).(*ImmuServer)
 
 	webServer, err := StartWebServer(
 		"0.0.0.0:8080",
 		tlsConfig,
 		server,
 		&mockLogger{})
+	require.NoError(t, err)
 	defer webServer.Close()
 
 	assert.IsType(t, &http.Server{}, webServer)
-	assert.NotNil(t, webServer.TLSConfig)
-	assert.Nil(t, err)
+
+	client := &http.Client{}
+	assert.Eventually(t, func() bool {
+		_, err = client.Get("http://0.0.0.0:8080")
+		return err == nil
+	}, 1*time.Second, 30*time.Millisecond)
+}
+
+func TestStartWebServerHTTPS(t *testing.T) {
+	options := DefaultOptions()
+	server := DefaultServer().WithOptions(options).(*ImmuServer)
+	certPem := []byte(`-----BEGIN CERTIFICATE-----
+MIIBhTCCASugAwIBAgIQIRi6zePL6mKjOipn+dNuaTAKBggqhkjOPQQDAjASMRAw
+DgYDVQQKEwdBY21lIENvMB4XDTE3MTAyMDE5NDMwNloXDTE4MTAyMDE5NDMwNlow
+EjEQMA4GA1UEChMHQWNtZSBDbzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABD0d
+7VNhbWvZLWPuj/RtHFjvtJBEwOkhbN/BnnE8rnZR8+sbwnc/KhCk3FhnpHZnQz7B
+5aETbbIgmuvewdjvSBSjYzBhMA4GA1UdDwEB/wQEAwICpDATBgNVHSUEDDAKBggr
+BgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MCkGA1UdEQQiMCCCDmxvY2FsaG9zdDo1
+NDUzgg4xMjcuMC4wLjE6NTQ1MzAKBggqhkjOPQQDAgNIADBFAiEA2zpJEPQyz6/l
+Wf86aX6PepsntZv2GYlA5UpabfT2EZICICpJ5h/iI+i341gBmLiAFQOyTDT+/wQc
+6MF9+Yw1Yy0t
+-----END CERTIFICATE-----`)
+	keyPem := []byte(`-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIIrYSSNQFaA2Hwf1duRSxKtLYX5CB04fSeQ6tF1aY/PuoAoGCCqGSM49
+AwEHoUQDQgAEPR3tU2Fta9ktY+6P9G0cWO+0kETA6SFs38GecTyudlHz6xvCdz8q
+EKTcWGekdmdDPsHloRNtsiCa697B2O9IFA==
+-----END EC PRIVATE KEY-----`)
+
+	cert, err := tls.X509KeyPair(certPem, keyPem)
+	require.NoError(t, err)
+	tlsConfig := &tls.Config{Certificates: []tls.Certificate{cert}}
+
+	webServer, err := StartWebServer(
+		"0.0.0.0:8080",
+		tlsConfig,
+		server,
+		&mockLogger{})
+	require.NoError(t, err)
+	defer webServer.Close()
+
+	assert.IsType(t, &http.Server{}, webServer)
+
+	tr := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
+	client := &http.Client{Transport: tr}
+	assert.Eventually(t, func() bool {
+		_, err = client.Get("https://0.0.0.0:8080")
+		return err == nil
+	}, 1*time.Second, 30*time.Millisecond)
 }


### PR DESCRIPTION
Before pgsql branch merge, tlsConfig was nil if no TLS configured. This is not longer the case.

We don't make assumptions about the resulting tlsConfig object anymore. We *do* only start a TLS server if tlsConfig is non-nil and has certificates, but we only test the resulting server can accept the right type of connection.