### PR TITLE
fix: go mod tidy/vendor with statik module

### DIFF
--- a/webconsole/statik/dummy.go
+++ b/webconsole/statik/dummy.go
@@ -1,0 +1,2 @@
+// this file is here so that go vendor and go mod tidy work
+package statik


### PR DESCRIPTION
The way statik works is by generating a module. This module is not present until `go generate` is run.

This is not a problem as the files are guarded by build tags, but `go mod vendor` and `go mod tidy` run with all build tags enabled, which result in a module referenced but not present.

This is a workaround. We should eventually use `go embed` present in Go 1.16.