### PR TITLE
move server UUID file to data dir

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -132,8 +132,7 @@ func (s *ImmuServer) Initialize() error {
 	}
 
 	systemDbRootDir := s.OS.Join(dataDir, s.Options.GetDefaultDbName())
-
-	if s.UUID, err = getOrSetUUID(systemDbRootDir); err != nil {
+	if s.UUID, err = getOrSetUUID(dataDir, systemDbRootDir); err != nil {
 		return logErr(s.Logger, "Unable to get or set uuid: %v", err)
 	}
 


### PR DESCRIPTION
the file used to reside in default DB dir. Because the file contains cross-database information, it should not be in default db dir.

Fixes #799