### PR TITLE
fix: consistent reads of recently written data

### DIFF
--- a/embedded/appendable/multiapp/multi_app.go
+++ b/embedded/appendable/multiapp/multi_app.go
@@ -367,6 +367,10 @@ func (mf *MultiFileAppendable) appendableFor(off int64) (*singleapp.AppendableFi
 
 	appID := appendableID(off, mf.fileSize)
 
+	if appID == mf.currAppID {
+		return mf.currApp, nil
+	}
+
 	app, err := mf.appendables.Get(appID)
 
 	if err != nil {

--- a/embedded/appendable/multiapp/multi_app_test.go
+++ b/embedded/appendable/multiapp/multi_app_test.go
@@ -286,3 +286,20 @@ func TestMultiAppCompression(t *testing.T) {
 	err = a.Close()
 	require.NoError(t, err)
 }
+
+func TestMultiAppAppendableForCurrentChunk(t *testing.T) {
+	a, err := Open("testdata", DefaultOptions().WithFileSize(10))
+	defer os.RemoveAll("testdata")
+	require.NoError(t, err)
+
+	testData := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
+
+	off, n, err := a.Append(testData)
+	require.NoError(t, err)
+	require.EqualValues(t, 0, off)
+	require.EqualValues(t, n, 12)
+
+	app, err := a.appendableFor(11)
+	require.NoError(t, err)
+	require.Equal(t, a.currApp, app)
+}


### PR DESCRIPTION
Ensure to use the current appender if the `ReadAt` function reads the data stored inside that appender.