### PR TITLE
chore(pkg/stream): fix namings on stream api objects

### DIFF
--- a/pkg/stream/execall_receiver.go
+++ b/pkg/stream/execall_receiver.go
@@ -25,22 +25,22 @@ import (
 type execAllStreamReceiver struct {
 	s                MsgReceiver
 	kvStreamReceiver KvStreamReceiver
-	StreamChunkSize  int
+	BufferSize       int
 }
 
 // NewExecAllStreamReceiver returns a new execAllStreamReceiver
-func NewExecAllStreamReceiver(s MsgReceiver, chunkSize int) ExecAllStreamReceiver {
+func NewExecAllStreamReceiver(s MsgReceiver, bs int) ExecAllStreamReceiver {
 	return &execAllStreamReceiver{
 		s:                s,
-		kvStreamReceiver: NewKvStreamReceiver(s, chunkSize),
-		StreamChunkSize:  chunkSize,
+		kvStreamReceiver: NewKvStreamReceiver(s, bs),
+		BufferSize:       bs,
 	}
 }
 
 // Next returns the following exec all operation found on the wire. If no more operations are presents on stream it returns io.EOF
 func (eas *execAllStreamReceiver) Next() (IsOp_Operation, error) {
 	for {
-		t, err := ReadValue(eas.s, eas.StreamChunkSize)
+		t, err := ReadValue(eas.s, eas.BufferSize)
 		if err != nil {
 			return nil, err
 		}
@@ -63,7 +63,7 @@ func (eas *execAllStreamReceiver) Next() (IsOp_Operation, error) {
 			}, nil
 		case TOp_ZAdd:
 			zr := &schema.ZAddRequest{}
-			zaddm, err := ReadValue(eas.s, eas.StreamChunkSize)
+			zaddm, err := ReadValue(eas.s, eas.BufferSize)
 			err = proto.Unmarshal(zaddm, zr)
 			if err != nil {
 				return nil, ErrUnableToReassembleExecAllMessage

--- a/pkg/stream/execall_sender.go
+++ b/pkg/stream/execall_sender.go
@@ -34,7 +34,7 @@ func NewExecAllStreamSender(s MsgSender) ExecAllStreamSender {
 	}
 }
 
-// Send send an ExecAllRequest on straem
+// Send send an ExecAllRequest on stream
 func (st *execAllStreamSender) Send(req *ExecAllRequest) error {
 	for _, op := range req.Operations {
 		switch x := op.Operation.(type) {

--- a/pkg/stream/kvparser.go
+++ b/pkg/stream/kvparser.go
@@ -7,11 +7,11 @@ import (
 
 // ReadValue returns the complete value from a message
 // If no more data is present on the reader nil and io.EOF are returned
-func ReadValue(vr io.Reader, chunkSize int) (value []byte, err error) {
+func ReadValue(vr io.Reader, bufferSize int) (value []byte, err error) {
 	b := bytes.NewBuffer([]byte{})
 	vl := 0
 	eof := false
-	chunk := make([]byte, chunkSize)
+	chunk := make([]byte, bufferSize)
 	for {
 		l, err := vr.Read(chunk)
 		if err != nil && err != io.EOF {

--- a/pkg/stream/kvreceiver.go
+++ b/pkg/stream/kvreceiver.go
@@ -21,21 +21,21 @@ import (
 )
 
 type kvStreamReceiver struct {
-	s               MsgReceiver
-	StreamChunkSize int
+	s          MsgReceiver
+	BufferSize int
 }
 
 // NewKvStreamReceiver returns a new kvStreamReceiver
-func NewKvStreamReceiver(s MsgReceiver, chunkSize int) KvStreamReceiver {
+func NewKvStreamReceiver(s MsgReceiver, bs int) KvStreamReceiver {
 	return &kvStreamReceiver{
-		s:               s,
-		StreamChunkSize: chunkSize,
+		s:          s,
+		BufferSize: bs,
 	}
 }
 
 // Next returns the following key and value reader pair found on stream. If no more key values are presents on stream it returns io.EOF
 func (kvr *kvStreamReceiver) Next() ([]byte, io.Reader, error) {
-	key, err := ReadValue(kvr.s, kvr.StreamChunkSize)
+	key, err := ReadValue(kvr.s, kvr.BufferSize)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/stream/sender.go
+++ b/pkg/stream/sender.go
@@ -29,18 +29,18 @@ type MsgSender interface {
 }
 
 type msgSender struct {
-	stream          ImmuServiceSender_Stream
-	b               *bytes.Buffer
-	StreamChunkSize int
+	stream     ImmuServiceSender_Stream
+	b          *bytes.Buffer
+	BufferSize int
 }
 
 // NewMsgSender returns a NewMsgSender. It can be used on server side or client side to send a message on a stream.
-func NewMsgSender(s ImmuServiceSender_Stream, chunkSize int) *msgSender {
+func NewMsgSender(s ImmuServiceSender_Stream, bs int) *msgSender {
 	buffer := new(bytes.Buffer)
 	return &msgSender{
-		stream:          s,
-		b:               buffer,
-		StreamChunkSize: chunkSize,
+		stream:     s,
+		b:          buffer,
+		BufferSize: bs,
 	}
 }
 
@@ -61,7 +61,7 @@ func (st *msgSender) Send(reader io.Reader, payloadSize int) (err error) {
 		}
 		// read data from reader and append it to the buffer
 		//  todo @Michele reader need to be dynamic, not of chunk size
-		data := make([]byte, st.StreamChunkSize)
+		data := make([]byte, st.BufferSize)
 		r, err := reader.Read(data)
 		if err != nil {
 			if err != io.EOF {
@@ -90,8 +90,8 @@ func (st *msgSender) Send(reader io.Reader, payloadSize int) (err error) {
 			}
 		}
 		// enough data to send a chunk
-		if st.b.Len() > st.StreamChunkSize {
-			chunk = make([]byte, st.StreamChunkSize)
+		if st.b.Len() > st.BufferSize {
+			chunk = make([]byte, st.BufferSize)
 			_, err = st.b.Read(chunk)
 			if err != nil {
 				return nil

--- a/pkg/stream/ventryreceiver.go
+++ b/pkg/stream/ventryreceiver.go
@@ -21,22 +21,22 @@ import (
 )
 
 type vEntryStreamReceiver struct {
-	s               MsgReceiver
-	StreamChunkSize int
+	s          MsgReceiver
+	BufferSize int
 }
 
 // NewVEntryStreamReceiver ...
-func NewVEntryStreamReceiver(s MsgReceiver, chunkSize int) VEntryStreamReceiver {
+func NewVEntryStreamReceiver(s MsgReceiver, bs int) VEntryStreamReceiver {
 	return &vEntryStreamReceiver{
-		s:               s,
-		StreamChunkSize: chunkSize,
+		s:          s,
+		BufferSize: bs,
 	}
 }
 
 func (vesr *vEntryStreamReceiver) Next() ([]byte, []byte, []byte, io.Reader, error) {
 	ris := make([][]byte, 3)
 	for i, _ := range ris {
-		r, err := ReadValue(vesr.s, vesr.StreamChunkSize)
+		r, err := ReadValue(vesr.s, vesr.BufferSize)
 		if err != nil {
 			return nil, nil, nil, nil, err
 		}

--- a/pkg/stream/zreceiver.go
+++ b/pkg/stream/zreceiver.go
@@ -21,22 +21,22 @@ import (
 )
 
 type zStreamReceiver struct {
-	s               MsgReceiver
-	StreamChunkSize int
+	s          MsgReceiver
+	BufferSize int
 }
 
 // NewZStreamReceiver ...
-func NewZStreamReceiver(s MsgReceiver, chunkSize int) *zStreamReceiver {
+func NewZStreamReceiver(s MsgReceiver, bs int) *zStreamReceiver {
 	return &zStreamReceiver{
-		s:               s,
-		StreamChunkSize: chunkSize,
+		s:          s,
+		BufferSize: bs,
 	}
 }
 
 func (zr *zStreamReceiver) Next() ([]byte, []byte, float64, uint64, io.Reader, error) {
 	ris := make([][]byte, 4)
 	for i, _ := range ris {
-		r, err := ReadValue(zr.s, zr.StreamChunkSize)
+		r, err := ReadValue(zr.s, zr.BufferSize)
 		if err != nil {
 			return nil, nil, 0, 0, nil, err
 		}


### PR DESCRIPTION
Fix naming on stream api object in order to clarify the purpose of message sender and receiver parameters