### PR TITLE
fix: bind psql port to the same IP address as grpc interface

### DIFF
--- a/pkg/pgsql/server/options.go
+++ b/pkg/pgsql/server/options.go
@@ -24,6 +24,12 @@ import (
 
 type Option func(s *srv)
 
+func Address(addr string) Option {
+	return func(args *srv) {
+		args.Address = addr
+	}
+}
+
 func Port(port int) Option {
 	return func(args *srv) {
 		args.Port = port

--- a/pkg/pgsql/server/server.go
+++ b/pkg/pgsql/server/server.go
@@ -35,6 +35,7 @@ type srv struct {
 	tlsConfig      *tls.Config
 	SessionFactory SessionFactory
 	Logger         logger.Logger
+	Address        string
 	Port           int
 	dbList         database.DatabaseList
 	sysDb          database.DB
@@ -57,6 +58,7 @@ func New(setters ...Option) *srv {
 		tlsConfig:      &tls.Config{},
 		SessionFactory: NewSessionFactory(),
 		Logger:         logger.NewSimpleLogger("sqlSrv", os.Stderr),
+		Address:        "",
 		Port:           5432,
 	}
 
@@ -69,7 +71,7 @@ func New(setters ...Option) *srv {
 
 // Initialize initialize listener. If provided port is zero os auto assign a free one.
 func (s *srv) Initialize() (err error) {
-	s.listener, err = net.Listen("tcp", fmt.Sprintf(":%d", s.Port))
+	s.listener, err = net.Listen("tcp", fmt.Sprintf("%s:%d", s.Address, s.Port))
 	if err != nil {
 		return err
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -220,7 +220,7 @@ func (s *ImmuServer) Initialize() error {
 	schema.RegisterImmuServiceServer(s.GrpcServer, s)
 	grpc_prometheus.Register(s.GrpcServer)
 
-	s.PgsqlSrv = pgsqlsrv.New(pgsqlsrv.Port(s.Options.PgsqlServerPort), pgsqlsrv.DatabaseList(s.dbList), pgsqlsrv.SysDb(s.sysDB), pgsqlsrv.TlsConfig(s.Options.TLSConfig), pgsqlsrv.Logger(s.Logger))
+	s.PgsqlSrv = pgsqlsrv.New(pgsqlsrv.Address(s.Options.Address), pgsqlsrv.Port(s.Options.PgsqlServerPort), pgsqlsrv.DatabaseList(s.dbList), pgsqlsrv.SysDb(s.sysDB), pgsqlsrv.TlsConfig(s.Options.TLSConfig), pgsqlsrv.Logger(s.Logger))
 	if s.Options.PgsqlServer {
 		if err = s.PgsqlSrv.Initialize(); err != nil {
 			return err


### PR DESCRIPTION
I've found a weird behavior of immudb, specifically the psql port.

If I ask immudb to bind to a specific IP address (i.e. `--address 127.0.0.2`)  I find only 3 out of 4 port bind are actually made to that interface:
```
$ ss -plnt|grep immudb
LISTEN 0      0          127.0.0.2:9497       0.0.0.0:*    users:(("immudb",pid=458586,fd=26))   
LISTEN 0      0          127.0.0.2:3322       0.0.0.0:*    users:(("immudb",pid=458586,fd=24))   
LISTEN 0      0          127.0.0.2:8080       0.0.0.0:*    users:(("immudb",pid=458586,fd=27))   
LISTEN 0      0                  *:5432             *:*    users:(("immudb",pid=458586,fd=25))   
```
Port 5432 is always binding to every interface.

That prevents me to (easily) launch to instance on the same machine, binding the first one on (say) `127.0.0.2` and the other on `127.0.0.3`.

This PR binds psql port on the very same address of the others ports.

