### PR TITLE
Feat/randompassword

### DIFF
--- a/Dockerfile.rndpass
+++ b/Dockerfile.rndpass
@@ -1,0 +1,43 @@
+FROM golang:1.13-stretch as build
+WORKDIR /src
+COPY . .
+RUN GOOS=linux GOARCH=amd64 WEBCONSOLE=1 make immuadmin-static immudb-static
+FROM debian:bullseye-slim
+MAINTAINER CodeNotary, Inc. <info@codenotary.io>
+
+COPY --from=build /src/immudb /usr/sbin/immudb
+COPY --from=build /src/immuadmin /usr/local/bin/immuadmin
+COPY tools/rndpass/startup.sh /usr/local/bin/startup.sh
+
+ARG IMMU_UID="3322"
+ARG IMMU_GID="3322"
+
+ENV IMMUDB_HOME="/usr/share/immudb" \
+    IMMUDB_DIR="/var/lib/immudb" \
+    IMMUDB_DBNAME="immudb" \
+    IMMUDB_ADDRESS="0.0.0.0" \
+    IMMUDB_PORT="3322" \
+    IMMUDB_PIDFILE="" \
+    IMMUDB_LOGFILE="" \
+    IMMUDB_MTLS="false" \
+    IMMUDB_AUTH="true" \
+    IMMUDB_DETACHED="false" \
+    IMMUDB_DEVMODE="true" \
+    IMMUDB_MAINTENANCE="false" \
+    IMMUDB_ADMIN_PASSWORD="immudb" \
+    IMMUADMIN_TOKENFILE="/var/lib/immudb/admin_token"
+
+RUN addgroup --system --gid $IMMU_GID immu && \
+    adduser --system --uid $IMMU_UID --no-create-home --ingroup immu immu && \
+    mkdir -p "$IMMUDB_HOME" && \
+    mkdir -p "$IMMUDB_DIR" && \
+    chown -R immu:immu "$IMMUDB_HOME" "$IMMUDB_DIR" && \
+    chmod -R 777 "$IMMUDB_HOME" "$IMMUDB_DIR" && \
+    chmod +x /usr/sbin/immudb /usr/local/bin/immuadmin
+
+EXPOSE 3322
+EXPOSE 9497
+
+HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD [ "/usr/local/bin/immuadmin", "status" ]
+USER immu
+ENTRYPOINT ["/usr/local/bin/startup.sh", "/usr/sbin/immudb"]

--- a/pkg/server/options.go
+++ b/pkg/server/options.go
@@ -259,10 +259,12 @@ func (o *Options) String() string {
 		opts = append(opts, rightPad("   bucket name", o.RemoteStorageOptions.S3BucketName))
 		opts = append(opts, rightPad("   prefix", o.RemoteStorageOptions.S3PathPrefix))
 	}
-	opts = append(opts, "----------------------------------------")
-	opts = append(opts, "Superadmin default credentials")
-	opts = append(opts, rightPad("   Username", auth.SysAdminUsername))
-	opts = append(opts, rightPad("   Password", auth.SysAdminPassword))
+	if o.AdminPassword == auth.SysAdminPassword {
+		opts = append(opts, "----------------------------------------")
+		opts = append(opts, "Superadmin default credentials")
+		opts = append(opts, rightPad("   Username", auth.SysAdminUsername))
+		opts = append(opts, rightPad("   Password", auth.SysAdminPassword))
+	}
 	opts = append(opts, "========================================")
 	return strings.Join(opts, "\n")
 }

--- a/tools/rndpass/startup.sh
+++ b/tools/rndpass/startup.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ -z "$IMMUDB_ADMIN_PASSWORD" ]
+then
+   export IMMUDB_ADMIN_PASSWORD=`tr -cd '[:alnum:].,:;/@_=' < /dev/urandom|head -c 16`
+   echo "Generated immudb password: $IMMUDB_ADMIN_PASSWORD"
+fi
+
+exec $@


### PR DESCRIPTION
This PR adds a dockerfile used for publication in AWS marketplace: it randomizes the initial password of immudb.

It also corrects the behavior of immudb server when providing an initial admin password using environmental variables: the default "immudb/immudb" credentials are not shown in the log if a different password is used. This  is also needed for AWS marketplace publication.

Please review and apply