### PR TITLE
Improve signature verification during audit

### DIFF
--- a/pkg/server/sever_current_state_test.go
+++ b/pkg/server/sever_current_state_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/codenotary/immudb/pkg/database"
 	"github.com/codenotary/immudb/pkg/signer"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -71,8 +72,10 @@ func TestServerCurrentStateSigned(t *testing.T) {
 	assert.NotNil(t, state.Signature.Signature)
 	assert.NotNil(t, state.Signature.PublicKey)
 
-	ok, err := signer.Verify(state.ToBytes(), state.Signature.Signature, signer.UnmarshalKey(state.Signature.PublicKey))
+	ecdsaPK, err := signer.UnmarshalKey(state.Signature.PublicKey)
+	require.NoError(t, err)
 
+	ok, err := signer.Verify(state.ToBytes(), state.Signature.Signature, ecdsaPK)
 	assert.NoError(t, err)
 	assert.True(t, ok)
 }

--- a/pkg/signer/ecdsa.go
+++ b/pkg/signer/ecdsa.go
@@ -30,6 +30,8 @@ import (
 	"math/big"
 )
 
+var ErrInvalidPublicKey = errors.New("invalid public key")
+
 type signer struct {
 	rand       io.Reader
 	privateKey *ecdsa.PrivateKey
@@ -77,9 +79,12 @@ func (sig signer) Sign(payload []byte) ([]byte, []byte, error) {
 	return m, p, nil
 }
 
-func UnmarshalKey(publicKey []byte) *ecdsa.PublicKey {
+func UnmarshalKey(publicKey []byte) (*ecdsa.PublicKey, error) {
 	x, y := elliptic.Unmarshal(elliptic.P256(), publicKey)
-	return &ecdsa.PublicKey{Curve: elliptic.P256(), X: x, Y: y}
+	if x == nil {
+		return nil, ErrInvalidPublicKey
+	}
+	return &ecdsa.PublicKey{Curve: elliptic.P256(), X: x, Y: y}, nil
 }
 
 // verify verifies a signed payload


### PR DESCRIPTION
This PR addresses the changes requested by @byo & @mmeloni in the previous PR which was already merged - see these comments for details:
- [x] https://github.com/codenotary/immudb/pull/872#discussion_r676320188
- [x] https://github.com/codenotary/immudb/pull/872#discussion_r676347176

@mmeloni Please not that i actually did something a bit different than what you suggested (to avoid exposing `ecdsa.PublicKey` in generic `Signer` interface): i just called in the auditor code the existing `UnmarshalKey` function from signer package (which i enhanced a bit by returning an error if the key bytes are not a valid key).