### PR TITLE
chore: decoupled token service

### DIFF
--- a/cmd/immuadmin/command/backup.go
+++ b/cmd/immuadmin/command/backup.go
@@ -20,13 +20,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/codenotary/immudb/pkg/client/homedir"
+	"github.com/codenotary/immudb/pkg/client/tokenservice"
 	stdos "os"
 	"path"
 	"runtime"
 	"strings"
 	"time"
-
-	"github.com/codenotary/immudb/pkg/client"
 
 	daem "github.com/takama/daemon"
 
@@ -104,7 +104,7 @@ func (cl *commandlineBck) ConfigChain(post func(cmd *cobra.Command, args []strin
 		}
 		// here all command line options and services need to be configured by options retrieved from viper
 		cl.options = Options()
-		cl.ts = client.NewTokenService().WithHds(client.NewHomedirService()).WithTokenFileName(cl.options.TokenFileName)
+		cl.ts = tokenservice.NewFileTokenService().WithHds(homedir.NewHomedirService()).WithTokenFileName(cl.options.TokenFileName)
 		if post != nil {
 			return post(cmd, args)
 		}

--- a/cmd/immuadmin/command/backup_test.go
+++ b/cmd/immuadmin/command/backup_test.go
@@ -154,7 +154,7 @@ func TestDumpToFile(t *testing.T) {
 	hds.FileExistsInUserHomeDirF = func(string) (bool, error) {
 		return true, nil
 	}
-	clb.ts = client.NewTokenService().WithHds(hds).WithTokenFileName("testTokenFile")
+	clb.ts = tokenservice.NewTokenService().WithHds(hds).WithTokenFileName("testTokenFile")
 
 	daemMock := defaultDaemonMock()
 	clb.Backupper = &backupper{
@@ -255,7 +255,7 @@ func TestBackup(t *testing.T) {
 	hds.FileExistsInUserHomeDirF = func(string) (bool, error) {
 		return true, nil
 	}
-	clb.ts = client.NewTokenService().WithHds(hds).WithTokenFileName("testTokenFile")
+	clb.ts = tokenservice.NewTokenService().WithHds(hds).WithTokenFileName("testTokenFile")
 
 	daemMock := defaultDaemonMock()
 	clb.Backupper = &backupper{
@@ -666,7 +666,7 @@ func TestRestore(t *testing.T) {
 	hds.FileExistsInUserHomeDirF = func(string) (bool, error) {
 		return true, nil
 	}
-	clb.ts = client.NewTokenService().WithHds(hds).WithTokenFileName("testTokenFile")
+	clb.ts = tokenservice.NewTokenService().WithHds(hds).WithTokenFileName("testTokenFile")
 
 	daemMock := defaultDaemonMock()
 	bckpr := &backupper{

--- a/cmd/immuadmin/command/commandline.go
+++ b/cmd/immuadmin/command/commandline.go
@@ -19,6 +19,8 @@ package immuadmin
 import (
 	"context"
 	"fmt"
+	"github.com/codenotary/immudb/pkg/client/homedir"
+	"github.com/codenotary/immudb/pkg/client/tokenservice"
 
 	c "github.com/codenotary/immudb/cmd/helper"
 	"github.com/codenotary/immudb/pkg/client"
@@ -53,7 +55,7 @@ type commandline struct {
 	newImmuClient  func(*client.Options) (client.ImmuClient, error)
 	passwordReader c.PasswordReader
 	context        context.Context
-	ts             client.TokenService
+	ts             tokenservice.TokenService
 	onError        func(msg interface{})
 	os             immuos.OS
 }
@@ -75,7 +77,7 @@ func (cl *commandline) ConfigChain(post func(cmd *cobra.Command, args []string) 
 		}
 		// here all command line options and services need to be configured by options retrieved from viper
 		cl.options = Options()
-		cl.ts = client.NewTokenService().WithHds(client.NewHomedirService()).WithTokenFileName(cl.options.TokenFileName)
+		cl.ts = tokenservice.NewFileTokenService().WithHds(homedir.NewHomedirService()).WithTokenFileName(cl.options.TokenFileName)
 		if post != nil {
 			return post(cmd, args)
 		}

--- a/cmd/immuadmin/command/commandline.go
+++ b/cmd/immuadmin/command/commandline.go
@@ -111,12 +111,12 @@ func (cl *commandline) disconnect(cmd *cobra.Command, args []string) {
 
 func (cl *commandline) connect(cmd *cobra.Command, args []string) (err error) {
 	if cl.newImmuClient == nil {
-		if cl.immuClient, err = client.NewImmuClient(cl.options); err != nil {
+		if cl.immuClient, err = client.NewImmuClient(cl.options.WithTokenService(tokenservice.NewFileTokenService().WithTokenFileName("token_admin"))); err != nil {
 			cl.quit(err)
 		}
 		return
 	}
-	if cl.immuClient, err = cl.newImmuClient(cl.options); err != nil {
+	if cl.immuClient, err = cl.newImmuClient(cl.options.WithTokenService(tokenservice.NewFileTokenService().WithTokenFileName("token_admin"))); err != nil {
 		cl.quit(err)
 	}
 	return

--- a/cmd/immuadmin/command/commandline_test.go
+++ b/cmd/immuadmin/command/commandline_test.go
@@ -47,7 +47,7 @@ func TestCommandline(t *testing.T) {
 		},
 		passwordReader: pwr,
 		context:        context.Background(),
-		ts:             client.NewTokenService().WithHds(hds).WithTokenFileName("testTokenFile"),
+		ts:             tokenservice.NewTokenService().WithHds(hds).WithTokenFileName("testTokenFile"),
 	}
 	cmd := &cobra.Command{}
 
@@ -85,16 +85,16 @@ func TestCommandline(t *testing.T) {
 	hds.FileExistsInUserHomeDirF = func(pathToFile string) (bool, error) {
 		return false, errFileExists
 	}
-	cl.ts = client.NewTokenService().WithHds(hds).WithTokenFileName("testTokenFile")
+	cl.ts = tokenservice.NewTokenService().WithHds(hds).WithTokenFileName("testTokenFile")
 	require.NoError(t, cl.checkLoggedIn(cmd, nil))
 	hds.FileExistsInUserHomeDirF = prevFileExists
-	cl.ts = client.NewTokenService().WithHds(hds).WithTokenFileName("testTokenFile")
+	cl.ts = tokenservice.NewTokenService().WithHds(hds).WithTokenFileName("testTokenFile")
 
 	require.Equal(t, errPleaseLogin, cl.checkLoggedInAndConnect(cmd, nil))
 	hds.FileExistsInUserHomeDirF = func(pathToFile string) (bool, error) {
 		return true, nil
 	}
-	cl.ts = client.NewTokenService().WithHds(hds).WithTokenFileName("testTokenFile")
+	cl.ts = tokenservice.NewTokenService().WithHds(hds).WithTokenFileName("testTokenFile")
 	cl.newImmuClient = func(*client.Options) (client.ImmuClient, error) {
 		return nil, errNewImmuClient
 	}

--- a/cmd/immuadmin/command/login_errors_test.go
+++ b/cmd/immuadmin/command/login_errors_test.go
@@ -54,7 +54,7 @@ func TestLoginLogoutErrors(t *testing.T) {
 	cl := &commandline{
 		immuClient:     immuClientMock,
 		passwordReader: pwReaderMock,
-		ts:             client.NewTokenService().WithHds(hdsMock).WithTokenFileName("tokenFileName"),
+		ts:             tokenservice.NewTokenService().WithHds(hdsMock).WithTokenFileName("tokenFileName"),
 	}
 
 	rootCmd := &cobra.Command{}

--- a/cmd/immuadmin/command/login_test.go
+++ b/cmd/immuadmin/command/login_test.go
@@ -19,6 +19,8 @@ package immuadmin
 import (
 	"bytes"
 	"context"
+	"github.com/codenotary/immudb/pkg/client/homedir"
+	"github.com/codenotary/immudb/pkg/client/tokenservice"
 	"io/ioutil"
 	"log"
 	"os"
@@ -100,7 +102,7 @@ func TestCommandLine_Disconnect(t *testing.T) {
 		immuClient:     &scIClientMock{*new(client.ImmuClient)},
 		passwordReader: pwReaderMock,
 		context:        context.Background(),
-		ts:             client.NewTokenService().WithHds(newHomedirServiceMock()).WithTokenFileName("token_admin"),
+		ts:             tokenservice.NewFileTokenService().WithHds(newHomedirServiceMock()).WithTokenFileName("token_admin"),
 	}
 	_ = cmdl.connect(&cobra.Command{}, []string{})
 
@@ -150,14 +152,14 @@ func TestCommandLine_LoginLogout(t *testing.T) {
 	}
 	cliopt := Options().WithDialOptions(&dialOptions)
 
-	cliopt.Tkns = client.NewTokenService().WithHds(client.NewHomedirService()).WithTokenFileName("token_admin")
+	cliopt.Tkns = tokenservice.NewFileTokenService().WithHds(homedir.NewHomedirService()).WithTokenFileName("token_admin")
 	cmdl := commandline{
 		config:         helper.Config{Name: "immuadmin"},
 		options:        cliopt,
 		immuClient:     &scIClientInnerMock{cliopt, *new(client.ImmuClient)},
 		passwordReader: pwReaderMock,
 		context:        context.Background(),
-		ts:             client.NewTokenService().WithHds(client.NewHomedirService()).WithTokenFileName("token_admin"),
+		ts:             tokenservice.NewFileTokenService().WithHds(homedir.NewHomedirService()).WithTokenFileName("token_admin"),
 		newImmuClient:  client.NewImmuClient,
 	}
 	cmdl.login(cmd)
@@ -184,7 +186,7 @@ func TestCommandLine_LoginLogout(t *testing.T) {
 		immuClient:     &scIClientMock{*new(client.ImmuClient)},
 		passwordReader: pwReaderMock,
 		context:        context.Background(),
-		ts:             client.NewTokenService().WithHds(client.NewHomedirService()).WithTokenFileName("token_admin"),
+		ts:             tokenservice.NewFileTokenService().WithHds(homedir.NewHomedirService()).WithTokenFileName("token_admin"),
 	}
 	b1 := bytes.NewBufferString("")
 	cl = commandline{}
@@ -236,7 +238,7 @@ func TestCommandLine_CheckLoggedIn(t *testing.T) {
 	cl1 := new(commandline)
 	cl1.context = context.Background()
 	cl1.passwordReader = pwReaderMock
-	cl1.ts = client.NewTokenService().WithHds(newHomedirServiceMock()).WithTokenFileName("token_admin")
+	cl1.ts = tokenservice.NewFileTokenService().WithHds(newHomedirServiceMock()).WithTokenFileName("token_admin")
 	dialOptions1 := []grpc.DialOption{
 		grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure(),
 	}

--- a/cmd/immuadmin/command/login_test.go
+++ b/cmd/immuadmin/command/login_test.go
@@ -132,7 +132,7 @@ func (c scIClientInnerMock) GetOptions() *client.Options {
 }
 
 func (c scIClientInnerMock) Login(ctx context.Context, user []byte, pass []byte) (*schema.LoginResponse, error) {
-	return &schema.LoginResponse{}, nil
+	return &schema.LoginResponse{Token: "fake-token"}, nil
 }
 
 func TestCommandLine_LoginLogout(t *testing.T) {

--- a/cmd/immuadmin/command/serverconfig_test.go
+++ b/cmd/immuadmin/command/serverconfig_test.go
@@ -60,7 +60,7 @@ func TestCommandLine_ServerconfigAuth(t *testing.T) {
 		immuClient:     &scIClientMock{*new(client.ImmuClient)},
 		passwordReader: pwReaderMock,
 		context:        context.Background(),
-		ts:             client.NewTokenService().WithHds(hds).WithTokenFileName("tokenFileName"),
+		ts:             tokenservice.NewTokenService().WithHds(hds).WithTokenFileName("tokenFileName"),
 	}
 
 	cmdso, err := cl.NewCmd()
@@ -112,7 +112,7 @@ func TestCommandLine_ServerconfigMtls(t *testing.T) {
 		immuClient:     &scIClientMock{*new(client.ImmuClient)},
 		passwordReader: pwReaderMock,
 		context:        context.Background(),
-		ts:             client.NewTokenService().WithHds(newHomedirServiceMock()).WithTokenFileName("tokenFileName"),
+		ts:             tokenservice.NewTokenService().WithHds(newHomedirServiceMock()).WithTokenFileName("tokenFileName"),
 	}
 
 	cmdso, _ := cl.NewCmd()

--- a/cmd/immuadmin/command/stats_test.go
+++ b/cmd/immuadmin/command/stats_test.go
@@ -56,7 +56,7 @@ func TestStats_Status(t *testing.T) {
 		immuClient:     clientb,
 		passwordReader: &clienttest.PasswordReaderMock{},
 		context:        context.Background(),
-		ts:             client.NewTokenService().WithHds(&clienttest.HomedirServiceMock{}).WithTokenFileName("tokenFileName"),
+		ts:             tokenservice.NewTokenService().WithHds(&clienttest.HomedirServiceMock{}).WithTokenFileName("tokenFileName"),
 	}
 	cmd, _ := cl.NewCmd()
 
@@ -111,7 +111,7 @@ func TestStats_StatsText(t *testing.T) {
 		immuClient:     clientb,
 		passwordReader: &clienttest.PasswordReaderMock{},
 		context:        context.Background(),
-		ts:             client.NewTokenService().WithHds(&clienttest.HomedirServiceMock{}).WithTokenFileName("tokenFileName"),
+		ts:             tokenservice.NewTokenService().WithHds(&clienttest.HomedirServiceMock{}).WithTokenFileName("tokenFileName"),
 	}
 	cmd, _ := cl.NewCmd()
 
@@ -165,7 +165,7 @@ func TestStats_StatsRaw(t *testing.T) {
 		immuClient:     clientb,
 		passwordReader: &clienttest.PasswordReaderMock{},
 		context:        context.Background(),
-		ts:             client.NewTokenService().WithHds(&clienttest.HomedirServiceMock{}).WithTokenFileName("tokenFileName"),
+		ts:             tokenservice.NewTokenService().WithHds(&clienttest.HomedirServiceMock{}).WithTokenFileName("tokenFileName"),
 	}
 	cmd, _ := cl.NewCmd()
 	cl.stats(cmd)

--- a/cmd/immuclient/cli/cli_test.go
+++ b/cmd/immuclient/cli/cli_test.go
@@ -55,7 +55,8 @@ func TestRunCommand(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -88,7 +89,8 @@ func TestRunCommandExtraArgs(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -120,7 +122,8 @@ func TestRunMissingArgs(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -153,7 +156,8 @@ func TestRunWrongCommand(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -185,7 +189,8 @@ func TestCheckCommand(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -245,7 +250,9 @@ func TestImmuClient_BackupAndRestoreUX(t *testing.T) {
 	cliOpts := client.DefaultOptions()
 	cliOpts.CurrentDatabase = client.DefaultDB
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
+
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(cliOpts.WithDir(stateFileDir))

--- a/cmd/immuclient/cli/cli_test.go
+++ b/cmd/immuclient/cli/cli_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cli
 
 import (
+	"github.com/codenotary/immudb/pkg/client/tokenservice"
 	"github.com/codenotary/immudb/pkg/fs"
 	"os"
 	"path"
@@ -54,7 +55,7 @@ func TestRunCommand(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -87,7 +88,7 @@ func TestRunCommandExtraArgs(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -119,7 +120,7 @@ func TestRunMissingArgs(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -152,7 +153,7 @@ func TestRunWrongCommand(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -184,7 +185,7 @@ func TestCheckCommand(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -244,7 +245,7 @@ func TestImmuClient_BackupAndRestoreUX(t *testing.T) {
 	cliOpts := client.DefaultOptions()
 	cliOpts.CurrentDatabase = client.DefaultDB
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(cliOpts.WithDir(stateFileDir))

--- a/cmd/immuclient/cli/currentstatus_test.go
+++ b/cmd/immuclient/cli/currentstatus_test.go
@@ -33,7 +33,7 @@ func TestCurrentRoot(t *testing.T) {
 	bs := servertest.NewBufconnServer(options)
 	bs.Start()
 defer bs.Stop()
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())

--- a/cmd/immuclient/cli/getcommands_test.go
+++ b/cmd/immuclient/cli/getcommands_test.go
@@ -32,7 +32,7 @@ func TestGetByIndex(t *testing.T) {
 	bs := servertest.NewBufconnServer(options)
 	bs.Start()
 defer bs.Stop()
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -58,7 +58,7 @@ func TestGetKey(t *testing.T) {
 	bs := servertest.NewBufconnServer(options)
 	bs.Start()
 defer bs.Stop()
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -83,7 +83,7 @@ func TestRawSafeGetKey(t *testing.T) {
 	bs := servertest.NewBufconnServer(options)
 	bs.Start()
 defer bs.Stop()
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -108,7 +108,7 @@ func TestSafeGetKey(t *testing.T) {
 	bs := servertest.NewBufconnServer(options)
 	bs.Start()
 defer bs.Stop()
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -134,7 +134,7 @@ func TestGetRawBySafeIndex(t *testing.T) {
 	bs := servertest.NewBufconnServer(options)
 	bs.Start()
 defer bs.Stop()
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())

--- a/cmd/immuclient/cli/login_test.go
+++ b/cmd/immuclient/cli/login_test.go
@@ -41,7 +41,8 @@ func TestLogin(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())

--- a/cmd/immuclient/cli/login_test.go
+++ b/cmd/immuclient/cli/login_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cli
 
 import (
+	"github.com/codenotary/immudb/pkg/client/tokenservice"
 	"os"
 	"strings"
 	"testing"
@@ -40,7 +41,7 @@ func TestLogin(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())

--- a/cmd/immuclient/cli/misc_test.go
+++ b/cmd/immuclient/cli/misc_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cli
 
 import (
+	"github.com/codenotary/immudb/pkg/client/tokenservice"
 	"os"
 	"strings"
 	"testing"
@@ -38,7 +39,7 @@ func TestHealthCheck(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -66,7 +67,7 @@ func TestHistory(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -107,7 +108,7 @@ func TestVersion(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())

--- a/cmd/immuclient/cli/misc_test.go
+++ b/cmd/immuclient/cli/misc_test.go
@@ -39,7 +39,8 @@ func TestHealthCheck(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -67,7 +68,8 @@ func TestHistory(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -108,7 +110,8 @@ func TestVersion(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())

--- a/cmd/immuclient/cli/references_test.go
+++ b/cmd/immuclient/cli/references_test.go
@@ -39,7 +39,8 @@ func TestReference(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -69,7 +70,8 @@ func _TestSafeReference(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())

--- a/cmd/immuclient/cli/references_test.go
+++ b/cmd/immuclient/cli/references_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cli
 
 import (
+	"github.com/codenotary/immudb/pkg/client/tokenservice"
 	"os"
 	"strings"
 	"testing"
@@ -38,7 +39,7 @@ func TestReference(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -68,7 +69,7 @@ func _TestSafeReference(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())

--- a/cmd/immuclient/cli/scanners_test.go
+++ b/cmd/immuclient/cli/scanners_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cli
 
 import (
+	"github.com/codenotary/immudb/pkg/client/tokenservice"
 	"os"
 	"strings"
 	"testing"
@@ -38,7 +39,7 @@ func TestZScan(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -76,7 +77,7 @@ func TestScan(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -109,7 +110,7 @@ func _TestCount(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())

--- a/cmd/immuclient/cli/scanners_test.go
+++ b/cmd/immuclient/cli/scanners_test.go
@@ -39,7 +39,8 @@ func TestZScan(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -77,7 +78,8 @@ func TestScan(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -110,7 +112,8 @@ func _TestCount(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())

--- a/cmd/immuclient/cli/setcommands_test.go
+++ b/cmd/immuclient/cli/setcommands_test.go
@@ -38,7 +38,8 @@ func TestSet(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -66,7 +67,8 @@ func TestSafeSet(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -94,7 +96,8 @@ func TestZAdd(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -125,7 +128,8 @@ func TestSafeZAdd(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())

--- a/cmd/immuclient/cli/setcommands_test.go
+++ b/cmd/immuclient/cli/setcommands_test.go
@@ -18,6 +18,7 @@ package cli
 
 import (
 	"github.com/codenotary/immudb/pkg/client"
+	"github.com/codenotary/immudb/pkg/client/tokenservice"
 	"os"
 	"strings"
 	"testing"
@@ -37,7 +38,7 @@ func TestSet(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -65,7 +66,7 @@ func TestSafeSet(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -93,7 +94,7 @@ func TestZAdd(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -124,7 +125,7 @@ func TestSafeZAdd(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())

--- a/cmd/immuclient/command/currentstatus_test.go
+++ b/cmd/immuclient/command/currentstatus_test.go
@@ -18,6 +18,7 @@ package immuclient
 
 import (
 	"bytes"
+	"github.com/codenotary/immudb/pkg/client/tokenservice"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -40,7 +41,7 @@ func TestCurrentState(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())

--- a/cmd/immuclient/command/currentstatus_test.go
+++ b/cmd/immuclient/command/currentstatus_test.go
@@ -40,8 +40,10 @@ func TestCurrentState(t *testing.T) {
 	defer bs.Stop()
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
+	defer os.Remove("testTokenFile")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())

--- a/cmd/immuclient/command/getcommands_test.go
+++ b/cmd/immuclient/command/getcommands_test.go
@@ -40,7 +40,7 @@ func TestGetByIndex(t *testing.T) {
 	bs.Start()
 defer bs.Stop()
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -100,7 +100,7 @@ func TestGetRawBySafeIndex(t *testing.T) {
 	bs.Start()
 defer bs.Stop()
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -154,7 +154,7 @@ func TestGetKey(t *testing.T) {
 	bs.Start()
 defer bs.Stop()
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -209,7 +209,7 @@ func TestSafeGetKey(t *testing.T) {
 	bs.Start()
 defer bs.Stop()
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -269,7 +269,7 @@ func TestRawSafeGetKey(t *testing.T) {
 	bs.Start()
 defer bs.Stop()
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())

--- a/cmd/immuclient/command/init_test.go
+++ b/cmd/immuclient/command/init_test.go
@@ -46,7 +46,8 @@ func TestConnect(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())

--- a/cmd/immuclient/command/init_test.go
+++ b/cmd/immuclient/command/init_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package immuclient
 
 import (
+	"github.com/codenotary/immudb/pkg/client/tokenservice"
 	"os"
 	"testing"
 
@@ -45,7 +46,7 @@ func TestConnect(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())

--- a/cmd/immuclient/command/login_test.go
+++ b/cmd/immuclient/command/login_test.go
@@ -42,7 +42,8 @@ func TestLogin(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())

--- a/cmd/immuclient/command/login_test.go
+++ b/cmd/immuclient/command/login_test.go
@@ -18,6 +18,7 @@ package immuclient
 
 import (
 	"bytes"
+	"github.com/codenotary/immudb/pkg/client/tokenservice"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -41,7 +42,7 @@ func TestLogin(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())

--- a/cmd/immuclient/command/misc_test.go
+++ b/cmd/immuclient/command/misc_test.go
@@ -39,7 +39,7 @@ func TestHistory(t *testing.T) {
 	bs.Start()
 defer bs.Stop()
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -85,7 +85,7 @@ func TestStatus(t *testing.T) {
 	bs.Start()
 defer bs.Stop()
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -131,7 +131,7 @@ func TestUseDatabase(t *testing.T) {
 	bs.Start()
 defer bs.Stop()
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())

--- a/cmd/immuclient/command/references_test.go
+++ b/cmd/immuclient/command/references_test.go
@@ -39,7 +39,7 @@ func TestReference(t *testing.T) {
 	bs.Start()
 defer bs.Stop()
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -86,7 +86,7 @@ func TestSafeReference(t *testing.T) {
 	bs.Start()
 defer bs.Stop()
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())

--- a/cmd/immuclient/command/scanners_test.go
+++ b/cmd/immuclient/command/scanners_test.go
@@ -40,7 +40,7 @@ func TestZScan(t *testing.T) {
 	bs.Start()
 defer bs.Stop()
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -88,7 +88,7 @@ func TestIScan(t *testing.T) {
 	bs.Start()
 defer bs.Stop()
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -134,7 +134,7 @@ func TestScan(t *testing.T) {
 	bs.Start()
 defer bs.Stop()
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -181,7 +181,7 @@ func TestCount(t *testing.T) {
 	bs.Start()
 defer bs.Stop()
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())

--- a/cmd/immuclient/command/setcommands_test.go
+++ b/cmd/immuclient/command/setcommands_test.go
@@ -40,7 +40,7 @@ func TestRawSafeSet(t *testing.T) {
 	bs.Start()
 defer bs.Stop()
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -84,7 +84,7 @@ func TestSet(t *testing.T) {
 	bs.Start()
 defer bs.Stop()
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -128,7 +128,7 @@ func TestSafeset(t *testing.T) {
 	bs.Start()
 defer bs.Stop()
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -172,7 +172,7 @@ func TestZAdd(t *testing.T) {
 	bs.Start()
 defer bs.Stop()
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -231,7 +231,7 @@ func TestSafeZAdd(t *testing.T) {
 	bs.Start()
 defer bs.Stop()
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())

--- a/cmd/immuclient/command/tamperproofing_test.go
+++ b/cmd/immuclient/command/tamperproofing_test.go
@@ -40,7 +40,7 @@ func TestConsistency(t *testing.T) {
 	bs.Start()
 defer bs.Stop()
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -89,7 +89,7 @@ func TestInclusion(t *testing.T) {
 	bs.Start()
 defer bs.Stop()
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())

--- a/cmd/immuclient/immuc/currentstatus_test.go
+++ b/cmd/immuclient/immuc/currentstatus_test.go
@@ -37,7 +37,8 @@ func TestCurrentRoot(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())

--- a/cmd/immuclient/immuc/currentstatus_test.go
+++ b/cmd/immuclient/immuc/currentstatus_test.go
@@ -17,14 +17,14 @@ limitations under the License.
 package immuc_test
 
 import (
+	test "github.com/codenotary/immudb/cmd/immuclient/immuclienttest"
+	"github.com/codenotary/immudb/pkg/client"
+	"github.com/codenotary/immudb/pkg/client/tokenservice"
+	"github.com/codenotary/immudb/pkg/server"
+	"github.com/codenotary/immudb/pkg/server/servertest"
 	"os"
 	"strings"
 	"testing"
-
-	test "github.com/codenotary/immudb/cmd/immuclient/immuclienttest"
-	"github.com/codenotary/immudb/pkg/client"
-	"github.com/codenotary/immudb/pkg/server"
-	"github.com/codenotary/immudb/pkg/server/servertest"
 )
 
 func TestCurrentRoot(t *testing.T) {
@@ -37,7 +37,7 @@ func TestCurrentRoot(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())

--- a/cmd/immuclient/immuc/getcommands_test.go
+++ b/cmd/immuclient/immuc/getcommands_test.go
@@ -40,7 +40,8 @@ func TestGetTxByID(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -68,7 +69,8 @@ func TestGet(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -96,7 +98,8 @@ func TestVerifiedGet(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())

--- a/cmd/immuclient/immuc/getcommands_test.go
+++ b/cmd/immuclient/immuc/getcommands_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package immuc_test
 
 import (
+	"github.com/codenotary/immudb/pkg/client/tokenservice"
 	"os"
 	"strings"
 	"testing"
@@ -39,7 +40,7 @@ func TestGetTxByID(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -67,7 +68,7 @@ func TestGet(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -95,7 +96,7 @@ func TestVerifiedGet(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())

--- a/cmd/immuclient/immuc/init.go
+++ b/cmd/immuclient/immuc/init.go
@@ -18,6 +18,8 @@ package immuc
 import (
 	"errors"
 	"fmt"
+	"github.com/codenotary/immudb/pkg/client/homedir"
+	"github.com/codenotary/immudb/pkg/client/tokenservice"
 	"strings"
 
 	c "github.com/codenotary/immudb/cmd/helper"
@@ -33,7 +35,7 @@ type immuc struct {
 	valueOnly      bool
 	options        *client.Options
 	isLoggedin     bool
-	ts             client.TokenService
+	ts             tokenservice.TokenService
 }
 
 // Client ...
@@ -165,7 +167,7 @@ func Options() *client.Options {
 		WithDatabase(viper.GetString("database")).
 		WithTokenFileName(viper.GetString("tokenfile")).
 		WithMTLs(viper.GetBool("mtls")).
-		WithTokenService(client.NewTokenService().WithTokenFileName(viper.GetString("tokenfile")).WithHds(client.NewHomedirService())).
+		WithTokenService(tokenservice.NewFileTokenService().WithTokenFileName(viper.GetString("tokenfile")).WithHds(homedir.NewHomedirService())).
 		WithServerSigningPubKey(viper.GetString("server-signing-pub-key"))
 
 	if viper.GetBool("mtls") {

--- a/cmd/immuclient/immuc/login_errors_test.go
+++ b/cmd/immuclient/immuc/login_errors_test.go
@@ -36,7 +36,7 @@ func TestLoginAndUserCommandsErrors(t *testing.T) {
 	ic := new(immuc)
 	ic.ImmuClient = immuClientMock
 	ic.passwordReader = passwordReaderMock
-	ic.ts = client.NewTokenService().WithHds(homedirServiceMock)
+	ic.ts = tokenservice.NewTokenService().WithHds(homedirServiceMock)
 
 	// Login errors
 	passwordReadErr := errors.New("Password read error")

--- a/cmd/immuclient/immuc/login_test.go
+++ b/cmd/immuclient/immuc/login_test.go
@@ -109,7 +109,8 @@ func TestUserList(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -131,7 +132,8 @@ func TestUserCreate(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -266,7 +268,8 @@ func TestUserChangePassword(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -343,7 +346,8 @@ func TestUserSetActive(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -415,7 +419,8 @@ func TestSetUserPermission(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())

--- a/cmd/immuclient/immuc/login_test.go
+++ b/cmd/immuclient/immuc/login_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package immuc_test
 
 import (
+	"github.com/codenotary/immudb/pkg/client/tokenservice"
 	"os"
 	"strings"
 	"testing"
@@ -108,7 +109,7 @@ func TestUserList(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -130,7 +131,7 @@ func TestUserCreate(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -265,7 +266,7 @@ func TestUserChangePassword(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -342,7 +343,7 @@ func TestUserSetActive(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -414,7 +415,7 @@ func TestSetUserPermission(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())

--- a/cmd/immuclient/immuc/misc_test.go
+++ b/cmd/immuclient/immuc/misc_test.go
@@ -39,7 +39,8 @@ func TestHistory(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())

--- a/cmd/immuclient/immuc/misc_test.go
+++ b/cmd/immuclient/immuc/misc_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package immuc_test
 
 import (
+	"github.com/codenotary/immudb/pkg/client/tokenservice"
 	"os"
 	"strings"
 	"testing"
@@ -38,7 +39,7 @@ func TestHistory(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())

--- a/cmd/immuclient/immuc/references_test.go
+++ b/cmd/immuclient/immuc/references_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package immuc_test
 
 import (
+	"github.com/codenotary/immudb/pkg/client/tokenservice"
 	"os"
 	"strings"
 	"testing"
@@ -38,7 +39,7 @@ func TestReference(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -68,7 +69,7 @@ func _TestVerifiedSetReference(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())

--- a/cmd/immuclient/immuc/references_test.go
+++ b/cmd/immuclient/immuc/references_test.go
@@ -39,7 +39,8 @@ func TestReference(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -69,7 +70,8 @@ func _TestVerifiedSetReference(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())

--- a/cmd/immuclient/immuc/scanners_test.go
+++ b/cmd/immuclient/immuc/scanners_test.go
@@ -39,7 +39,8 @@ func TestZScan(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -77,7 +78,8 @@ func TestIScan(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -100,7 +102,8 @@ func TestScan(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -131,7 +134,8 @@ func _TestCount(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())

--- a/cmd/immuclient/immuc/scanners_test.go
+++ b/cmd/immuclient/immuc/scanners_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package immuc_test
 
 import (
+	"github.com/codenotary/immudb/pkg/client/tokenservice"
 	"os"
 	"strings"
 	"testing"
@@ -38,7 +39,7 @@ func TestZScan(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -76,7 +77,7 @@ func TestIScan(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -99,7 +100,7 @@ func TestScan(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -130,7 +131,7 @@ func _TestCount(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())

--- a/cmd/immuclient/immuc/setcommands_errors_test.go
+++ b/cmd/immuclient/immuc/setcommands_errors_test.go
@@ -166,7 +166,7 @@ func TestSetCommandsErrors(t *testing.T) {
 		return &client.Options{TokenFileName: "sometokenfile"}
 	}
 	hdsMock := clienttest.DefaultHomedirServiceMock()
-	ic.ts = client.NewTokenService().WithHds(hdsMock)
+	ic.ts = tokenservice.NewTokenService().WithHds(hdsMock)
 	errWriteFileToHomeDir := errors.New("write file to home dir errror")
 	hdsMock.WriteFileToUserHomeDirF = func(content []byte, pathToFile string) error {
 		return errWriteFileToHomeDir

--- a/cmd/immuclient/immuc/setcommands_test.go
+++ b/cmd/immuclient/immuc/setcommands_test.go
@@ -39,7 +39,8 @@ func TestSet(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -67,7 +68,8 @@ func TestVerifiedSet(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -95,7 +97,8 @@ func TestZAdd(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -125,7 +128,8 @@ func _TestVerifiedZAdd(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -154,7 +158,8 @@ func TestCreateDatabase(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").
+		WithHds(&test.HomedirServiceMock{Token: tokenservice.BuildToken("database", "fakeToken")})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())

--- a/cmd/immuclient/immuc/setcommands_test.go
+++ b/cmd/immuclient/immuc/setcommands_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package immuc_test
 
 import (
+	"github.com/codenotary/immudb/pkg/client/tokenservice"
 	"os"
 	"strings"
 	"testing"
@@ -38,7 +39,7 @@ func TestSet(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -66,7 +67,7 @@ func TestVerifiedSet(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -94,7 +95,7 @@ func TestZAdd(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -124,7 +125,7 @@ func _TestVerifiedZAdd(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())
@@ -153,7 +154,7 @@ func TestCreateDatabase(t *testing.T) {
 	defer os.RemoveAll(options.Dir)
 	defer os.Remove(".state-")
 
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
 	}, ts).WithOptions(client.DefaultOptions())

--- a/cmd/immuclient/immuclienttest/helper.go
+++ b/cmd/immuclient/immuclienttest/helper.go
@@ -18,6 +18,8 @@ package immuclienttest
 
 import (
 	"bytes"
+	"github.com/codenotary/immudb/pkg/client/homedir"
+	"github.com/codenotary/immudb/pkg/client/tokenservice"
 	"io"
 	"log"
 	"os"
@@ -32,13 +34,13 @@ import (
 
 type clientTest struct {
 	Imc     immuc.Client
-	Ts      client.TokenService
+	Ts      tokenservice.TokenService
 	Options client.Options
 	Pr      helper.PasswordReader
 }
 
 type HomedirServiceMock struct {
-	client.HomedirService
+	homedir.HomedirService
 	token []byte
 }
 
@@ -62,7 +64,7 @@ func (h *HomedirServiceMock) ReadFileFromUserHomeDir(pathToFile string) (string,
 func NewDefaultClientTest() *clientTest {
 	return &clientTest{}
 }
-func NewClientTest(pr helper.PasswordReader, tkns client.TokenService) *clientTest {
+func NewClientTest(pr helper.PasswordReader, tkns tokenservice.TokenService) *clientTest {
 	return &clientTest{
 		Ts: tkns,
 		Pr: pr,

--- a/cmd/immuclient/immuclienttest/helper.go
+++ b/cmd/immuclient/immuclienttest/helper.go
@@ -41,7 +41,7 @@ type clientTest struct {
 
 type HomedirServiceMock struct {
 	homedir.HomedirService
-	token []byte
+	Token []byte
 }
 
 func (h *HomedirServiceMock) FileExistsInUserHomeDir(pathToFile string) (bool, error) {
@@ -49,7 +49,7 @@ func (h *HomedirServiceMock) FileExistsInUserHomeDir(pathToFile string) (bool, e
 }
 
 func (h *HomedirServiceMock) WriteFileToUserHomeDir(content []byte, pathToFile string) error {
-	h.token = content
+	h.Token = content
 	return nil
 }
 
@@ -58,7 +58,7 @@ func (h *HomedirServiceMock) DeleteFileFromUserHomeDir(pathToFile string) error 
 }
 
 func (h *HomedirServiceMock) ReadFileFromUserHomeDir(pathToFile string) (string, error) {
-	return string(h.token), nil
+	return string(h.Token), nil
 }
 
 func NewDefaultClientTest() *clientTest {

--- a/cmd/immutest/command/cmd.go
+++ b/cmd/immutest/command/cmd.go
@@ -20,6 +20,7 @@ import (
 	c "github.com/codenotary/immudb/cmd/helper"
 	"github.com/codenotary/immudb/cmd/version"
 	"github.com/codenotary/immudb/pkg/client"
+	"github.com/codenotary/immudb/pkg/client/tokenservice"
 	"github.com/spf13/cobra"
 )
 
@@ -28,7 +29,7 @@ func NewCmd(
 	newImmuClient func(*client.Options) (client.ImmuClient, error),
 	pwr c.PasswordReader,
 	tr c.TerminalReader,
-	ts client.TokenService,
+	ts tokenservice.TokenService,
 	onError func(err error)) *cobra.Command {
 	cmd := &cobra.Command{}
 	Init(cmd,

--- a/cmd/immutest/command/init.go
+++ b/cmd/immutest/command/init.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/codenotary/immudb/pkg/client/tokenservice"
 	"strconv"
 	"strings"
 	"time"
@@ -40,7 +41,7 @@ type commandline struct {
 	newImmuClient func(*client.Options) (client.ImmuClient, error)
 	pwr           c.PasswordReader
 	tr            c.TerminalReader
-	tkns          client.TokenService
+	tkns          tokenservice.TokenService
 	config        c.Config
 	onError       func(err error)
 }
@@ -84,8 +85,8 @@ func Init(cmd *cobra.Command, cl *commandline) {
 		user := viper.GetString("user")
 		ctx := context.Background()
 		onSuccess := func() { reconnect(cl, cmd) } // used to redial with new token
-		login(ctx, cl, cl.immuClient, cl.pwr, cl.tkns.WithHds(client.NewHomedirService()).WithTokenFileName(viper.GetString("tokenfile")), user, defaultUser, defaultPassword, onSuccess)
-		selectDb(ctx, cl, cl.immuClient, cl.tkns.WithHds(client.NewHomedirService()).WithTokenFileName(viper.GetString("tokenfile")), db, onSuccess)
+		login(ctx, cl, cl.immuClient, cl.pwr, cl.tkns, user, defaultUser, defaultPassword, onSuccess)
+		selectDb(ctx, cl, cl.immuClient, cl.tkns, db, onSuccess)
 		nbEntries := parseNbEntries(args, cl)
 		fmt.Printf("Database %s will be populated with %d entries.\n", db, nbEntries)
 		askUserToConfirmOrCancel(cl.tr, cl)
@@ -134,7 +135,7 @@ func login(
 	cl *commandline,
 	immuClient client.ImmuClient,
 	pwr c.PasswordReader,
-	tkns client.TokenService,
+	tkns tokenservice.TokenService,
 	user string,
 	defaultUser string,
 	defaultPassword string,
@@ -171,7 +172,7 @@ func selectDb(
 	ctx context.Context,
 	cl *commandline,
 	immuClient client.ImmuClient,
-	tkns client.TokenService,
+	tkns tokenservice.TokenService,
 	db string,
 	onSuccess func()) {
 	response, err := immuClient.UseDatabase(ctx, &schema.Database{DatabaseName: db})

--- a/cmd/immutest/immutest.go
+++ b/cmd/immutest/immutest.go
@@ -17,6 +17,9 @@ limitations under the License.
 package main
 
 import (
+	"github.com/codenotary/immudb/pkg/client/homedir"
+	"github.com/codenotary/immudb/pkg/client/tokenservice"
+	"github.com/spf13/viper"
 	"os"
 
 	c "github.com/codenotary/immudb/cmd/helper"
@@ -30,7 +33,7 @@ func main() {
 		client.NewImmuClient,
 		c.DefaultPasswordReader,
 		c.NewTerminalReader(os.Stdin),
-		client.NewTokenService(),
+		tokenservice.NewFileTokenService().WithHds(homedir.NewHomedirService()).WithTokenFileName(viper.GetString("tokenfile")),
 		c.QuitWithUserError,
 		nil)
 	if err != nil {
@@ -43,7 +46,7 @@ func execute(
 	newImmuClient func(*client.Options) (client.ImmuClient, error),
 	pwr c.PasswordReader,
 	tr c.TerminalReader,
-	ts client.TokenService,
+	ts tokenservice.TokenService,
 	onError func(err error),
 	args []string,
 ) error {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -482,10 +482,10 @@ func (c *immuClient) Login(ctx context.Context, user []byte, pass []byte) (*sche
 
 	err = c.Tkns.SetToken("defaultdb", result.Token)
 	if err != nil {
-		return nil, err
+		return nil, errors.FromError(err)
 	}
 
-	return result, errors.FromError(err)
+	return result, nil
 }
 
 // Logout ...

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -23,6 +23,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"github.com/codenotary/immudb/pkg/client/tokenservice"
 	"io"
 	"io/ioutil"
 	"os"
@@ -75,7 +76,7 @@ type ImmuClient interface {
 	WithStateService(rs state.StateService) *immuClient
 	WithClientConn(clientConn *grpc.ClientConn) *immuClient
 	WithServiceClient(serviceClient schema.ImmuServiceClient) *immuClient
-	WithTokenService(tokenService TokenService) *immuClient
+	WithTokenService(tokenService tokenservice.TokenService) *immuClient
 	WithServerSigningPubKey(serverSigningPubKey *ecdsa.PublicKey) *immuClient
 	WithStreamServiceFactory(ssf stream.ServiceFactory) *immuClient
 
@@ -166,7 +167,7 @@ type immuClient struct {
 	clientConn           *grpc.ClientConn
 	ServiceClient        schema.ImmuServiceClient
 	StateService         state.StateService
-	Tkns                 TokenService
+	Tkns                 tokenservice.TokenService
 	serverSigningPubKey  *ecdsa.PublicKey
 	StreamServiceFactory stream.ServiceFactory
 	sync.RWMutex
@@ -190,7 +191,7 @@ func NewImmuClient(options *Options) (c ImmuClient, err error) {
 	c.WithOptions(options)
 	l := logger.NewSimpleLogger("immuclient", os.Stderr)
 	c.WithLogger(l)
-	c.WithTokenService(options.Tkns.WithTokenFileName(options.TokenFileName))
+	c.WithTokenService(options.Tkns)
 
 	if options.ServerSigningPubKey != "" {
 		pk, err := signer.ParsePublicKeyFile(options.ServerSigningPubKey)
@@ -316,6 +317,8 @@ func (c *immuClient) SetupDialOptions(options *Options) *[]grpc.DialOption {
 			opts = append(opts, grpc.WithStreamInterceptor(auth.ClientStreamInterceptor(token)))
 		}
 	}
+	uic = append(uic, c.TokenInterceptor)
+
 	opts = append(opts, grpc.WithUnaryInterceptor(grpc_middleware.ChainUnaryClient(uic...)), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(options.MaxRecvMsgSize)))
 
 	return &opts
@@ -472,8 +475,15 @@ func (c *immuClient) Login(ctx context.Context, user []byte, pass []byte) (*sche
 		User:     user,
 		Password: pass,
 	})
-
+	if err != nil {
+		return nil, errors.FromError(err)
+	}
 	c.Logger.Debugf("login finished in %s", time.Since(start))
+
+	err = c.Tkns.SetToken("defaultdb", result.Token)
+	if err != nil {
+		return nil, err
+	}
 
 	return result, errors.FromError(err)
 }
@@ -1371,12 +1381,20 @@ func (c *immuClient) UseDatabase(ctx context.Context, db *schema.Database) (*sch
 	}
 
 	result, err := c.ServiceClient.UseDatabase(ctx, db)
+	if err != nil {
+		return nil, errors.FromError(err)
+	}
 
 	c.Options.CurrentDatabase = db.DatabaseName
 
+	err = c.Tkns.SetToken("defaultdb", result.Token)
+	if err != nil {
+		return nil, errors.FromError(err)
+	}
+
 	c.Logger.Debugf("UseDatabase finished in %s", time.Since(start))
 
-	return result, err
+	return result, errors.FromError(err)
 }
 
 // UpdateDatabase updates database settings

--- a/pkg/client/clienttest/homedir_mock.go
+++ b/pkg/client/clienttest/homedir_mock.go
@@ -17,11 +17,13 @@ limitations under the License.
 // Package clienttest ...
 package clienttest
 
-import "github.com/codenotary/immudb/pkg/client"
+import (
+	"github.com/codenotary/immudb/pkg/client/homedir"
+)
 
 // HomedirServiceMock ...
 type HomedirServiceMock struct {
-	client.HomedirService
+	homedir.HomedirService
 	WriteFileToUserHomeDirF    func(content []byte, pathToFile string) error
 	FileExistsInUserHomeDirF   func(pathToFile string) (bool, error)
 	ReadFileFromUserHomeDirF   func(pathToFile string) (string, error)

--- a/pkg/client/clienttest/token_service_mock.go
+++ b/pkg/client/clienttest/token_service_mock.go
@@ -17,11 +17,12 @@ limitations under the License.
 package clienttest
 
 import (
-	"github.com/codenotary/immudb/pkg/client"
+	"github.com/codenotary/immudb/pkg/client/homedir"
+	"github.com/codenotary/immudb/pkg/client/tokenservice"
 )
 
 type TokenServiceMock struct {
-	client.TokenService
+	tokenservice.TokenService
 	GetTokenF       func() (string, error)
 	SetTokenF       func(database string, token string) error
 	IsTokenPresentF func() (bool, error)
@@ -48,11 +49,11 @@ func (ts TokenServiceMock) GetDatabase() (string, error) {
 	return "", nil
 }
 
-func (ts TokenServiceMock) WithHds(hds client.HomedirService) client.TokenService {
+func (ts TokenServiceMock) WithHds(hds homedir.HomedirService) tokenservice.TokenService {
 	return ts
 }
 
-func (ts TokenServiceMock) WithTokenFileName(tfn string) client.TokenService {
+func (ts TokenServiceMock) WithTokenFileName(tfn string) tokenservice.TokenService {
 	return ts
 }
 

--- a/pkg/client/homedir/homedir.go
+++ b/pkg/client/homedir/homedir.go
@@ -1,4 +1,20 @@
-package client
+/*
+Copyright 2021 CodeNotary, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package homedir
 
 import (
 	"io/ioutil"

--- a/pkg/client/homedir/homedir_test.go
+++ b/pkg/client/homedir/homedir_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package client
+package homedir
 
 import (
 	"os"

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -18,6 +18,8 @@ package client
 
 import (
 	"encoding/json"
+	"github.com/codenotary/immudb/pkg/client/homedir"
+	"github.com/codenotary/immudb/pkg/client/tokenservice"
 	"strconv"
 
 	"github.com/codenotary/immudb/pkg/stream"
@@ -49,7 +51,7 @@ type Options struct {
 	Password       string
 	Database       string
 	//<--
-	Tkns                TokenService
+	Tkns                tokenservice.TokenService
 	Metrics             bool
 	PidPath             string
 	LogFileName         string
@@ -71,7 +73,7 @@ func DefaultOptions() *Options {
 		TokenFileName:       "token",
 		DialOptions:         &[]grpc.DialOption{},
 		PasswordReader:      c.DefaultPasswordReader,
-		Tkns:                NewTokenService().WithTokenFileName("token").WithHds(NewHomedirService()),
+		Tkns:                tokenservice.NewFileTokenService().WithTokenFileName("token").WithHds(homedir.NewHomedirService()),
 		Metrics:             true,
 		PidPath:             "",
 		LogFileName:         "",
@@ -196,7 +198,7 @@ func (o *Options) WithDatabase(database string) *Options {
 }
 
 // WithTokenService sets the TokenService for the client
-func (o *Options) WithTokenService(tkns TokenService) *Options {
+func (o *Options) WithTokenService(tkns tokenservice.TokenService) *Options {
 	o.Tkns = tkns
 	return o
 }

--- a/pkg/client/token_interceptor.go
+++ b/pkg/client/token_interceptor.go
@@ -26,9 +26,11 @@ import (
 // TokenInterceptor inject token from tokenservice if present and if provided context contain no one
 func (c *immuClient) TokenInterceptor(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 	if md, ok := metadata.FromOutgoingContext(ctx); !ok || len(md.Get("authorization")) == 0 {
-		if token, err := c.Tkns.GetToken(); err == nil && token != "" {
-			ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs("authorization", token))
+		token, err := c.Tkns.GetToken()
+		if err != nil {
+			return err
 		}
+		ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs("authorization", token))
 	}
 	ris := invoker(ctx, method, req, reply, cc, opts...)
 	return ris

--- a/pkg/client/token_interceptor.go
+++ b/pkg/client/token_interceptor.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2021 CodeNotary, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"google.golang.org/grpc/metadata"
+
+	"google.golang.org/grpc"
+)
+
+// TokenInterceptor inject token from tokenservice if present and if provided context contain no one
+func (c *immuClient) TokenInterceptor(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	var ctxToken string
+	if md, ok := metadata.FromOutgoingContext(ctx); ok && len(md.Get("authorization")) > 0 {
+		ctxToken = md.Get("authorization")[0]
+	}
+	if token, err := c.Tkns.GetToken(); ctxToken == "" && err == nil {
+		md := metadata.Pairs("authorization", token)
+		ctx = metadata.NewOutgoingContext(ctx, md)
+	}
+	ris := invoker(ctx, method, req, reply, cc, opts...)
+
+	return ris
+}

--- a/pkg/client/tokenservice/errors.go
+++ b/pkg/client/tokenservice/errors.go
@@ -20,5 +20,6 @@ import "errors"
 
 // Errors related to Client connection and health check
 var (
-	ErrEmptyTokenProvided = errors.New("empty token provided")
+	ErrEmptyTokenProvided     = errors.New("empty token provided")
+	ErrTokenContentNotPresent = errors.New("token content not present")
 )

--- a/pkg/client/tokenservice/errors.go
+++ b/pkg/client/tokenservice/errors.go
@@ -16,26 +16,9 @@ limitations under the License.
 
 package tokenservice
 
-import (
-	"github.com/stretchr/testify/require"
-	"testing"
-)
+import "errors"
 
-func TestNewInmemoryTokenService(t *testing.T) {
-	ts := NewInmemoryTokenService()
-	err := ts.SetToken("db1", "")
-	require.Equal(t, ErrEmptyTokenProvided, err)
-	err = ts.SetToken("db", "tk")
-	require.NoError(t, err)
-	present, err := ts.IsTokenPresent()
-	require.True(t, present)
-	require.NoError(t, err)
-	db, err := ts.GetDatabase()
-	require.Equal(t, db, "db")
-	require.NoError(t, err)
-	tk, err := ts.GetToken()
-	require.NoError(t, err)
-	require.Equal(t, tk, "tk")
-	err = ts.DeleteToken()
-	require.NoError(t, err)
-}
+// Errors related to Client connection and health check
+var (
+	ErrEmptyTokenProvided = errors.New("empty token provided")
+)

--- a/pkg/client/tokenservice/file.go
+++ b/pkg/client/tokenservice/file.go
@@ -14,35 +14,29 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package client
+package tokenservice
 
 import (
 	"encoding/binary"
 	"errors"
+	"github.com/codenotary/immudb/pkg/client/homedir"
 	"strings"
 )
 
-type TokenService interface {
-	SetToken(database string, token string) error
-	WithHds(hds HomedirService) TokenService
-	WithTokenFileName(tfn string) TokenService
-	IsTokenPresent() (bool, error)
-	DeleteToken() error
-	GetToken() (string, error)
-	GetDatabase() (string, error)
-}
-
-type tokenService struct {
+type file struct {
 	tokenFileName string
-	hds           HomedirService
+	hds           homedir.HomedirService
 }
 
-//NewTokenService ...
-func NewTokenService() TokenService {
-	return &tokenService{}
+//NewFileTokenService ...
+func NewFileTokenService() *file {
+	return &file{
+		tokenFileName: "token",
+		hds:           homedir.NewHomedirService(),
+	}
 }
 
-func (ts *tokenService) GetToken() (string, error) {
+func (ts *file) GetToken() (string, error) {
 	_, token, err := ts.parseContent()
 	if err != nil {
 		return "", err
@@ -51,7 +45,7 @@ func (ts *tokenService) GetToken() (string, error) {
 }
 
 //SetToken ...
-func (ts *tokenService) SetToken(database string, token string) error {
+func (ts *file) SetToken(database string, token string) error {
 	return ts.hds.WriteFileToUserHomeDir(BuildToken(database, token), ts.tokenFileName)
 }
 
@@ -67,21 +61,21 @@ func BuildToken(database string, token string) []byte {
 	return cnt
 }
 
-func (ts *tokenService) DeleteToken() error {
+func (ts *file) DeleteToken() error {
 	return ts.hds.DeleteFileFromUserHomeDir(ts.tokenFileName)
 }
 
 //IsTokenPresent ...
-func (ts *tokenService) IsTokenPresent() (bool, error) {
+func (ts *file) IsTokenPresent() (bool, error) {
 	return ts.hds.FileExistsInUserHomeDir(ts.tokenFileName)
 }
 
-func (ts *tokenService) GetDatabase() (string, error) {
+func (ts *file) GetDatabase() (string, error) {
 	dbname, _, err := ts.parseContent()
 	return dbname, err
 }
 
-func (ts *tokenService) parseContent() (string, string, error) {
+func (ts *file) parseContent() (string, string, error) {
 	content, err := ts.hds.ReadFileFromUserHomeDir(ts.tokenFileName)
 	if err != nil {
 		return "", "", err
@@ -109,13 +103,13 @@ func (ts *tokenService) parseContent() (string, string, error) {
 }
 
 // WithHds ...
-func (ts *tokenService) WithHds(hds HomedirService) TokenService {
+func (ts *file) WithHds(hds homedir.HomedirService) *file {
 	ts.hds = hds
 	return ts
 }
 
 // WithTokenFileName ...
-func (ts *tokenService) WithTokenFileName(tfn string) TokenService {
+func (ts *file) WithTokenFileName(tfn string) *file {
 	ts.tokenFileName = tfn
 	return ts
 }

--- a/pkg/client/tokenservice/inmemory.go
+++ b/pkg/client/tokenservice/inmemory.go
@@ -33,6 +33,9 @@ func NewInmemoryTokenService() *inmemoryTokenService {
 func (m *inmemoryTokenService) SetToken(database string, token string) error {
 	m.Lock()
 	defer m.Unlock()
+	if token == "" {
+		return ErrEmptyTokenProvided
+	}
 	m.token = token
 	m.database = database
 	return nil

--- a/pkg/client/tokenservice/inmemory.go
+++ b/pkg/client/tokenservice/inmemory.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2021 CodeNotary, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tokenservice
+
+import (
+	"sync"
+)
+
+type inmemoryTokenService struct {
+	sync.Mutex
+	token    string
+	database string
+}
+
+func NewInmemoryTokenService() *inmemoryTokenService {
+	return &inmemoryTokenService{}
+}
+
+func (m *inmemoryTokenService) SetToken(database string, token string) error {
+	m.Lock()
+	defer m.Unlock()
+	m.token = token
+	m.database = database
+	return nil
+}
+
+func (m *inmemoryTokenService) IsTokenPresent() (bool, error) {
+	m.Lock()
+	defer m.Unlock()
+	return m.token != "", nil
+}
+
+func (m *inmemoryTokenService) DeleteToken() error {
+	m.Lock()
+	defer m.Unlock()
+	m.token = ""
+	m.database = ""
+	return nil
+}
+
+func (m *inmemoryTokenService) GetToken() (string, error) {
+	m.Lock()
+	defer m.Unlock()
+	return m.token, nil
+}
+
+func (m *inmemoryTokenService) GetDatabase() (string, error) {
+	m.Lock()
+	defer m.Unlock()
+	return m.database, nil
+}

--- a/pkg/client/tokenservice/inmemory_test.go
+++ b/pkg/client/tokenservice/inmemory_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2021 CodeNotary, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tokenservice
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestNewInmemoryTokenService(t *testing.T) {
+	ts := NewInmemoryTokenService()
+	err := ts.SetToken("db", "tk")
+	require.NoError(t, err)
+	_, err = ts.IsTokenPresent()
+	require.NoError(t, err)
+	_, err = ts.GetDatabase()
+	require.NoError(t, err)
+	_, err = ts.GetToken()
+	require.NoError(t, err)
+	err = ts.DeleteToken()
+	require.NoError(t, err)
+}

--- a/pkg/client/tokenservice/token_service.go
+++ b/pkg/client/tokenservice/token_service.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2021 CodeNotary, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tokenservice
+
+type TokenService interface {
+	SetToken(database string, token string) error
+	IsTokenPresent() (bool, error)
+	DeleteToken() error
+	GetToken() (string, error)
+	GetDatabase() (string, error)
+}

--- a/pkg/client/tokenservice/token_service_test.go
+++ b/pkg/client/tokenservice/token_service_test.go
@@ -21,21 +21,22 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestTokenSevice_setToken(t *testing.T) {
 	fn := "deleteme"
 	ts := file{tokenFileName: fn, hds: homedir.NewHomedirService()}
-	err := ts.SetToken("db1", "toooooken")
-	assert.Nil(t, err)
+	err := ts.SetToken("db1", "")
+	require.Equal(t, ErrEmptyTokenProvided, err)
+	err = ts.SetToken("db1", "toooooken")
+	require.Nil(t, err)
 	database, err := ts.GetDatabase()
-	assert.Nil(t, err)
-	assert.Equal(t, "db1", database)
+	require.Nil(t, err)
+	require.Equal(t, "db1", database)
 	token, err := ts.GetToken()
-	assert.Nil(t, err)
-	assert.Equal(t, "toooooken", token)
+	require.Nil(t, err)
+	require.Equal(t, "toooooken", token)
 	os.Remove(fn)
 }
 
@@ -46,7 +47,7 @@ func TestTokenService_IsTokenPresent(t *testing.T) {
 	require.Nil(t, err)
 	ok, err := ts.IsTokenPresent()
 	require.Nil(t, err)
-	assert.True(t, ok)
+	require.True(t, ok)
 }
 
 func TestTokenService_DeleteToken(t *testing.T) {
@@ -55,5 +56,5 @@ func TestTokenService_DeleteToken(t *testing.T) {
 	err := ts.SetToken("db1", "toooooken")
 	require.Nil(t, err)
 	err = ts.DeleteToken()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }

--- a/pkg/client/tokenservice/token_service_test.go
+++ b/pkg/client/tokenservice/token_service_test.go
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package client
+package tokenservice
 
 import (
+	"github.com/codenotary/immudb/pkg/client/homedir"
 	"os"
 	"testing"
 
@@ -26,7 +27,7 @@ import (
 
 func TestTokenSevice_setToken(t *testing.T) {
 	fn := "deleteme"
-	ts := tokenService{tokenFileName: fn, hds: NewHomedirService()}
+	ts := file{tokenFileName: fn, hds: homedir.NewHomedirService()}
 	err := ts.SetToken("db1", "toooooken")
 	assert.Nil(t, err)
 	database, err := ts.GetDatabase()
@@ -40,7 +41,7 @@ func TestTokenSevice_setToken(t *testing.T) {
 
 func TestTokenService_IsTokenPresent(t *testing.T) {
 	fn := "deleteme"
-	ts := tokenService{tokenFileName: fn, hds: NewHomedirService()}
+	ts := file{tokenFileName: fn, hds: homedir.NewHomedirService()}
 	err := ts.SetToken("db1", "toooooken")
 	require.Nil(t, err)
 	ok, err := ts.IsTokenPresent()
@@ -50,7 +51,7 @@ func TestTokenService_IsTokenPresent(t *testing.T) {
 
 func TestTokenService_DeleteToken(t *testing.T) {
 	fn := "deleteme"
-	ts := tokenService{tokenFileName: fn, hds: NewHomedirService()}
+	ts := file{tokenFileName: fn, hds: homedir.NewHomedirService()}
 	err := ts.SetToken("db1", "toooooken")
 	require.Nil(t, err)
 	err = ts.DeleteToken()

--- a/pkg/client/types.go
+++ b/pkg/client/types.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"crypto/ecdsa"
+	"github.com/codenotary/immudb/pkg/client/tokenservice"
 	"github.com/codenotary/immudb/pkg/stream"
 
 	"github.com/codenotary/immudb/pkg/api/schema"
@@ -46,7 +47,7 @@ func (c *immuClient) WithServiceClient(serviceClient schema.ImmuServiceClient) *
 	return c
 }
 
-func (c *immuClient) WithTokenService(tokenService TokenService) *immuClient {
+func (c *immuClient) WithTokenService(tokenService tokenservice.TokenService) *immuClient {
 	c.Tkns = tokenService
 	return c
 }

--- a/pkg/integration/auditor_test.go
+++ b/pkg/integration/auditor_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"fmt"
+	"github.com/codenotary/immudb/pkg/client/homedir"
+	"github.com/codenotary/immudb/pkg/client/tokenservice"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -111,7 +113,7 @@ func TestDefaultAuditorRunOnDb(t *testing.T) {
 	dialOptions := []grpc.DialOption{
 		grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure(),
 	}
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(client.NewHomedirService())
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(homedir.NewHomedirService())
 	cliopt := client.DefaultOptions().WithDialOptions(&dialOptions).WithPasswordReader(pr).WithTokenService(ts)
 
 	cliopt.PasswordReader = pr
@@ -175,7 +177,7 @@ func TestRepeatedAuditorRunOnDb(t *testing.T) {
 	dialOptions := []grpc.DialOption{
 		grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure(),
 	}
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(client.NewHomedirService())
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(homedir.NewHomedirService())
 	cliopt := client.DefaultOptions().WithDialOptions(&dialOptions).WithPasswordReader(pr).WithTokenService(ts)
 
 	cliopt.PasswordReader = pr
@@ -273,7 +275,7 @@ func testDefaultAuditorRunOnDbWithSignature(t *testing.T, pk *ecdsa.PublicKey) {
 	dialOptions := []grpc.DialOption{
 		grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure(),
 	}
-	ts := client.NewTokenService().WithTokenFileName("testTokenFile").WithHds(client.NewHomedirService())
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(homedir.NewHomedirService())
 	cliopt := client.DefaultOptions().WithDialOptions(&dialOptions).WithPasswordReader(pr).WithTokenService(ts)
 
 	cliopt.PasswordReader = pr

--- a/pkg/integration/client_test.go
+++ b/pkg/integration/client_test.go
@@ -18,6 +18,8 @@ package integration
 import (
 	"context"
 	"errors"
+	"github.com/codenotary/immudb/pkg/client/homedir"
+	"github.com/codenotary/immudb/pkg/client/tokenservice"
 	"log"
 	"os"
 	"path"
@@ -232,7 +234,7 @@ func TestImmuClient(t *testing.T) {
 	bs.Start()
 	defer bs.Stop()
 
-	ts := ic.NewTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
 	opts := ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(ts)
 	client, err := ic.NewImmuClient(opts.WithServerSigningPubKey("./../../test/signer/ec1.pub"))
 	if err != nil {
@@ -276,7 +278,7 @@ func TestImmuClientTampering(t *testing.T) {
 	bs.Start()
 	defer bs.Stop()
 
-	ts := ic.NewTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
 	opts := ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(ts)
 	client, err := ic.NewImmuClient(opts.WithServerSigningPubKey("./../../test/signer/ec1.pub"))
 	if err != nil {
@@ -426,7 +428,7 @@ func TestReplica(t *testing.T) {
 	bs.Start()
 	defer bs.Stop()
 
-	ts := ic.NewTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
 	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(ts))
 	if err != nil {
 		log.Fatal(err)
@@ -474,7 +476,7 @@ func TestDatabasesSwitching(t *testing.T) {
 	bs.Start()
 	defer bs.Stop()
 
-	ts := ic.NewTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
 	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(ts))
 	if err != nil {
 		log.Fatal(err)
@@ -535,7 +537,7 @@ func TestImmuClientDisconnect(t *testing.T) {
 	bs.Start()
 	defer bs.Stop()
 
-	ts := ic.NewTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
 	opts := ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(ts)
 	client, err := ic.NewImmuClient(opts.WithServerSigningPubKey("./../../test/signer/ec1.pub"))
 	if err != nil {
@@ -660,7 +662,7 @@ func TestImmuClientDisconnectNotConn(t *testing.T) {
 	bs.Start()
 	defer bs.Stop()
 
-	ts := ic.NewTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
 	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(ts))
 	if err != nil {
 		log.Fatal(err)
@@ -682,7 +684,7 @@ func TestWaitForHealthCheck(t *testing.T) {
 	bs.Start()
 	defer bs.Stop()
 
-	ts := ic.NewTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
 	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(ts))
 	if err != nil {
 		log.Fatal(err)
@@ -733,7 +735,7 @@ func TestUserManagement(t *testing.T) {
 	bs.Start()
 	defer bs.Stop()
 
-	ts := ic.NewTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
 	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(ts))
 	if err != nil {
 		log.Fatal(err)
@@ -827,7 +829,7 @@ func TestDatabaseManagement(t *testing.T) {
 	bs.Start()
 	defer bs.Stop()
 
-	ts := ic.NewTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
 	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(ts))
 	if err != nil {
 		log.Fatal(err)
@@ -860,7 +862,7 @@ func TestImmuClient_History(t *testing.T) {
 	bs.Start()
 	defer bs.Stop()
 
-	ts := ic.NewTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
 	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(ts))
 	if err != nil {
 		log.Fatal(err)
@@ -898,7 +900,7 @@ func TestImmuClient_SetAll(t *testing.T) {
 	bs.Start()
 	defer bs.Stop()
 
-	ts := ic.NewTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
 	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(ts))
 	if err != nil {
 		log.Fatal(err)
@@ -953,7 +955,7 @@ func TestImmuClient_GetAll(t *testing.T) {
 	bs.Start()
 	defer bs.Stop()
 
-	ts := ic.NewTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
 	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(ts))
 	if err != nil {
 		log.Fatal(err)
@@ -993,7 +995,7 @@ func TestImmuClient_ExecAllOpsOptions(t *testing.T) {
 	bs.Start()
 	defer bs.Stop()
 
-	ts := ic.NewTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
 	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(ts))
 	if err != nil {
 		log.Fatal(err)
@@ -1036,7 +1038,7 @@ func TestImmuClient_Scan(t *testing.T) {
 	bs.Start()
 	defer bs.Stop()
 
-	ts := ic.NewTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
 	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(ts))
 	if err != nil {
 		log.Fatal(err)
@@ -1070,7 +1072,7 @@ func TestImmuClient_TxScan(t *testing.T) {
 	bs.Start()
 	defer bs.Stop()
 
-	ts := ic.NewTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
 	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(ts))
 	if err != nil {
 		log.Fatal(err)
@@ -1125,7 +1127,7 @@ func TestImmuClient_Logout(t *testing.T) {
 	bs.Start()
 	defer bs.Stop()
 
-	ts1 := ic.NewTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
+	ts1 := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
 	ts2 := &TokenServiceMock{
 		TokenService: ts1,
 		GetTokenF:    ts1.GetToken,
@@ -1142,7 +1144,7 @@ func TestImmuClient_Logout(t *testing.T) {
 	ts3.IsTokenPresentF = func() (bool, error) {
 		return true, nil
 	}
-	tokenServices := []ic.TokenService{ts1, ts2, &ts3}
+	tokenServices := []tokenservice.TokenService{ts1, ts2, &ts3}
 	expectations := []func(error){
 		func(err error) { require.Nil(t, err) },
 		func(err error) {
@@ -1187,7 +1189,7 @@ func TestImmuClient_GetServiceClient(t *testing.T) {
 	bs.Start()
 	defer bs.Stop()
 
-	ts := ic.NewTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
 	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(ts))
 	if err != nil {
 		log.Fatal(err)
@@ -1214,7 +1216,7 @@ func TestImmuClient_CurrentRoot(t *testing.T) {
 	bs.Start()
 	defer bs.Stop()
 
-	ts := ic.NewTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
 	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(ts))
 	if err != nil {
 		log.Fatal(err)
@@ -1245,7 +1247,7 @@ func TestImmuClient_Count(t *testing.T) {
 	bs.Start()
 	defer bs.Stop()
 
-	ts := ic.NewTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
 	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(ts))
 	if err != nil {
 		log.Fatal(err)
@@ -1271,7 +1273,7 @@ func TestImmuClient_CountAll(t *testing.T) {
 	bs.Start()
 	defer bs.Stop()
 
-	ts := ic.NewTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
 	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(ts))
 	if err != nil {
 		log.Fatal(err)
@@ -1405,7 +1407,7 @@ func TestEnforcedLogoutAfterPasswordChange(t *testing.T) {
 	bs.Start()
 	defer bs.Stop()
 
-	ts := ic.NewTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
 	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(ts))
 	if err != nil {
 		log.Fatal(err)
@@ -1485,7 +1487,7 @@ func TestImmuClient_CurrentStateVerifiedSignature(t *testing.T) {
 	}
 	defer bs.Stop()
 
-	ts := ic.NewTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
 	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(ts).WithServerSigningPubKey("./../../test/signer/ec1.pub"))
 	if err != nil {
 		log.Fatal(err)
@@ -1512,7 +1514,7 @@ func TestImmuClient_VerifiedGetAt(t *testing.T) {
 	bs.Start()
 	defer bs.Stop()
 
-	ts := ic.NewTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
 	opts := ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(ts)
 	client, err := ic.NewImmuClient(opts.WithServerSigningPubKey("./../../test/signer/ec1.pub"))
 	if err != nil {
@@ -1558,7 +1560,7 @@ func TestImmuClient_VerifiedGetSince(t *testing.T) {
 	bs.Start()
 	defer bs.Stop()
 
-	ts := ic.NewTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
 	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(ts))
 	if err != nil {
 		log.Fatal(err)
@@ -1679,7 +1681,7 @@ func TestImmuClient_BackupAndRestoreUX(t *testing.T) {
 }
 
 type HomedirServiceMock struct {
-	ic.HomedirService
+	homedir.HomedirService
 	WriteFileToUserHomeDirF    func(content []byte, pathToFile string) error
 	FileExistsInUserHomeDirF   func(pathToFile string) (bool, error)
 	ReadFileFromUserHomeDirF   func(pathToFile string) (string, error)
@@ -1725,7 +1727,7 @@ func DefaultHomedirServiceMock() *HomedirServiceMock {
 }
 
 type TokenServiceMock struct {
-	ic.TokenService
+	tokenservice.TokenService
 	GetTokenF       func() (string, error)
 	SetTokenF       func(database string, token string) error
 	IsTokenPresentF func() (bool, error)
@@ -1752,10 +1754,10 @@ func (ts TokenServiceMock) GetDatabase() (string, error) {
 	return "", nil
 }
 
-func (ts TokenServiceMock) WithHds(hds ic.HomedirService) ic.TokenService {
+func (ts TokenServiceMock) WithHds(hds homedir.HomedirService) tokenservice.TokenService {
 	return ts
 }
 
-func (ts TokenServiceMock) WithTokenFileName(tfn string) ic.TokenService {
+func (ts TokenServiceMock) WithTokenFileName(tfn string) tokenservice.TokenService {
 	return ts
 }

--- a/pkg/integration/client_test.go
+++ b/pkg/integration/client_test.go
@@ -477,14 +477,15 @@ func TestDatabasesSwitching(t *testing.T) {
 	defer bs.Stop()
 
 	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
-	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(ts))
-	if err != nil {
-		log.Fatal(err)
-	}
+	client, err := ic.NewImmuClient(
+		ic.DefaultOptions().
+			WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).
+			WithTokenService(ts))
+	require.NoError(t, err)
+
 	lr, err := client.Login(context.TODO(), []byte(`immudb`), []byte(`immudb`))
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	md := metadata.Pairs("authorization", lr.Token)
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
 
@@ -537,14 +538,14 @@ func TestDatabasesSwitchingWithInMemoryToken(t *testing.T) {
 	bs.Start()
 	defer bs.Stop()
 
-	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(tokenservice.NewInmemoryTokenService()))
-	if err != nil {
-		log.Fatal(err)
-	}
+	client, err := ic.NewImmuClient(
+		ic.DefaultOptions().
+			WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).
+			WithTokenService(tokenservice.NewInmemoryTokenService()))
+	require.NoError(t, err)
+
 	_, err = client.Login(context.TODO(), []byte(`immudb`), []byte(`immudb`))
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	err = client.CreateDatabase(context.TODO(), &schema.DatabaseSettings{
 		DatabaseName: "db1",

--- a/pkg/integration/server_recovery_test.go
+++ b/pkg/integration/server_recovery_test.go
@@ -28,7 +28,8 @@ func TestServerRecovertMode(t *testing.T) {
 	serverOptions := server.DefaultOptions().
 		WithMetricsServer(false).
 		WithMaintenance(true).
-		WithAuth(true)
+		WithAuth(true).
+		WithPort(0)
 	s := server.DefaultServer().WithOptions(serverOptions).(*server.ImmuServer)
 	defer os.RemoveAll(s.Options.Dir)
 
@@ -39,7 +40,8 @@ func TestServerRecovertMode(t *testing.T) {
 		WithMetricsServer(true).
 		WithPgsqlServer(true).
 		WithMaintenance(true).
-		WithAuth(false)
+		WithAuth(false).
+		WithPort(0)
 	s = server.DefaultServer().WithOptions(serverOptions).(*server.ImmuServer)
 
 	err = s.Initialize()

--- a/pkg/integration/stream_test.go
+++ b/pkg/integration/stream_test.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"github.com/codenotary/immudb/pkg/client/tokenservice"
 
 	ic "github.com/codenotary/immudb/pkg/client"
 	"github.com/codenotary/immudb/pkg/client/errors"
@@ -706,7 +707,7 @@ func TestImmuClient_StreamWithSignature(t *testing.T) {
 	}
 	defer bs.Stop()
 
-	ts := ic.NewTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
 	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(ts).WithServerSigningPubKey("./../../test/signer/ec1.pub"))
 	if err != nil {
 		log.Fatal(err)
@@ -747,7 +748,7 @@ func TestImmuClient_StreamWithSignatureErrors(t *testing.T) {
 	}
 	defer bs.Stop()
 
-	ts := ic.NewTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
 	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(ts).WithServerSigningPubKey("./../../test/signer/ec3.pub"))
 	if err != nil {
 		log.Fatal(err)
@@ -788,7 +789,7 @@ func TestImmuClient_StreamWithSignatureErrorsMissingServerKey(t *testing.T) {
 	}
 	defer bs.Stop()
 
-	ts := ic.NewTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
 	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(ts).WithServerSigningPubKey("./../../test/signer/ec3.pub"))
 	if err != nil {
 		log.Fatal(err)
@@ -830,7 +831,7 @@ func TestImmuClient_StreamWithSignatureErrorsWrongClientKey(t *testing.T) {
 	}
 	defer bs.Stop()
 
-	ts := ic.NewTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
 	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(ts).WithServerSigningPubKey("./../../test/signer/ec3.pub"))
 	if err != nil {
 		log.Fatal(err)
@@ -856,7 +857,7 @@ func TestImmuClient_StreamWithSignatureErrorsWrongClientKey(t *testing.T) {
 
 	client.Disconnect()
 
-	ts = ic.NewTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
+	ts = tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
 	client, err = ic.NewImmuClient(ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(ts).WithServerSigningPubKey("./../../test/signer/ec1.pub"))
 	if err != nil {
 		log.Fatal(err)
@@ -936,7 +937,7 @@ func TestImmuClient_StreamerServiceErrors(t *testing.T) {
 		return stream.NewExecAllStreamSender(str)
 	}
 
-	ts := ic.NewTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
 	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(ts))
 	if err != nil {
 		log.Fatal(err)
@@ -1041,7 +1042,7 @@ func TestImmuClient_StreamerServiceHistoryErrors(t *testing.T) {
 		return stream.NewZStreamReceiver(msr, 4096)
 	}
 
-	ts := ic.NewTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
+	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
 	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(ts))
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/integration/stream_test.go
+++ b/pkg/integration/stream_test.go
@@ -707,8 +707,9 @@ func TestImmuClient_StreamWithSignature(t *testing.T) {
 	}
 	defer bs.Stop()
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
-	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(ts).WithServerSigningPubKey("./../../test/signer/ec1.pub"))
+	ts := tokenservice.NewInmemoryTokenService()
+	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).
+		WithTokenService(ts).WithServerSigningPubKey("./../../test/signer/ec1.pub"))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -748,7 +749,7 @@ func TestImmuClient_StreamWithSignatureErrors(t *testing.T) {
 	}
 	defer bs.Stop()
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
+	ts := tokenservice.NewInmemoryTokenService()
 	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(ts).WithServerSigningPubKey("./../../test/signer/ec3.pub"))
 	if err != nil {
 		log.Fatal(err)
@@ -789,7 +790,7 @@ func TestImmuClient_StreamWithSignatureErrorsMissingServerKey(t *testing.T) {
 	}
 	defer bs.Stop()
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
+	ts := tokenservice.NewInmemoryTokenService()
 	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(ts).WithServerSigningPubKey("./../../test/signer/ec3.pub"))
 	if err != nil {
 		log.Fatal(err)
@@ -831,7 +832,7 @@ func TestImmuClient_StreamWithSignatureErrorsWrongClientKey(t *testing.T) {
 	}
 	defer bs.Stop()
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
+	ts := tokenservice.NewInmemoryTokenService()
 	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(ts).WithServerSigningPubKey("./../../test/signer/ec3.pub"))
 	if err != nil {
 		log.Fatal(err)
@@ -857,7 +858,7 @@ func TestImmuClient_StreamWithSignatureErrorsWrongClientKey(t *testing.T) {
 
 	client.Disconnect()
 
-	ts = tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
+	ts = tokenservice.NewInmemoryTokenService()
 	client, err = ic.NewImmuClient(ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(ts).WithServerSigningPubKey("./../../test/signer/ec1.pub"))
 	if err != nil {
 		log.Fatal(err)
@@ -937,7 +938,7 @@ func TestImmuClient_StreamerServiceErrors(t *testing.T) {
 		return stream.NewExecAllStreamSender(str)
 	}
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
+	ts := tokenservice.NewInmemoryTokenService()
 	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(ts))
 	if err != nil {
 		log.Fatal(err)
@@ -1042,7 +1043,7 @@ func TestImmuClient_StreamerServiceHistoryErrors(t *testing.T) {
 		return stream.NewZStreamReceiver(msr, 4096)
 	}
 
-	ts := tokenservice.NewFileTokenService().WithTokenFileName("testTokenFile").WithHds(DefaultHomedirServiceMock())
+	ts := tokenservice.NewInmemoryTokenService()
 	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(ts))
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/stdlib/sql_test.go
+++ b/pkg/stdlib/sql_test.go
@@ -22,6 +22,7 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"github.com/codenotary/immudb/pkg/client"
+	"github.com/codenotary/immudb/pkg/client/tokenservice"
 	"github.com/codenotary/immudb/pkg/server"
 	"github.com/codenotary/immudb/pkg/server/servertest"
 	"github.com/stretchr/testify/require"
@@ -294,7 +295,7 @@ func TestDriverConnector_ConnectLoginErr(t *testing.T) {
 	opts := client.DefaultOptions()
 	opts.Username = "wrongUsername"
 
-	opts.WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()})
+	opts.WithDialOptions(&[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithTokenService(tokenservice.NewInmemoryTokenService())
 
 	db := OpenDB(opts)
 	defer db.Close()


### PR DESCRIPTION
Token service interface now is implemented by:
**[inmemory](https://github.com/codenotary/immudb/blob/chore/decoupled-token-service/pkg/client/tokenservice/inmemory.go)** and **[file](https://github.com/codenotary/immudb/blob/chore/decoupled-token-service/pkg/client/tokenservice/file.go)** struct

WithHomedirService and WithTokenFilename was now removed from interface and are coupled only with file TokenService implementation.

[Login method](https://github.com/codenotary/immudb/blob/chore/decoupled-token-service/pkg/client/client.go#L467), useDatabase immuclient method now use token service to store token response before exit.
[Token interceptor](https://github.com/codenotary/immudb/blob/chore/decoupled-token-service/pkg/client/token_interceptor.go) if doesn't find a token in the context check if the token is present in the token service

Several tests are modified mainly for token service package movement, so no particular checks are needed on them IMO.
