### PR TITLE
Fix index compaction data syncing

### DIFF
--- a/embedded/ahtree/ahtree.go
+++ b/embedded/ahtree/ahtree.go
@@ -81,12 +81,12 @@ func Open(path string, opts *Options) (*AHtree, error) {
 
 	finfo, err := os.Stat(path)
 	if err != nil {
-		if os.IsNotExist(err) {
-			err = os.Mkdir(path, opts.fileMode)
-			if err != nil {
-				return nil, err
-			}
-		} else {
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+
+		err := os.Mkdir(path, opts.fileMode)
+		if err != nil {
 			return nil, err
 		}
 	} else if !finfo.IsDir() {

--- a/embedded/store/immustore.go
+++ b/embedded/store/immustore.go
@@ -180,12 +180,12 @@ func Open(path string, opts *Options) (*ImmuStore, error) {
 
 	finfo, err := os.Stat(path)
 	if err != nil {
-		if os.IsNotExist(err) {
-			err = os.Mkdir(path, opts.FileMode)
-			if err != nil {
-				return nil, err
-			}
-		} else {
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+
+		err := os.Mkdir(path, opts.FileMode)
+		if err != nil {
 			return nil, err
 		}
 	} else if !finfo.IsDir() {

--- a/embedded/store/immustore_test.go
+++ b/embedded/store/immustore_test.go
@@ -735,8 +735,10 @@ func TestImmudbStoreHistoricalValues(t *testing.T) {
 
 func TestImmudbStoreCompactionFailureForRemoteStorage(t *testing.T) {
 	opts := DefaultOptions().WithCompactionDisabled(true)
-	immuStore, err := Open("data_historical", opts)
+	immuStore, err := Open("data_compaction_remote_storage", opts)
 	require.NoError(t, err)
+
+	defer os.RemoveAll("data_compaction_remote_storage")
 
 	err = immuStore.CompactIndex()
 	require.Equal(t, ErrCompactionUnsupported, err)

--- a/embedded/tbtree/tbtree_test.go
+++ b/embedded/tbtree/tbtree_test.go
@@ -123,6 +123,9 @@ func TestEdgeCases(t *testing.T) {
 	err = tree.Close()
 	require.Equal(t, ErrSnapshotsNotClosed, err)
 
+	_, err = tree.CompactIndex()
+	require.Equal(t, ErrSnapshotsNotClosed, err)
+
 	err = s1.Close()
 	require.NoError(t, err)
 
@@ -436,6 +439,9 @@ func TestTBTreeInsertionInAscendingOrder(t *testing.T) {
 	require.Equal(t, err, ErrAlreadyClosed)
 
 	_, err = tbtree.Snapshot()
+	require.Equal(t, err, ErrAlreadyClosed)
+
+	_, err = tbtree.CompactIndex()
 	require.Equal(t, err, ErrAlreadyClosed)
 
 	tbtree, err = Open("test_tree_iasc", DefaultOptions().WithMaxNodeSize(256))


### PR DESCRIPTION
Index compaction was not handling data syncing as expected. IO errors might not have been detected leading to inconsistent snapshots, requiring index re-generation.