### PR TITLE
feat: display version at startup

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -42,6 +42,7 @@ import (
 	"github.com/codenotary/immudb/pkg/signer"
 
 	"github.com/codenotary/immudb/cmd/helper"
+	"github.com/codenotary/immudb/cmd/version"
 	"github.com/codenotary/immudb/pkg/api/schema"
 	"github.com/codenotary/immudb/pkg/auth"
 	"github.com/golang/protobuf/ptypes/empty"
@@ -69,11 +70,11 @@ var immudbTextLogo = " _                               _ _     \n" +
 
 // Initialize initializes dependencies, set up multi database capabilities and stats
 func (s *ImmuServer) Initialize() error {
-	_, err := fmt.Fprintf(os.Stdout, "%s\n%s\n\n", immudbTextLogo, s.Options)
+	_, err := fmt.Fprintf(os.Stdout, "%s\n%s\n%s\n\n", immudbTextLogo, version.VersionStr(), s.Options)
 	logErr(s.Logger, "Error printing immudb config: %v", err)
 
 	if s.Options.Logfile != "" {
-		s.Logger.Infof("\n%s\n%s\n\n", immudbTextLogo, s.Options)
+		s.Logger.Infof("\n%s\n%s\n%s\n\n", immudbTextLogo, version.VersionStr(), s.Options)
 	}
 
 	adminPassword, err := auth.DecodeBase64Password(s.Options.AdminPassword)


### PR DESCRIPTION
This PR is a request to add version when starting up the server. It is the less intrusive way that I thought of, without moving parts of cmd/version around.

```
 _                               _ _
(_)                             | | |
 _ _ __ ___  _ __ ___  _   _  __| | |__
| | '_ ` _ \| '_ ` _ \| | | |/ _` | '_ \
| | | | | | | | | | | | |_| | (_| | |_) |
|_|_| |_| |_|_| |_| |_|\__,_|\__,_|_.__/

immudb 0.9.2
Commit  : 36738cd16d8d020c99ef121e57791fc401c4e65e
Built by: xxxxxxxx@codenotary.com
Built at: Wed, 19 May 2021 18:50:51 CEST
================ Config ================
Data dir         : /dev/shm/immu4
Address          : 0.0.0.0:3322
Metrics address  : 0.0.0.0:9497/metrics
Config file      : configs/immudb.toml
Max recv msg size: 33554432
Auth enabled     : true
Dev mode         : false
Default database : defaultdb
Maintenance mode : false
...
```
