### PR TITLE
fix(cmd/immuclient): remove warnings on sql commands in interactive mode

### DIFF
--- a/cmd/immuclient/cli/register.go
+++ b/cmd/immuclient/cli/register.go
@@ -59,8 +59,8 @@ func (cli *cli) initCommands() {
 	cli.Register(&command{"version", "Print version", cli.version, nil, false})
 
 	// SQL
-	cli.Register(&command{"exec", "Executes sql statement", cli.sqlExec, []string{"statement"}, false})
-	cli.Register(&command{"query", "Query sql statement", cli.sqlQuery, []string{"statement"}, false})
+	cli.Register(&command{"exec", "Executes sql statement", cli.sqlExec, []string{"statement"}, true})
+	cli.Register(&command{"query", "Query sql statement", cli.sqlQuery, []string{"statement"}, true})
 	cli.Register(&command{"describe", "Describe table", cli.describeTable, []string{"table"}, false})
 	cli.Register(&command{"tables", "List tables", cli.listTables, nil, false})
 }


### PR DESCRIPTION
This PR changes the `exec` and `query` commands to variable ones.
That way those commands can accept arbitrary number of arguments without issuing a warning in the interactive mode.

Closes  #803