### PR TITLE
Adding AUTO_INCREMENT column to describe table

### DIFF
--- a/embedded/sql/catalog.go
+++ b/embedded/sql/catalog.go
@@ -278,3 +278,7 @@ func (c *Column) Type() SQLValueType {
 func (c *Column) IsNullable() bool {
 	return !c.notNull
 }
+
+func (c *Column) IsAutoIncremental() bool {
+	return c.autoIncrement
+}

--- a/pkg/database/sql.go
+++ b/pkg/database/sql.go
@@ -214,6 +214,7 @@ func (d *db) DescribeTable(tableName string) (*schema.SQLQueryResult, error) {
 		{Name: "TYPE", Type: sql.VarcharType},
 		{Name: "NULLABLE", Type: sql.BooleanType},
 		{Name: "INDEX", Type: sql.VarcharType},
+		{Name: "AUTO_INCREMENT", Type: sql.BooleanType},
 	}}
 
 	for _, c := range table.ColsByID() {
@@ -237,6 +238,7 @@ func (d *db) DescribeTable(tableName string) (*schema.SQLQueryResult, error) {
 				{Value: &schema.SQLValue_S{S: c.Type()}},
 				{Value: &schema.SQLValue_B{B: c.IsNullable()}},
 				{Value: &schema.SQLValue_S{S: index}},
+				{Value: &schema.SQLValue_B{B: c.IsAutoIncremental()}},
 			},
 		})
 	}


### PR DESCRIPTION
In order to correctly identifying autoincremental column(s) in table, I've added the `AUTO INCREMENT` column to the `describe` call.
It is a boolean field, default to false.


```sql
immuclient>exec CREATE TABLE demo (id INTEGER AUTO_INCREMENT, description VARCHAR, PRIMARY KEY id)
Updated rows: 0 
immuclient>describe demo
+---------------+-----------+----------+---------------+----------------+
|    COLUMN     |   TYPE    | NULLABLE |     INDEX     | AUTO INCREMENT |
+---------------+-----------+----------+---------------+----------------+
| "id"          | "INTEGER" | false    | "PRIMARY KEY" | true           |
| "description" | "VARCHAR" | true     | "NO"          | false          |
+---------------+-----------+----------+---------------+----------------+

```﻿
