### PR TITLE
Apply synced settings to indexing data

### DIFF
--- a/embedded/store/immustore.go
+++ b/embedded/store/immustore.go
@@ -408,7 +408,7 @@ func OpenWith(path string, vLogs []appendable.Appendable, txLog, cLog appendable
 		WithFileMode(opts.FileMode).
 		WithLog(opts.log).
 		WithFileSize(fileSize).
-		WithSynced(opts.Synced). // built from derived data, but temporarily to reduce chances of data inconsistencies
+		WithSynced(opts.Synced). // built from derived data, but temporarily modified to reduce chances of data inconsistencies until a better solution is implemented
 		WithCacheSize(opts.IndexOpts.CacheSize).
 		WithFlushThld(opts.IndexOpts.FlushThld).
 		WithMaxActiveSnapshots(opts.IndexOpts.MaxActiveSnapshots).

--- a/embedded/store/immustore.go
+++ b/embedded/store/immustore.go
@@ -408,7 +408,7 @@ func OpenWith(path string, vLogs []appendable.Appendable, txLog, cLog appendable
 		WithFileMode(opts.FileMode).
 		WithLog(opts.log).
 		WithFileSize(fileSize).
-		WithSynced(false). // index is built from derived data
+		WithSynced(opts.Synced). // built from derived data, but temporarily to reduce chances of data inconsistencies
 		WithCacheSize(opts.IndexOpts.CacheSize).
 		WithFlushThld(opts.IndexOpts.FlushThld).
 		WithMaxActiveSnapshots(opts.IndexOpts.MaxActiveSnapshots).


### PR DESCRIPTION
This PR applies global `synced` configuration to indexing data structure in order to prevent inconsistencies during unexpected/forced terminations.

While some performance degradation may be expected, it shouldn't be much noticeable to final applications given indexing data is eventually flushed to disk. Furthermore, depending on the use case, eventual indexing feature can be used per transaction basis by setting attribute `NoWait=true`.

This approach may be useful until a more elaborated solution is implemented i.e. #823

Signed-off-by: Jeronimo Irazabal <jeronimo.irazabal@gmail.com>