### PR TITLE
fix(embedded/store): use reserved concurrency slot for indexing

### DIFF
--- a/embedded/store/immustore_test.go
+++ b/embedded/store/immustore_test.go
@@ -559,14 +559,10 @@ func TestImmudbStoreEdgeCases(t *testing.T) {
 	tx1, err := immuStore.fetchAllocTx()
 	require.NoError(t, err)
 
-	tx2, err := immuStore.fetchAllocTx()
-	require.NoError(t, err)
-
 	_, err = immuStore.fetchAllocTx()
 	require.Equal(t, ErrMaxConcurrencyLimitExceeded, err)
 
 	immuStore.releaseAllocTx(tx1)
-	immuStore.releaseAllocTx(tx2)
 
 	_, err = immuStore.NewTxReader(1, false, nil)
 	require.Equal(t, ErrIllegalArguments, err)


### PR DESCRIPTION
Indexing go-routine was't using the reserved concurrency slot allocated for that purpose. As consequence of this, it was competing for resources as a normal transaction. Slowing down indexing tasks and potentially blocking if max concurrency limit was reached with synchronous commits.

Signed-off-by: Jeronimo Irazabal <jeronimo.irazabal@gmail.com>