### PR TITLE
Sql positional parameters

### DIFF
--- a/embedded/sql/engine_test.go
+++ b/embedded/sql/engine_test.go
@@ -1622,8 +1622,14 @@ func TestInferParameters(t *testing.T) {
 	params, err = engine.InferParameters("SELECT * FROM mytable WHERE id > ? AND (NOT ? OR active)")
 	require.NoError(t, err)
 	require.Len(t, params, 2)
-	require.Equal(t, IntegerType, params["param0"])
+	require.Equal(t, IntegerType, params["param1"])
+	require.Equal(t, BooleanType, params["param2"])
+
+	params, err = engine.InferParameters("SELECT * FROM mytable WHERE id > $2 AND (NOT $1 OR active)")
+	require.NoError(t, err)
+	require.Len(t, params, 2)
 	require.Equal(t, BooleanType, params["param1"])
+	require.Equal(t, IntegerType, params["param2"])
 
 	params, err = engine.InferParameters("SELECT COUNT() FROM mytable GROUP BY active HAVING @param1 = COUNT()")
 	require.NoError(t, err)

--- a/embedded/sql/parser_test.go
+++ b/embedded/sql/parser_test.go
@@ -310,9 +310,9 @@ func TestInsertIntoStmt(t *testing.T) {
 							&SysFn{fn: "now"},
 							&Varchar{val: "untitled row"},
 							&Bool{val: true},
-							&Param{id: "param0", positional: true},
+							&Param{id: "param1", pos: 1},
 							&Blob{val: decodedBLOB},
-							&Param{id: "param1", positional: true},
+							&Param{id: "param2", pos: 2},
 						},
 						},
 					},
@@ -321,12 +321,59 @@ func TestInsertIntoStmt(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			input: "UPSERT INTO table1(id, time, title, active, compressed, payload, note) VALUES (2, now(), $1, TRUE, $2, x'AED0393F', $1)",
+			expectedOutput: []SQLStmt{
+				&UpsertIntoStmt{
+					tableRef: &TableRef{table: "table1"},
+					cols:     []string{"id", "time", "title", "active", "compressed", "payload", "note"},
+					rows: []*RowSpec{
+						{Values: []ValueExp{
+							&Number{val: 2},
+							&SysFn{fn: "now"},
+							&Param{id: "param1", pos: 1},
+							&Bool{val: true},
+							&Param{id: "param2", pos: 2},
+							&Blob{val: decodedBLOB},
+							&Param{id: "param1", pos: 1},
+						},
+						},
+					},
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			input:          "UPSERT INTO table1(id, title) VALUES ($0, $1)",
+			expectedOutput: nil,
+			expectedError:  errors.New("syntax error: unexpected ERROR"),
+		},
+		{
 			input:          "UPSERT INTO table1(id, title) VALUES (?, @title)",
 			expectedOutput: nil,
 			expectedError:  errors.New("syntax error: unexpected ERROR"),
 		},
 		{
-			input:          "UPSERT INTO table1(id, title) VALUES (@title, ?)",
+			input:          "UPSERT INTO table1(id, title) VALUES (@id, ?)",
+			expectedOutput: nil,
+			expectedError:  errors.New("syntax error: unexpected ERROR"),
+		},
+		{
+			input:          "UPSERT INTO table1(id, title) VALUES (@id, $1)",
+			expectedOutput: nil,
+			expectedError:  errors.New("syntax error: unexpected ERROR"),
+		},
+		{
+			input:          "UPSERT INTO table1(id, title) VALUES ($1, @title)",
+			expectedOutput: nil,
+			expectedError:  errors.New("syntax error: unexpected ERROR"),
+		},
+		{
+			input:          "UPSERT INTO table1(id, title) VALUES ($1, ?)",
+			expectedOutput: nil,
+			expectedError:  errors.New("syntax error: unexpected ERROR"),
+		},
+		{
+			input:          "UPSERT INTO table1(id, title) VALUES (?, $1)",
 			expectedOutput: nil,
 			expectedError:  errors.New("syntax error: unexpected ERROR"),
 		},

--- a/embedded/sql/parser_test.go
+++ b/embedded/sql/parser_test.go
@@ -378,6 +378,11 @@ func TestInsertIntoStmt(t *testing.T) {
 			expectedError:  errors.New("syntax error: unexpected ERROR"),
 		},
 		{
+			input:          "UPSERT INTO table1(id, title) VALUES ($1, $title)",
+			expectedOutput: nil,
+			expectedError:  errors.New("syntax error: unexpected ERROR"),
+		},
+		{
 			input: "UPSERT INTO table1(id, active) VALUES (1, false), (2, true), (3, true)",
 			expectedOutput: []SQLStmt{
 				&UpsertIntoStmt{

--- a/embedded/sql/sql_grammar.y
+++ b/embedded/sql/sql_grammar.y
@@ -58,7 +58,7 @@ func setResult(l yyLexer, stmts []SQLStmt) {
     opt_ord Comparison
     logicOp LogicOperator
     cmpOp CmpOperator
-    uparam int
+    pparam int
 }
 
 %token CREATE USE DATABASE SNAPSHOT SINCE UP TO TABLE INDEX ON ALTER ADD COLUMN PRIMARY KEY
@@ -67,7 +67,7 @@ func setResult(l yyLexer, stmts []SQLStmt) {
 %token SELECT DISTINCT FROM BEFORE TX JOIN HAVING WHERE GROUP BY LIMIT ORDER ASC DESC AS
 %token NOT LIKE IF EXISTS
 %token NULL NPARAM
-%token <uparam> UPARAM
+%token <pparam> PPARAM
 %token <joinType> JOINTYPE
 %token <logicOp> LOP
 %token <cmpOp> CMPOP
@@ -315,9 +315,9 @@ val:
         $$ = &Param{id: $2}
     }
 |
-    UPARAM
+    PPARAM
     {
-        $$ = &Param{id: fmt.Sprintf("param%d", $1), positional: true}
+        $$ = &Param{id: fmt.Sprintf("param%d", $1), pos: $1}
     }
 |
     NULL

--- a/embedded/sql/sql_parser.go
+++ b/embedded/sql/sql_parser.go
@@ -44,7 +44,7 @@ type yySymType struct {
 	opt_ord  Comparison
 	logicOp  LogicOperator
 	cmpOp    CmpOperator
-	uparam   int
+	pparam   int
 }
 
 const CREATE = 57346
@@ -90,7 +90,7 @@ const IF = 57385
 const EXISTS = 57386
 const NULL = 57387
 const NPARAM = 57388
-const UPARAM = 57389
+const PPARAM = 57389
 const JOINTYPE = 57390
 const LOP = 57391
 const CMPOP = 57392
@@ -151,7 +151,7 @@ var yyToknames = [...]string{
 	"EXISTS",
 	"NULL",
 	"NPARAM",
-	"UPARAM",
+	"PPARAM",
 	"JOINTYPE",
 	"LOP",
 	"CMPOP",
@@ -868,7 +868,7 @@ yydefault:
 	case 40:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		{
-			yyVAL.value = &Param{id: fmt.Sprintf("param%d", yyDollar[1].uparam), positional: true}
+			yyVAL.value = &Param{id: fmt.Sprintf("param%d", yyDollar[1].pparam), pos: yyDollar[1].pparam}
 		}
 	case 41:
 		yyDollar = yyS[yypt-1 : yypt+1]

--- a/embedded/sql/stmt.go
+++ b/embedded/sql/stmt.go
@@ -872,8 +872,8 @@ func (v *SysFn) reduce(catalog *Catalog, row *Row, implicitDB, implicitTable str
 }
 
 type Param struct {
-	id         string
-	positional bool
+	id  string
+	pos int
 }
 
 func (v *Param) inferType(cols map[string]*ColDescriptor, params map[string]SQLValueType, implicitDB, implicitTable string) (SQLValueType, error) {


### PR DESCRIPTION
This PR introduces initial(*) support for positional parameters in sql statements

e.g. `SELECT * FROM mytable WHERE id > $1 OR ($2 AND active)`

```
params, err = engine.InferParameters("SELECT * FROM mytable WHERE id > $1 OR ($2 AND active)")
require.NoError(t, err)
require.Len(t, params, 2)
require.Equal(t, IntegerType, params["param1"])
require.Equal(t, BooleanType, params["param2"])
```

Note: Validation of using either named (positional or non-positional) or unnamed parameters is currently done while parsing.
Although the underlying datatype carries such information (pos attribute) in case semantic validations are additionally added.

(*): semantic validations regarding parameters are not included e.g. `SELECT * from mytable WHERE id = $2` will be valid besides parameter `$1` is not present. However, this shouldn't introduce any inconsistency during query resolution.