### PR TITLE
chore(Makefile): More explicit webconsole version

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Build with webconsole
         run: |
           sudo apt update && sudo apt install curl -y
-          WEBCONSOLE=1 make all
+          WEBCONSOLE=default make all
         if: runner.os == 'Linux'
       - name: Upload webconsole artifact
         uses: actions/upload-artifact@v2

--- a/BUILD.md
+++ b/BUILD.md
@@ -9,6 +9,7 @@ make all
 To embed the webconsole, build with
 
 ```
+rm -rf webconsole/dist  # force download of the correct webconsole version
 make WEBCONSOLE=default
 ```
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -6,14 +6,15 @@ To build the binaries yourself, simply clone this repo and run
 make all
 ```
 
-To embed the webconsole, place the front-end code in `webconsole/dist`, and build with
+To embed the webconsole, build with
 
 ```
-make WEBCONSOLE=1
+make WEBCONSOLE=default
 ```
 
-This will add the Go build tag `webconsole` which will use the *statik* library to embed the
-front-end code. The front-end will be then served in the web API root "/".
+This will download the appropriate webconsole release and add the Go build tag `webconsole`
+which will use the *statik* library to embed the front-end code.
+The front-end will be then served in the web API root "/".
 
 The webconsole generation will override the default page statik.go. To regenerate the default page, change the files in webconsole/default and run `make webconsole/default`
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.13-stretch as build
 WORKDIR /src
 COPY . .
-RUN GOOS=linux GOARCH=amd64 WEBCONSOLE=1 make immuadmin-static immudb-static
+RUN GOOS=linux GOARCH=amd64 WEBCONSOLE=default make immuadmin-static immudb-static
 FROM ubuntu:18.04
 MAINTAINER CodeNotary, Inc. <info@codenotary.io>
 

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ export GO111MODULE=on
 SHELL=/bin/bash -o pipefail
 
 VERSION=1.0.5
+DEFAULT_WEBCONSOLE_VERSION=0.1.9
 SERVICES=immudb immuadmin immuclient
 TARGETS=linux/amd64 windows/amd64 darwin/amd64 linux/s390x linux/arm64 freebsd/amd64
 
@@ -171,7 +172,7 @@ CHANGELOG.md.next-tag:
 clean/dist:
 	rm -Rf ./dist
 
-# WEBCONSOLE=1 SIGNCODE_PVK_PASSWORD='secret' SIGNCODE_PVK={path to pvk file} SIGNCODE_SPC={path to spc file} make dist
+# WEBCONSOLE=default SIGNCODE_PVK_PASSWORD='secret' SIGNCODE_PVK={path to pvk file} SIGNCODE_SPC={path to spc file} make dist
 # it enables by default webconsole
 .PHONY: dist
 dist: webconsole dist/binaries dist/winsign
@@ -222,6 +223,21 @@ dist/binary.md:
 	done
 
 ./webconsole/dist:
+ifeq (${WEBCONSOLE}, default)
+	@echo "Using webconsole version: ${DEFAULT_WEBCONSOLE_VERSION}"
+	curl -L https://github.com/codenotary/immudb-webconsole/releases/download/v${DEFAULT_WEBCONSOLE_VERSION}/immudb-webconsole.tar.gz | tar -xvz -C webconsole
+else ifeq (${WEBCONSOLE}, latest)
+	@echo "Using webconsole version: latest"
 	curl -L https://github.com/codenotary/immudb-webconsole/releases/latest/download/immudb-webconsole.tar.gz | tar -xvz -C webconsole
+else ifeq (${WEBCONSOLE}, 1)
+	@echo "The meaning of the 'WEBCONSOLE' variable has changed, please specify one of:"
+	@echo "  default   - to use the default version of the webconsole for this immudb release"
+	@echo "  latest    - to use the latest version of the webconsole"
+	@echo "  <version> - to use a specific version of the webconsole"
+	@exit 1
+else
+	@echo "Using webconsole version: ${WEBCONSOLE}"
+	curl -L https://github.com/codenotary/immudb-webconsole/releases/download/v${WEBCONSOLE}/immudb-webconsole.tar.gz | tar -xvz -C webconsole
+endif
 
 ########################## releases scripts end ########################################################################

--- a/build/RELEASING.md
+++ b/build/RELEASING.md
@@ -28,10 +28,11 @@ rm -rf webconsole/dist
 
 ## 2. Bump version (vX.Y.Z)
 
-Edit `Makefile` and modify the `VERSION` variable:
+Edit `Makefile` and modify the `VERSION` and `DEFAULT_WEBCONSOLE_VERSION` variables:
 
 ```
 VERSION=X.Y.Z
+DEFAULT_WEBCONSOLE_VERSION=A.B.C
 ```
 > N.B. Omit the `v` prefix.
 
@@ -70,7 +71,7 @@ Make sure the path of those files is accessible.
 Build all dist files. It's possible launch script on all services. Modify SERVICE_NAME according your needs:
 
 ```
-WEBCONSOLE=1 SIGNCODE_PVK_PASSWORD=<pvk password> SIGNCODE_PVK=<path to vchain.pvk> SIGNCODE_SPC=<path to vchain.spc> make dist
+WEBCONSOLE=default SIGNCODE_PVK_PASSWORD=<pvk password> SIGNCODE_PVK=<path to vchain.pvk> SIGNCODE_SPC=<path to vchain.spc> make dist
 ```
 > Distribution files will be created into the `dist` directory.
 


### PR DESCRIPTION
Makefile now contains an information what webconsole version
is the best match for the current immudb code. That version is
selected when building with `make WEBSONCOLE=default ...`.
Alternatively one can select the latest released version of
webconsole with `make WEBCONSOLE=latest ...` or use a specific
version with `make WEBCONSOLE=<version> ...`.