### PR TITLE
fix(embedded/sql): enforce ordering by grouping column

### DIFF
--- a/embedded/sql/cond_row_reader.go
+++ b/embedded/sql/cond_row_reader.go
@@ -47,6 +47,10 @@ func (cr *conditionalRowReader) SetParameters(params map[string]interface{}) {
 	cr.params = params
 }
 
+func (cr *conditionalRowReader) OrderBy() *ColDescriptor {
+	return cr.rowReader.OrderBy()
+}
+
 func (cr *conditionalRowReader) Columns() ([]*ColDescriptor, error) {
 	return cr.rowReader.Columns()
 }

--- a/embedded/sql/cond_row_reader_test.go
+++ b/embedded/sql/cond_row_reader_test.go
@@ -75,6 +75,10 @@ func (r *dummyRowReader) Close() error {
 	return dummyError
 }
 
+func (r *dummyRowReader) OrderBy() *ColDescriptor {
+	return nil
+}
+
 func (r *dummyRowReader) Columns() ([]*ColDescriptor, error) {
 	return nil, dummyError
 }

--- a/embedded/sql/engine.go
+++ b/embedded/sql/engine.go
@@ -52,6 +52,7 @@ var ErrInvalidValue = errors.New("invalid value provided")
 var ErrInferredMultipleTypes = errors.New("inferred multiple types")
 var ErrExpectingDQLStmt = errors.New("illegal statement. DQL statement expected")
 var ErrLimitedOrderBy = errors.New("order is limit to one indexed column")
+var ErrLimitedGroupBy = errors.New("group by requires ordering by the grouping column")
 var ErrIllegalMappedKey = errors.New("error illegal mapped key")
 var ErrCorruptedData = store.ErrCorruptedData
 var ErrCatalogNotReady = errors.New("catalog not ready")

--- a/embedded/sql/grouped_row_reader.go
+++ b/embedded/sql/grouped_row_reader.go
@@ -31,8 +31,13 @@ type groupedRowReader struct {
 }
 
 func (e *Engine) newGroupedRowReader(rowReader RowReader, selectors []Selector, groupBy []*ColSelector) (*groupedRowReader, error) {
-	if rowReader == nil || len(selectors) == 0 {
+	if rowReader == nil || len(selectors) == 0 || len(groupBy) > 1 {
 		return nil, ErrIllegalArguments
+	}
+
+	if len(groupBy) == 1 &&
+		rowReader.OrderBy().Selector() != EncodeSelector(groupBy[0].resolve(rowReader.ImplicitDB(), rowReader.ImplicitTable())) {
+		return nil, ErrLimitedGroupBy
 	}
 
 	return &groupedRowReader{
@@ -49,6 +54,10 @@ func (gr *groupedRowReader) ImplicitDB() string {
 
 func (gr *groupedRowReader) ImplicitTable() string {
 	return gr.rowReader.ImplicitTable()
+}
+
+func (gr *groupedRowReader) OrderBy() *ColDescriptor {
+	return gr.rowReader.OrderBy()
 }
 
 func (gr *groupedRowReader) Columns() ([]*ColDescriptor, error) {

--- a/embedded/sql/grouped_row_reader_test.go
+++ b/embedded/sql/grouped_row_reader_test.go
@@ -56,6 +56,11 @@ func TestGroupedRowReader(t *testing.T) {
 	gr, err := engine.newGroupedRowReader(r, []Selector{&ColSelector{col: "id"}}, []*ColSelector{{col: "id"}})
 	require.NoError(t, err)
 
+	orderBy := gr.OrderBy()
+	require.NotNil(t, orderBy)
+	require.Equal(t, "id", orderBy.Column)
+	require.Equal(t, "table1", orderBy.Table)
+
 	cols, err := gr.Columns()
 	require.NoError(t, err)
 	require.Len(t, cols, 1)

--- a/embedded/sql/joint_row_reader.go
+++ b/embedded/sql/joint_row_reader.go
@@ -72,6 +72,10 @@ func (jointr *jointRowReader) ImplicitTable() string {
 	return jointr.rowReader.ImplicitTable()
 }
 
+func (jointr *jointRowReader) OrderBy() *ColDescriptor {
+	return jointr.rowReader.OrderBy()
+}
+
 func (jointr *jointRowReader) Columns() ([]*ColDescriptor, error) {
 	colsBySel, err := jointr.colsBySelector()
 	if err != nil {

--- a/embedded/sql/joint_row_reader_test.go
+++ b/embedded/sql/joint_row_reader_test.go
@@ -66,6 +66,11 @@ func TestJointRowReader(t *testing.T) {
 	jr, err := engine.newJointRowReader(db, snap, nil, r, []*JoinSpec{{joinType: InnerJoin, ds: &TableRef{table: "table1"}}})
 	require.NoError(t, err)
 
+	orderBy := jr.OrderBy()
+	require.NotNil(t, orderBy)
+	require.Equal(t, "id", orderBy.Column)
+	require.Equal(t, "table1", orderBy.Table)
+
 	cols, err := jr.Columns()
 	require.NoError(t, err)
 	require.Len(t, cols, 1)

--- a/embedded/sql/proj_row_reader.go
+++ b/embedded/sql/proj_row_reader.go
@@ -53,6 +53,10 @@ func (pr *projectedRowReader) ImplicitTable() string {
 	return pr.tableAlias
 }
 
+func (pr *projectedRowReader) OrderBy() *ColDescriptor {
+	return pr.rowReader.OrderBy()
+}
+
 func (pr *projectedRowReader) Columns() ([]*ColDescriptor, error) {
 	colsBySel, err := pr.colsBySelector()
 	if err != nil {

--- a/embedded/sql/stmt.go
+++ b/embedded/sql/stmt.go
@@ -1119,6 +1119,10 @@ func (stmt *SelectStmt) compileUsing(e *Engine, implicitDB *Database, params map
 		return nil, ErrHavingClauseRequiresGroupClause
 	}
 
+	if len(stmt.groupBy) > 1 {
+		return nil, ErrLimitedGroupBy
+	}
+
 	if len(stmt.orderBy) > 1 {
 		return nil, ErrLimitedOrderBy
 	}


### PR DESCRIPTION
This PR enforces all rows of the same group are consecutive so to get up most one entry per group.

As a consequence of this enforcement, grouping is restricted to the indexed column the results are ordered by.

```sql
CREATE TABLE t1(id INTEGER AUTO_INCREMENT, val1 INTEGER, PRIMARY KEY id)
CREATE INDEX ON t1(val1)
SELECT COUNT() as c FROM t1 GROUP BY val1 ORDER BY val1
```

Signed-off-by: Jeronimo Irazabal <jeronimo.irazabal@gmail.com>