### PR TITLE
Changed EOF handling for immuclient

### DIFF
--- a/cmd/immuclient/cli/cli.go
+++ b/cmd/immuclient/cli/cli.go
@@ -111,7 +111,7 @@ func (cli *cli) Run() {
 				continue
 			}
 		} else if err == io.EOF {
-			continue
+			break
 		}
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)


### PR DESCRIPTION
This PR just makes it so if you hit CTRL+D on immuclient it will exit instead of ignoring it, see issue [819](https://github.com/codenotary/immudb/issues/819)