### PR TITLE
fix: go mod tidy/vendor with statik module

### DIFF
--- a/webconsole/.gitignore
+++ b/webconsole/.gitignore
@@ -1,0 +1,2 @@
+dist
+statik.go

--- a/webconsole/webconsole.go
+++ b/webconsole/webconsole.go
@@ -1,13 +1,11 @@
 // +build webconsole
-//go:generate go run github.com/rakyll/statik -f -src=./dist
+//go:generate go run github.com/rakyll/statik -f -src=./dist -p=webconsole -dest=../ -tags=webconsole
 
 package webconsole
 
 import (
 	"github.com/codenotary/immudb/pkg/logger"
 	"net/http"
-	// embedded static files
-	_ "github.com/codenotary/immudb/webconsole/statik"
 	"github.com/rakyll/statik/fs"
 )
 


### PR DESCRIPTION
The way statik works is by generating a module. This module is not present until go generate is run.

This is not a problem as the files are guarded by build tags, but go mod vendor and go mod tidy run with all build tags enabled, which result in a module referenced but not present.

This is an alternative fix to https://github.com/codenotary/immudb/pull/794 suggested by @jeroiraz 
Instead of a dummy `statik` module, we generate the statik data instead of the `webconsole` module itself, which is always present.

In addition to the suggestion, I have also added a flag to *statik* to guard the file with the `webconsole` build tag and added `dist` and `statik.go` to `.gitignore`.

This is a workaround. We should eventually use go embed present in Go 1.16.