### PR TITLE
Auto-registration when database is not present in the catalog

### DIFF
--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -139,7 +139,9 @@ func OpenDb(op *DbOptions, catalogDB DB, log logger.Logger) (DB, error) {
 		}
 		log.Infof("Database '%s' successfully registered", dbDir)
 
-	} else if err != nil {
+		err = dbi.sqlEngine.UseDatabase(dbi.options.dbName)
+	}
+	if err != nil {
 		return nil, logErr(dbi.Logger, "Unable to open store: %s", err)
 	}
 
@@ -193,9 +195,6 @@ func NewDb(op *DbOptions, catalogDB DB, log logger.Logger) (DB, error) {
 	}
 
 	err = dbi.sqlEngine.UseDatabase(dbi.options.dbName)
-	if err == sql.ErrDatabaseDoesNotExist {
-		return nil, logErr(dbi.Logger, "Unable to open store: %s", err)
-	}
 	if err != nil {
 		return nil, logErr(dbi.Logger, "Unable to open store: %s", err)
 	}


### PR DESCRIPTION
Database registration may be needed when opening a database created with an older version of immudb (older than v1.0.0)

This PR handles the above described situation by registering the database in the catalog as part of the database opening procedure.

Signed-off-by: Jeronimo Irazabal <jeronimo.irazabal@gmail.com>