### PR TITLE
non-blocking sql initialization

### DIFF
--- a/embedded/sql/engine_test.go
+++ b/embedded/sql/engine_test.go
@@ -187,7 +187,7 @@ func TestDumpCatalogTo(t *testing.T) {
 	engine, err = NewEngine(dumpedCatalogStore, dataStore, prefix)
 	require.NoError(t, err)
 
-	err = engine.EnsureCatalogReady()
+	err = engine.EnsureCatalogReady(nil)
 	require.NoError(t, err)
 
 	exists, err := engine.ExistDatabase("db1")
@@ -1668,7 +1668,7 @@ func TestReOpening(t *testing.T) {
 	_, err = engine.ExistDatabase("db1")
 	require.ErrorIs(t, err, ErrCatalogNotReady)
 
-	err = engine.EnsureCatalogReady()
+	err = engine.EnsureCatalogReady(nil)
 	require.NoError(t, err)
 
 	exists, err := engine.ExistDatabase("db1")
@@ -1791,7 +1791,7 @@ func TestInferParameters(t *testing.T) {
 	engine, err := NewEngine(catalogStore, dataStore, prefix)
 	require.NoError(t, err)
 
-	err = engine.EnsureCatalogReady()
+	err = engine.EnsureCatalogReady(nil)
 	require.NoError(t, err)
 
 	stmt := "CREATE DATABASE db1"

--- a/embedded/sql/grouped_row_reader_test.go
+++ b/embedded/sql/grouped_row_reader_test.go
@@ -35,7 +35,7 @@ func TestGroupedRowReader(t *testing.T) {
 	engine, err := NewEngine(catalogStore, dataStore, prefix)
 	require.NoError(t, err)
 
-	err = engine.EnsureCatalogReady()
+	err = engine.EnsureCatalogReady(nil)
 	require.NoError(t, err)
 
 	_, err = engine.newGroupedRowReader(nil, nil, nil)

--- a/embedded/sql/grouped_row_reader_test.go
+++ b/embedded/sql/grouped_row_reader_test.go
@@ -35,6 +35,9 @@ func TestGroupedRowReader(t *testing.T) {
 	engine, err := NewEngine(catalogStore, dataStore, prefix)
 	require.NoError(t, err)
 
+	err = engine.EnsureCatalogReady()
+	require.NoError(t, err)
+
 	_, err = engine.newGroupedRowReader(nil, nil, nil)
 	require.Equal(t, ErrIllegalArguments, err)
 

--- a/embedded/sql/joint_row_reader_test.go
+++ b/embedded/sql/joint_row_reader_test.go
@@ -36,7 +36,7 @@ func TestJointRowReader(t *testing.T) {
 	engine, err := NewEngine(catalogStore, dataStore, prefix)
 	require.NoError(t, err)
 
-	err = engine.EnsureCatalogReady()
+	err = engine.EnsureCatalogReady(nil)
 	require.NoError(t, err)
 
 	_, err = engine.newJointRowReader(nil, nil, nil, nil, nil)

--- a/embedded/sql/joint_row_reader_test.go
+++ b/embedded/sql/joint_row_reader_test.go
@@ -36,6 +36,9 @@ func TestJointRowReader(t *testing.T) {
 	engine, err := NewEngine(catalogStore, dataStore, prefix)
 	require.NoError(t, err)
 
+	err = engine.EnsureCatalogReady()
+	require.NoError(t, err)
+
 	_, err = engine.newJointRowReader(nil, nil, nil, nil, nil)
 	require.Equal(t, ErrIllegalArguments, err)
 

--- a/embedded/tbtree/tbtree.go
+++ b/embedded/tbtree/tbtree.go
@@ -1193,10 +1193,6 @@ func (t *TBtree) SnapshotSince(ts uint64) (*Snapshot, error) {
 		return nil, ErrorToManyActiveSnapshots
 	}
 
-	if t.compacting {
-		return nil, ErrCompactAlreadyInProgress
-	}
-
 	if t.lastSnapRoot == nil || t.lastSnapRoot.ts() < ts ||
 		(t.renewSnapRootAfter > 0 && time.Since(t.lastSnapRootAt) >= t.renewSnapRootAfter) {
 

--- a/embedded/watchers/watchers_test.go
+++ b/embedded/watchers/watchers_test.go
@@ -34,10 +34,11 @@ func TestWatchersHub(t *testing.T) {
 
 	go func(cancel chan<- struct{}) {
 		time.Sleep(100 * time.Millisecond)
-		cancel <- struct{}{}
+		close(cancel)
 	}(cancellation)
 
-	wHub.WaitFor(1, cancellation)
+	err := wHub.WaitFor(1, cancellation)
+	require.ErrorIs(t, err, ErrCancellationRequested)
 
 	doneUpto, waiting, err := wHub.Status()
 	require.NoError(t, err)

--- a/pkg/database/database_test.go
+++ b/pkg/database/database_test.go
@@ -193,13 +193,14 @@ func TestOpenV1_0_1_DB(t *testing.T) {
 	sysDB, err := OpenDb(sysOpts, nil, logger.NewSimpleLogger("immudb ", os.Stderr))
 	require.NoError(t, err)
 
-	defer sysDB.Close()
-
 	dbOpts := DefaultOption().WithDbName("defaultdb").WithDbRootPath("./data_v1.0.1")
 	db, err := OpenDb(dbOpts, sysDB, logger.NewSimpleLogger("immudb ", os.Stderr))
 	require.NoError(t, err)
 
 	err = db.Close()
+	require.NoError(t, err)
+
+	err = sysDB.Close()
 	require.NoError(t, err)
 }
 

--- a/pkg/database/sql.go
+++ b/pkg/database/sql.go
@@ -46,7 +46,7 @@ func (d *db) VerifiableSQLGet(req *schema.VerifiableSQLGetRequest) (*schema.Veri
 		}
 	}
 
-	err := d.sqlEngine.EnsureCatalogReady()
+	err := d.sqlEngine.EnsureCatalogReady(nil)
 	if err != nil {
 		return nil, err
 	}
@@ -169,7 +169,7 @@ func (d *db) ListTables() (*schema.SQLQueryResult, error) {
 		}
 	}
 
-	err := d.sqlEngine.EnsureCatalogReady()
+	err := d.sqlEngine.EnsureCatalogReady(nil)
 	if err != nil {
 		return nil, err
 	}
@@ -199,7 +199,7 @@ func (d *db) DescribeTable(tableName string) (*schema.SQLQueryResult, error) {
 		}
 	}
 
-	err := d.sqlEngine.EnsureCatalogReady()
+	err := d.sqlEngine.EnsureCatalogReady(nil)
 	if err != nil {
 		return nil, err
 	}
@@ -288,7 +288,7 @@ func (d *db) SQLExecPrepared(stmts []sql.SQLStmt, namedParams []*schema.NamedPar
 		params[p.Name] = schema.RawValue(p.Value)
 	}
 
-	err := d.sqlEngine.EnsureCatalogReady()
+	err := d.sqlEngine.EnsureCatalogReady(nil)
 	if err != nil {
 		return nil, err
 	}
@@ -437,7 +437,7 @@ func (d *db) SQLQueryRowReader(stmt *sql.SelectStmt, renewSnapshot bool) (sql.Ro
 	d.mutex.RLock()
 	defer d.mutex.RUnlock()
 
-	err := d.sqlEngine.EnsureCatalogReady()
+	err := d.sqlEngine.EnsureCatalogReady(nil)
 	if err != nil {
 		return nil, err
 	}
@@ -449,7 +449,7 @@ func (d *db) InferParameters(sql string) (map[string]sql.SQLValueType, error) {
 	d.mutex.RLock()
 	defer d.mutex.RUnlock()
 
-	err := d.sqlEngine.EnsureCatalogReady()
+	err := d.sqlEngine.EnsureCatalogReady(nil)
 	if err != nil {
 		return nil, err
 	}
@@ -461,7 +461,7 @@ func (d *db) InferParametersPrepared(stmt sql.SQLStmt) (map[string]sql.SQLValueT
 	d.mutex.RLock()
 	defer d.mutex.RUnlock()
 
-	err := d.sqlEngine.EnsureCatalogReady()
+	err := d.sqlEngine.EnsureCatalogReady(nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/database/sql.go
+++ b/pkg/database/sql.go
@@ -53,7 +53,7 @@ func (d *db) VerifiableSQLGet(req *schema.VerifiableSQLGetRequest) (*schema.Veri
 
 	txEntry := d.tx1
 
-	table, err := d.sqlEngine.Catalog().GetTableByName(dbInstanceName, req.SqlGetRequest.Table)
+	table, err := d.sqlEngine.GetTableByName(dbInstanceName, req.SqlGetRequest.Table)
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +174,7 @@ func (d *db) ListTables() (*schema.SQLQueryResult, error) {
 		return nil, err
 	}
 
-	db, err := d.sqlEngine.Catalog().GetDatabaseByName(dbInstanceName)
+	db, err := d.sqlEngine.GetDatabaseByName(dbInstanceName)
 	if err != nil {
 		return nil, err
 	}
@@ -204,7 +204,7 @@ func (d *db) DescribeTable(tableName string) (*schema.SQLQueryResult, error) {
 		return nil, err
 	}
 
-	table, err := d.sqlEngine.Catalog().GetTableByName(dbInstanceName, tableName)
+	table, err := d.sqlEngine.GetTableByName(dbInstanceName, tableName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/options.go
+++ b/pkg/server/options.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/codenotary/immudb/pkg/stream"
 
@@ -110,7 +111,10 @@ func DefaultOptions() *Options {
 }
 
 func DefaultStoreOptions() *store.Options {
-	indexOptions := store.DefaultIndexOptions().WithRenewSnapRootAfter(0)
+	indexOptions := store.DefaultIndexOptions().
+		WithRenewSnapRootAfter(0).
+		WithDelayDuringCompaction(10 * time.Millisecond)
+
 	return store.DefaultOptions().
 		WithIndexOptions(indexOptions).
 		WithMaxLinearProofLen(0).


### PR DESCRIPTION
SQL Functionality requires the catalog to be loaded. Currently, this implies indexing be up to date.

In cases were a complete index regeneration was required, initialization was blocking. Depending on the amount of data, not being able to periodically call compaction may require an excessive amount of disk space.

This PR places SQL initialization into the background, thus operations which don't require the indexing to be up to date can be normally executed.

Signed-off-by: Jeronimo Irazabal <jeronimo.irazabal@gmail.com>