### PR TITLE
LINUX: tool to update binaries all over the system

### DIFF
--- a/tools/linux/update_bins.sh
+++ b/tools/linux/update_bins.sh
@@ -27,7 +27,7 @@ FIMMUCLIENT="immuclient"
 FIMMUADMIN="immuadmin"
 FIMMUTEST="immutest"
 SERVICE="immudb.service"
-USAGE="Usage: ./$0 [--ask|--quite]\nDebug: bash -x ./$0 [--ask|--quite]"
+USAGE="Usage: ./tools/linux/$0 [--ask|--quite]\nDebug: bash -x tools/linux/$0 [--ask|--quite]"
 
 # Parsing script arguments, in order to identify the writing mode
 INTERACTIVE=${1:-"--ask"}
@@ -39,7 +39,7 @@ elif [ $# -gt 1 ]; then
     echo -e $USAGE
     exit $ERROR
 else
-    echo "Writing mode: $INTERACTIVE"
+    echo "Passed: $INTERACTIVE"
 fi
 
 # Argument parsing: parameters passed to the script, or help. Everything else is an error
@@ -48,7 +48,7 @@ if [ "${INTERACTIVE}" == "--quite" ]; then
 elif [ "${INTERACTIVE}" == "--ask" ]; then
     CPI="-i"
 elif [ "${INTERACTIVE}" == "--help" ]; then
-    echo -n "${USAGE}"
+    echo -e "${USAGE}"
     exit ${SUCCESS}
 else
     echo "EROOR: unknown option ${INTERACTIVE}"

--- a/tools/linux/update_bins.sh
+++ b/tools/linux/update_bins.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # 
-# usage: ./tools/linux/immudbin.sh [<writing_mode>]  
+# usage: ./tools/linux/update_bins.sh [<writing_mode>]  
 # Arguments: 
 #   writing_mode: --ask |--quite
 #   default: --ask
@@ -14,7 +14,6 @@
 # Example:
 # $ bash tools/linux/update_bins.sh --ask # this will ask you for confirmation before overwriting files
 # $ bash tools/linux/update_bins.sh --quite # this will overwrite files without asking for confirmation
-#
 
 set -o nounset
 
@@ -59,7 +58,6 @@ fi
 # Searching for all binaries occurences, it will overwrite them 
 search_replace(){
     BNAME=${1}
-
     echo "## WRITING ${BNAME^^} ##"
     C=0
     for i in $( sudo find / -name ${BNAME} -type f 2> /dev/null );do 

--- a/tools/linux/update_bins.sh
+++ b/tools/linux/update_bins.sh
@@ -11,9 +11,10 @@
 # If systemctl is available and service is running, it will be stopped and started afterwards.
 #
 # 
-# Example:
-# $ bash tools/linux/update_bins.sh --ask # this will ask you for confirmation before overwriting files
-# $ bash tools/linux/update_bins.sh --quite # this will overwrite files without asking for confirmation
+# Examples:
+# $ ./tools/linux/update_bins.sh --help # print help
+# $ ./tools/linux/update_bins.sh --ask # this will ask you for confirmation before overwriting files
+# $ ./tools/linux/update_bins.sh --quite # this will overwrite files without asking for confirmation
 
 set -o nounset
 

--- a/tools/linux/update_bins.sh
+++ b/tools/linux/update_bins.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # 
-# usage: ./immudbin.sh [<writing_mode>]  
+# usage: ./tools/linux/immudbin.sh [<writing_mode>]  
 # Arguments: 
 #   writing_mode: --ask |--quite
 #   default: --ask

--- a/tools/linux/update_bins.sh
+++ b/tools/linux/update_bins.sh
@@ -2,23 +2,25 @@
 # 
 # usage: ./tools/linux/update_bins.sh [<writing_mode>]  
 # Arguments: 
-#   writing_mode: --ask |--quite
+#   writing_mode: --ask |--batch
 #   default: --ask
 #
 # Description:
 # This script will update the immudb binaries. After building, running this script will overwrite files all over the place.
-# You can choose whether to use interactive (--ask) or quiet (--quite) mode.
+# You can choose whether to use interactive (--ask) or batch (--batch) mode.
 # If systemctl is available and service is running, it will be stopped and started afterwards.
 #
 # 
 # Examples:
 # $ ./tools/linux/update_bins.sh --help # print help
 # $ ./tools/linux/update_bins.sh --ask # this will ask you for confirmation before overwriting files
-# $ ./tools/linux/update_bins.sh --quite # this will overwrite files without asking for confirmation
+# $ ./tools/linux/update_bins.sh --batch # this will overwrite files without asking for confirmation
+# $ ./tools/linux/update_bins.sh # writing mode omitted, default is --ask
 
+# no unset, please
 set -o nounset
 
-# script stuff
+# script stuff declarations
 ERROR=1
 SUCCESS=0
 PWD=$(pwd)
@@ -27,12 +29,12 @@ FIMMUCLIENT="immuclient"
 FIMMUADMIN="immuadmin"
 FIMMUTEST="immutest"
 SERVICE="immudb.service"
-USAGE="Usage: ./tools/linux/$0 [--ask|--quite]\nDebug: bash -x tools/linux/$0 [--ask|--quite]"
+USAGE="Usage: ./tools/linux/$0 [--ask|--batch]\nDebug: bash -x tools/linux/$0 [--ask|--batch]"
 
 # Parsing script arguments, in order to identify the writing mode
 INTERACTIVE=${1:-"--ask"}
 
-# I need one argument, either --ask or --quite. Nothing more, nothing less.
+# I need one argument, either --ask or --batch. Nothing more, nothing less.
 if [ $# -eq 0 ]; then
     echo "Writing mode not passed, I set --ask for you"
 elif [ $# -gt 1 ]; then
@@ -43,7 +45,7 @@ else
 fi
 
 # Argument parsing: parameters passed to the script, or help. Everything else is an error
-if [ "${INTERACTIVE}" == "--quite" ]; then
+if [ "${INTERACTIVE}" == "--batch" ]; then
     CPI=""
 elif [ "${INTERACTIVE}" == "--ask" ]; then
     CPI="-i"

--- a/tools/linux/update_bins.sh
+++ b/tools/linux/update_bins.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# 
+# usage: ./immudbin.sh [<writing_mode>]  
+# Arguments: 
+#   writing_mode: --ask |--quite
+#   default: --ask
+#
+# Description:
+# This script will update the immudb binaries. After building, running this script will overwrite files all over the place.
+# You can choose whether to use interactive (--ask) or quiet (--quite) mode.
+# If systemctl is available and service is running, it will be stopped and started afterwards.
+#
+# 
+# Example:
+# $ bash tools/linux/update_bins.sh --ask # this will ask you for confirmation before overwriting files
+# $ bash tools/linux/update_bins.sh --quite # this will overwrite files without asking for confirmation
+#
+
+set -o nounset
+
+# script stuff
+ERROR=1
+SUCCESS=0
+PWD=$(pwd)
+FIMMUDB="immudb"
+FIMMUCLIENT="immuclient"
+FIMMUADMIN="immuadmin"
+FIMMUTEST="immutest"
+SERVICE="immudb.service"
+USAGE="Usage: ./$0 [--ask|--quite]\nDebug: bash -x ./$0 [--ask|--quite]"
+
+# Parsing script arguments, in order to identify the writing mode
+INTERACTIVE=${1:-"--ask"}
+
+# I need one argument, either --ask or --quite. Nothing more, nothing less.
+if [ $# -eq 0 ]; then
+    echo "Writing mode not passed, I set --ask for you"
+elif [ $# -gt 1 ]; then
+    echo -e $USAGE
+    exit $ERROR
+else
+    echo "Writing mode: $INTERACTIVE"
+fi
+
+# Argument parsing: parameters passed to the script, or help. Everything else is an error
+if [ "${INTERACTIVE}" == "--quite" ]; then
+    CPI=""
+elif [ "${INTERACTIVE}" == "--ask" ]; then
+    CPI="-i"
+elif [ "${INTERACTIVE}" == "--help" ]; then
+    echo -n "${USAGE}"
+    exit ${SUCCESS}
+else
+    echo "EROOR: unknown option ${INTERACTIVE}"
+    exit ${ERROR}
+fi
+
+
+# Searching for all binaries occurences, it will overwrite them 
+search_replace(){
+    BNAME=${1}
+
+    echo "## WRITING ${BNAME^^} ##"
+    C=0
+    for i in $( sudo find / -name ${BNAME} -type f 2> /dev/null );do 
+        DIRNAME=$( dirname ${i} )
+        # we don't have to replace the the bin with itself
+        if [[ ${DIRNAME} != ${PWD} ]];then
+            ((C=C+1))
+            echo -n "[${C}]..."
+            sudo cp ${CPI} ${BNAME} ${i}
+        fi
+    done
+    echo -e "Processed ${C} ${BNAME} files\n\n"
+}
+
+# if systemctl is available and service installed, we will stop and start the service
+restart_idb_service(){
+    echo "Checking for ${FIMMUDB} service..."
+    SYSCTL=$( which systemctl )
+    SERV_INSTALLED=$( sudo ${SYSCTL} list-unit-files | grep ${SERVICE} | cut -f1 -d" " )
+    # if systemd service is installed, then we can restart it
+    if [[ ${SERV_INSTALLED} == ${SERVICE} ]]; then
+        echo -n "Restarting: "
+        sudo ${SYSCTL} restart ${SERVICE}
+        if [[ $? -ne ${SUCCESS} ]];then
+            echo "Operation failed"
+            exit ${ERROR}
+        else
+            echo "Operation completed"
+        fi
+    else
+        echo "Not installed. NOOP."
+    fi
+    echo -e "${FIMMUDB^^} service management done\n\n"
+}
+
+#------------#
+# EXECUTIONS #
+#------------#
+
+# 1 IMMUDB ACTIONS
+search_replace ${FIMMUDB} 
+restart_idb_service 
+
+# 2 IMMUCLIENT ACTIONS
+search_replace ${FIMMUCLIENT} 
+
+#  3 IMMUADMIN ACTIONS
+search_replace ${FIMMUADMIN} 
+
+# 4 IMMUTEST ACTIONS
+search_replace ${FIMMUTEST} 
+
+
+# GOODBYE 
+echo "Done."


### PR DESCRIPTION
Each time you compile with `make all`, you need to deploy updating binaries (e.g: in /usr/bin, /sbin/, /usr/sbin,...), and restarting immudb service.

Running this simple automation script you can automate this boring, error-prone process, saving time.
Default is the interactive `--ask` mode: you will check files to be overwritten, one by one.
If you need a batch mode you can use the `--batch` flag, allowing you to call it from devops scripts, in CI/CD pipelines, ...

From the immudb root directory, a typical use case is:
```sh
./tools/linux/update_bins.sh --ask
```
Note: it uses sudo, therefore you'll be asked to enter password in order to process non-user files.
If you are deploying on a systemctl system like me, the script restarts immudb.service for you.


```sh
# usage: bash tools/linux/update_bins.sh [<writing_mode>]  
# Arguments: 
#   writing_mode: --ask |--batch
#   default: --ask
#
# Description:
# This script will update the immudb binaries. After building, running this script will overwrite files all over the place.
# You can choose whether to use interactive (--ask) or batch (--batch) mode.
# If systemctl is available and service is running, it will be stopped and started afterwards.
#
```


Examples:
1. Confirm before overwriting files:
```sh
$ bash tools/linux/update_bins.sh --ask 
Writing mode: --ask
## WRITING IMMUDB ##
[1]...cp: overwrite '/usr/bin/immudb'? y
...
...
[8]...cp: overwrite '/home/zreq3b/go/src/github.com/zreq3b/service_10/immudb'? y
[9]...cp: overwrite '/home/zreq3b/go/src/github.com/zreq3b/service_4/tools/packaging/deb/default/immudb'? y
...
...
...
[15]...cp: overwrite '/home/zreq3b/go/src/github.com/zreq3b/service_2/immudb'? y
Processed 15 immudb files


Checking for immudb service...
Not installed. NOOP.
IMMUDB service management done
#
# This can be (if is installed...):
# Checking for immudb service...
# Restarting: Operation completed
# IMMUDB service management done


## WRITING IMMUCLIENT ##
[1]
...
... Omissis
...
[6]...cp: overwrite '/home/zreq3b/go/src/github.com/zreq3b/service_2/immuclient'? y
Processed 6 immuclient files


## WRITING IMMUADMIN ##
[1]
...
...Omissis
...
[9]...cp: overwrite '/home/zreq3b/go/src/github.com/zreq3b/service_5/immuadmin'? y
Processed 9 immuadmin files


## WRITING IMMUTEST ##
... Omissis
[2]...cp: overwrite '/home/zreq3b/go/src/github.com/zreq3b/service_10/immutest'? y
[3]...cp: overwrite '/home/zreq3b/go/src/github.com/zreq3b/service2_1/immutest'? y
Processed 3 immutest files


Done.
```

2. Overwrite files without confirmation
```sh
$ bash tools/linux/update_bins.sh --batch
Writing mode: --batch
## WRITING IMMUDB ##
[1]...[2]...[3]...[4]...[5]...[6]...[7]...[8]...[9]...[10]...[11]...[12]...[13]...[14]...[15]...Processed 15 immudb files


Checking for immudb service...
Not installed. NOOP.
IMMUDB service management done


## WRITING IMMUCLIENT ##
[1]...[2]...[3]...[4]...[5]...[6]...Processed 6 immuclient files


## WRITING IMMUADMIN ##
[1]...[2]...[3]...[4]...[5]...[6]...[7]...[8]...[9]...Processed 9 immuadmin files


## WRITING IMMUTEST ##
[1]...[2]...[3]...Processed 3 immutest files

Done.
﻿```