### PR TITLE
automated snapshot recovery

### DIFF
--- a/embedded/ahtree/ahtree.go
+++ b/embedded/ahtree/ahtree.go
@@ -165,7 +165,7 @@ func OpenWith(pLog, dLog, cLog appendable.Appendable, opts *Options) (*AHtree, e
 		dLog:     dLog,
 		cLog:     cLog,
 		pLogSize: 0,
-		dLogSize: int64(nodesUpto(uint64(cLogSize/cLogEntrySize)) * sha256.Size),
+		dLogSize: 0,
 		cLogSize: cLogSize,
 		pCache:   pCache,
 		dCache:   dCache,
@@ -195,6 +195,8 @@ func OpenWith(pLog, dLog, cLog appendable.Appendable, opts *Options) (*AHtree, e
 	if pLogFileSize < t.pLogSize {
 		return nil, ErrorCorruptedData
 	}
+
+	t.dLogSize = int64(nodesUpto(uint64(cLogSize/cLogEntrySize)) * sha256.Size)
 
 	dLogSize, err := dLog.Size()
 	if err != nil {

--- a/embedded/store/immustore_test.go
+++ b/embedded/store/immustore_test.go
@@ -330,10 +330,13 @@ func TestImmudbStoreEdgeCases(t *testing.T) {
 
 	// Should fail validating cLogSize
 	cLog.SizeFn = func() (int64, error) {
-		return cLogEntrySize + 1, nil
+		return cLogEntrySize - 1, nil
+	}
+	cLog.SetOffsetFn = func(off int64) error {
+		return nil
 	}
 	_, err = OpenWith("edge_cases", vLogs, txLog, cLog, opts)
-	require.ErrorIs(t, err, ErrCorruptedCLog)
+	require.NoError(t, err)
 
 	// Should fail reading cLog
 	cLog.SizeFn = func() (int64, error) {
@@ -347,7 +350,10 @@ func TestImmudbStoreEdgeCases(t *testing.T) {
 
 	// Should fail reading txLogSize
 	cLog.SizeFn = func() (int64, error) {
-		return 0, nil
+		return cLogEntrySize + 1, nil
+	}
+	cLog.SetOffsetFn = func(off int64) error {
+		return nil
 	}
 	txLog.SizeFn = func() (int64, error) {
 		return 0, injectedError

--- a/embedded/store/immustore_test.go
+++ b/embedded/store/immustore_test.go
@@ -807,8 +807,10 @@ func TestImmudbStoreCommitWith(t *testing.T) {
 		}, nil
 	}
 
-	md, err := immuStore.CommitWith(callback, false)
+	md, err := immuStore.CommitWith(callback, true)
 	require.NoError(t, err)
+
+	require.Equal(t, uint64(1), immuStore.IndexInfo())
 
 	tx := immuStore.NewTx()
 	immuStore.ReadTx(md.ID, tx)

--- a/embedded/store/immustore_test.go
+++ b/embedded/store/immustore_test.go
@@ -490,8 +490,9 @@ func TestImmudbStoreEdgeCases(t *testing.T) {
 				}, nil
 			}
 			return &mocked.MockedAppendable{
-				SizeFn:  func() (int64, error) { return 0, nil },
-				CloseFn: func() error { return nil },
+				SizeFn:   func() (int64, error) { return 0, nil },
+				OffsetFn: func() int64 { return 0 },
+				CloseFn:  func() error { return nil },
 			}, nil
 		}),
 	)

--- a/embedded/store/indexer.go
+++ b/embedded/store/indexer.go
@@ -237,14 +237,9 @@ func (idx *indexer) restartIndex() error {
 		return err
 	}
 
-	index, err := tbtree.Open(idx.path, opts)
-	if err != nil {
-		return err
-	}
+	idx.index, err = tbtree.Open(idx.path, opts)
 
-	idx.index = index
-
-	return nil
+	return err
 }
 
 func (idx *indexer) Resume() {

--- a/embedded/store/indexer.go
+++ b/embedded/store/indexer.go
@@ -237,7 +237,12 @@ func (idx *indexer) restartIndex() error {
 		return err
 	}
 
-	idx.index, err = tbtree.Open(idx.path, opts)
+	index, err := tbtree.Open(idx.path, opts)
+	if err != nil {
+		return err
+	}
+
+	idx.index = index
 
 	return err
 }

--- a/embedded/store/indexer.go
+++ b/embedded/store/indexer.go
@@ -191,7 +191,7 @@ func (idx *indexer) CompactIndex() (err error) {
 		}
 	}()
 
-	_, err = idx.index.CompactIndex()
+	_, err = idx.index.Compact()
 	if err != nil {
 		return err
 	}

--- a/embedded/store/indexer_test.go
+++ b/embedded/store/indexer_test.go
@@ -132,34 +132,32 @@ func TestRestartIndexCornerCases(t *testing.T) {
 			func(t *testing.T, dir string, s *ImmuStore) {
 				s.Close()
 				err := s.indexer.restartIndex()
-				require.Equal(t, tbtree.ErrAlreadyClosed, err)
+				require.Equal(t, ErrAlreadyClosed, err)
 			},
 		},
 		{
 			"No nodes folder",
 			func(t *testing.T, dir string, s *ImmuStore) {
-				require.NoError(t, os.MkdirAll(filepath.Join(dir, "index/commit_1"), 0777))
+				require.NoError(t, os.MkdirAll(filepath.Join(dir, "index/commit1"), 0777))
 				err := s.indexer.restartIndex()
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "nodes_1")
+				require.NoError(t, err)
 			},
 		},
 		{
 			"No commit folder",
 			func(t *testing.T, dir string, s *ImmuStore) {
-				require.NoError(t, os.MkdirAll(filepath.Join(dir, "index/nodes_1"), 0777))
+				require.NoError(t, os.MkdirAll(filepath.Join(dir, "index/nodes1"), 0777))
 				err := s.indexer.restartIndex()
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "commit_1")
+				require.NoError(t, err)
 			},
 		},
 		{
 			"Invalid index structure",
 			func(t *testing.T, dir string, s *ImmuStore) {
-				require.NoError(t, os.MkdirAll(filepath.Join(dir, "index/nodes_1"), 0777))
-				require.NoError(t, ioutil.WriteFile(filepath.Join(dir, "index/commit_1"), []byte{}, 0777))
+				require.NoError(t, os.MkdirAll(filepath.Join(dir, "index/nodes1"), 0777))
+				require.NoError(t, ioutil.WriteFile(filepath.Join(dir, "index/commit1"), []byte{}, 0777))
 				err := s.indexer.restartIndex()
-				require.Equal(t, tbtree.ErrorPathIsNotADirectory, err)
+				require.NoError(t, err)
 			},
 		},
 	} {

--- a/embedded/store/indexer_test.go
+++ b/embedded/store/indexer_test.go
@@ -122,7 +122,7 @@ func TestMaxIndexWaitees(t *testing.T) {
 	}
 }
 
-func TestReplaceIndexCornerCases(t *testing.T) {
+func TestRestartIndexCornerCases(t *testing.T) {
 	for _, c := range []struct {
 		name string
 		fn   func(t *testing.T, dir string, s *ImmuStore)
@@ -131,7 +131,7 @@ func TestReplaceIndexCornerCases(t *testing.T) {
 			"Closed store",
 			func(t *testing.T, dir string, s *ImmuStore) {
 				s.Close()
-				err := s.indexer.replaceIndex(1)
+				err := s.indexer.restartIndex()
 				require.Equal(t, tbtree.ErrAlreadyClosed, err)
 			},
 		},
@@ -139,7 +139,7 @@ func TestReplaceIndexCornerCases(t *testing.T) {
 			"No nodes folder",
 			func(t *testing.T, dir string, s *ImmuStore) {
 				require.NoError(t, os.MkdirAll(filepath.Join(dir, "index/commit_1"), 0777))
-				err := s.indexer.replaceIndex(1)
+				err := s.indexer.restartIndex()
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "nodes_1")
 			},
@@ -148,7 +148,7 @@ func TestReplaceIndexCornerCases(t *testing.T) {
 			"No commit folder",
 			func(t *testing.T, dir string, s *ImmuStore) {
 				require.NoError(t, os.MkdirAll(filepath.Join(dir, "index/nodes_1"), 0777))
-				err := s.indexer.replaceIndex(1)
+				err := s.indexer.restartIndex()
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "commit_1")
 			},
@@ -158,7 +158,7 @@ func TestReplaceIndexCornerCases(t *testing.T) {
 			func(t *testing.T, dir string, s *ImmuStore) {
 				require.NoError(t, os.MkdirAll(filepath.Join(dir, "index/nodes_1"), 0777))
 				require.NoError(t, ioutil.WriteFile(filepath.Join(dir, "index/commit_1"), []byte{}, 0777))
-				err := s.indexer.replaceIndex(1)
+				err := s.indexer.restartIndex()
 				require.Equal(t, tbtree.ErrorPathIsNotADirectory, err)
 			},
 		},

--- a/embedded/tbtree/snapshot_test.go
+++ b/embedded/tbtree/snapshot_test.go
@@ -130,7 +130,7 @@ func TestSnapshotLoadFromFullDump(t *testing.T) {
 	done := make(chan struct{})
 
 	go func(done chan<- struct{}) {
-		tbtree.CompactIndex()
+		tbtree.Compact()
 		done <- struct{}{}
 	}(done)
 

--- a/embedded/tbtree/tbtree.go
+++ b/embedded/tbtree/tbtree.go
@@ -267,7 +267,7 @@ func Open(path string, opts *Options) (*TBtree, error) {
 
 			err = discardSnapshots(path, snapIDs[i-1:i], opts.log)
 			if err != nil {
-				return nil, err
+				opts.log.Warningf("Error discarding snapshots at '%s'. %v", path, err)
 			}
 
 			continue
@@ -278,7 +278,7 @@ func Open(path string, opts *Options) (*TBtree, error) {
 		// Discard older snapshots upon sucessful validation
 		err = discardSnapshots(path, snapIDs[:i-1], opts.log)
 		if err != nil {
-			return nil, err
+			opts.log.Warningf("Error discarding snapshots at '%s'. %v", path, err)
 		}
 
 		return t, nil

--- a/embedded/tbtree/tbtree.go
+++ b/embedded/tbtree/tbtree.go
@@ -285,8 +285,13 @@ func Open(path string, opts *Options) (*TBtree, error) {
 	// No snapshot present or none was valid, fresh initialization
 	opts.log.Infof("Staring with an empty index...")
 
+	hsz, err := hLog.Size()
+	if err != nil {
+		return nil, err
+	}
+
 	// Remove history data as it'd become garbage otherwise
-	if len(snapIDs) > 0 {
+	if hsz > 0 {
 		err = hLog.Close()
 		if err != nil {
 			return nil, err
@@ -343,7 +348,8 @@ func recoverFullSnapshots(path, prefix string, log logger.Logger) (snapIDs []int
 
 			id, err := strconv.ParseInt(strings.TrimPrefix(f.Name(), prefix), 10, 64)
 			if err != nil {
-				return nil, err
+				log.Warningf("invalid folder found '%s'", f.Name())
+				continue
 			}
 
 			snapIDs = append(snapIDs, id)

--- a/embedded/tbtree/tbtree.go
+++ b/embedded/tbtree/tbtree.go
@@ -312,7 +312,7 @@ func snapFolder(folder string, snapID uint64) string {
 		return folder
 	}
 
-	return fmt.Sprintf("%s%d", folder, snapID)
+	return fmt.Sprintf("%s%016d", folder, snapID)
 }
 
 func recoverFullSnapshots(path, prefix string, log logger.Logger) (snapIDs []uint64, err error) {

--- a/embedded/tbtree/tbtree.go
+++ b/embedded/tbtree/tbtree.go
@@ -415,7 +415,7 @@ func OpenWith(path string, nLog, hLog, cLog appendable.Appendable, opts *Options
 		nLog:                  nLog,
 		hLog:                  hLog,
 		cLog:                  cLog,
-		committedNLogSize:     0,
+		committedNLogSize:     0, // If garbage is accepted then t.committedNLogSize should be set to its size during initialization
 		committedHLogSize:     hLogSize,
 		cache:                 cache,
 		maxNodeSize:           maxNodeSize,
@@ -839,6 +839,12 @@ func (t *TBtree) flushTree() (wN int64, wH int64, err error) {
 	}
 
 	snapshot := t.newSnapshot(0, t.root)
+
+	// If garbage is accepted then t.committedNLogSize should be set to its size during initialization
+	err = t.nLog.SetOffset(t.committedNLogSize)
+	if err != nil {
+		return 0, 0, err
+	}
 
 	wopts := &WriteOpts{
 		OnlyMutated:    true,

--- a/embedded/tbtree/tbtree_test.go
+++ b/embedded/tbtree/tbtree_test.go
@@ -519,7 +519,7 @@ func TestSnapshotRecovery(t *testing.T) {
 	require.NoError(t, err)
 
 	// Starting with an invalid folder name
-	os.MkdirAll(filepath.Join(d, fmt.Sprintf("%s1z", commitFolder)), 0777)
+	os.MkdirAll(filepath.Join(d, fmt.Sprintf("%s1z", commitFolderPrefix)), 0777)
 
 	tree, err := Open(d, DefaultOptions().WithCompactionThld(0))
 	require.NoError(t, err)
@@ -551,7 +551,7 @@ func TestSnapshotRecovery(t *testing.T) {
 	err = tree.Close()
 	require.NoError(t, err)
 
-	os.RemoveAll(filepath.Join(d, fmt.Sprintf("%s%d", nodesFolder, c)))
+	os.RemoveAll(filepath.Join(d, fmt.Sprintf("%s%d", nodesFolderPrefix, c)))
 
 	tree, err = Open(d, DefaultOptions())
 	require.NoError(t, err)
@@ -584,13 +584,13 @@ func TestSnapshotRecovery(t *testing.T) {
 
 	{
 		// Should fail opening nLog
-		_, err = Open(d, DefaultOptions().WithAppFactory(metaFaultyAppFactory(nodesFolder)))
+		_, err = Open(d, DefaultOptions().WithAppFactory(metaFaultyAppFactory(nodesFolderPrefix)))
 		require.ErrorIs(t, err, injectedError)
 	}
 
 	{
 		// Should fail opening cLog
-		_, err = Open(d, DefaultOptions().WithAppFactory(metaFaultyAppFactory(commitFolder)))
+		_, err = Open(d, DefaultOptions().WithAppFactory(metaFaultyAppFactory(commitFolderPrefix)))
 		require.ErrorIs(t, err, injectedError)
 	}
 }

--- a/pkg/client/stream_replication_test.go
+++ b/pkg/client/stream_replication_test.go
@@ -97,7 +97,7 @@ func TestImmuClient_ExportAndReplicateTx(t *testing.T) {
 		require.Equal(t, i, rtxmd.Id)
 	}
 
-	replicatedEntry, err := client.Get(rctx, []byte("key1"))
+	replicatedEntry, err := client.GetAt(rctx, []byte("key1"), txmd.Id)
 	require.NoError(t, err)
 	require.Equal(t, []byte("value1"), replicatedEntry.Value)
 	require.Equal(t, txmd.Id, replicatedEntry.Tx)


### PR DESCRIPTION
This PR includes:

- Fix an issue in btree flushing step to make it crash tolerant. Current solution is based on `SetOffset` operation as originally designed. Which may evolve to support garbage with a full or pseudo-full appendable implementation.

- Auto truncation of commit logs based on fixed commit entry sizes. Originally, an error was retuned if an inconsistency was produced in commit logs. This point was discussed during a team meeting and mentioned as part of a more broad discussion #858.

- Btree initialization following a similar approach to MultiAppendable initialization. Btree compaction creates a full dump of the tree into new folders, previously the folders to use were fixed i.e. `nodes` and `commit` but since this change, the folders are dynamically chosen from the most recent to the older ones. Once the btree is successfully opened, remaining folders are removed. 
Note: This change is not yet prepared for remote appendable implementation. Originally, `OpenWith` method was designed to provide any kind of appendable implementation but currently an appendable factory is injected into `Open` method. Some design and implementation considerations should be discussed in order to provide this functionality while being compatible with remote storage.