### PR TITLE
test(embedded/tbtree): compare against latest key update

### DIFF
--- a/embedded/tbtree/tbtree_test.go
+++ b/embedded/tbtree/tbtree_test.go
@@ -328,7 +328,7 @@ func randomInsertions(t *testing.T, tbtree *TBtree, kCount int, override bool) {
 			require.Equal(t, uint64(1), hc1)
 		}
 
-		tss, err := snapshot.History(k, 0, false, 1)
+		tss, err := snapshot.History(k, 0, true, 1)
 		require.NoError(t, err)
 		require.Equal(t, ts, tss[0])
 


### PR DESCRIPTION
This PR contains a small fix on a random key insertion unit testing.

The issue was that in case of a key update, the timestamp was compared with the first timestamp instead of the latest one.
 
Signed-off-by: Jeronimo Irazabal <jeronimo.irazabal@gmail.com>