### PR TITLE
auto-conversion from varchar to integer and boolean types

### DIFF
--- a/embedded/sql/engine.go
+++ b/embedded/sql/engine.go
@@ -1098,40 +1098,38 @@ func EncodeAsKey(val interface{}, colType SQLValueType, maxLen int) ([]byte, err
 
 func intFrom(val interface{}) (int64, error) {
 	intVal, ok := val.(int64)
-	if !ok {
-		str, ok := val.(string)
-		if !ok {
-			return 0, ErrInvalidValue
-		}
+	if ok {
+		return intVal, nil
+	}
 
-		n, err := strconv.Atoi(str)
+	str, ok := val.(string)
+	if ok {
+		intVal, err := strconv.Atoi(str)
 		if err != nil {
 			return 0, ErrInvalidValue
 		}
-
-		intVal = int64(n)
+		return int64(intVal), nil
 	}
 
-	return intVal, nil
+	return 0, ErrInvalidValue
 }
 
 func boolFrom(val interface{}) (bool, error) {
 	boolVal, ok := val.(bool)
-	if !ok {
-		str, ok := val.(string)
-		if !ok {
-			return false, ErrInvalidValue
-		}
+	if ok {
+		return boolVal, nil
+	}
 
-		b, err := strconv.ParseBool(str)
+	str, ok := val.(string)
+	if ok {
+		boolVal, err := strconv.ParseBool(str)
 		if err != nil {
 			return false, ErrInvalidValue
 		}
-
-		boolVal = b
+		return boolVal, nil
 	}
 
-	return boolVal, nil
+	return false, ErrInvalidValue
 }
 
 func DecodeValue(b []byte, colType SQLValueType) (TypedValue, int, error) {

--- a/embedded/sql/engine.go
+++ b/embedded/sql/engine.go
@@ -943,9 +943,9 @@ func EncodeValue(val interface{}, colType SQLValueType, maxLen int) ([]byte, err
 		}
 	case IntegerType:
 		{
-			intVal, ok := val.(int64)
-			if !ok {
-				return nil, ErrInvalidValue
+			intVal, err := intFrom(val)
+			if err != nil {
+				return nil, err
 			}
 
 			// map to unsigned integer space
@@ -958,9 +958,9 @@ func EncodeValue(val interface{}, colType SQLValueType, maxLen int) ([]byte, err
 		}
 	case BooleanType:
 		{
-			boolVal, ok := val.(bool)
-			if !ok {
-				return nil, ErrInvalidValue
+			boolVal, err := boolFrom(val)
+			if err != nil {
+				return nil, err
 			}
 
 			// len(v) + v
@@ -1037,9 +1037,9 @@ func EncodeAsKey(val interface{}, colType SQLValueType, maxLen int) ([]byte, err
 				return nil, ErrCorruptedData
 			}
 
-			intVal, ok := val.(int64)
-			if !ok {
-				return nil, ErrInvalidValue
+			intVal, err := intFrom(val)
+			if err != nil {
+				return nil, err
 			}
 
 			// v
@@ -1056,9 +1056,9 @@ func EncodeAsKey(val interface{}, colType SQLValueType, maxLen int) ([]byte, err
 				return nil, ErrCorruptedData
 			}
 
-			boolVal, ok := val.(bool)
-			if !ok {
-				return nil, ErrInvalidValue
+			boolVal, err := boolFrom(val)
+			if err != nil {
+				return nil, err
 			}
 
 			// v
@@ -1094,6 +1094,44 @@ func EncodeAsKey(val interface{}, colType SQLValueType, maxLen int) ([]byte, err
 	*/
 
 	return nil, ErrInvalidValue
+}
+
+func intFrom(val interface{}) (int64, error) {
+	intVal, ok := val.(int64)
+	if !ok {
+		str, ok := val.(string)
+		if !ok {
+			return 0, ErrInvalidValue
+		}
+
+		n, err := strconv.Atoi(str)
+		if err != nil {
+			return 0, ErrInvalidValue
+		}
+
+		intVal = int64(n)
+	}
+
+	return intVal, nil
+}
+
+func boolFrom(val interface{}) (bool, error) {
+	boolVal, ok := val.(bool)
+	if !ok {
+		str, ok := val.(string)
+		if !ok {
+			return false, ErrInvalidValue
+		}
+
+		b, err := strconv.ParseBool(str)
+		if err != nil {
+			return false, ErrInvalidValue
+		}
+
+		boolVal = b
+	}
+
+	return boolVal, nil
 }
 
 func DecodeValue(b []byte, colType SQLValueType) (TypedValue, int, error) {

--- a/embedded/sql/stmt_test.go
+++ b/embedded/sql/stmt_test.go
@@ -629,3 +629,19 @@ func TestIsConstant(t *testing.T) {
 
 	require.False(t, (&ExistsBoolExp{}).isConstant())
 }
+
+func TestComparisonWithTypeConversion(t *testing.T) {
+	r, err := (&Number{val: 0}).Compare(&Varchar{val: "0"})
+	require.NoError(t, err)
+	require.Zero(t, r)
+
+	_, err = (&Number{val: 0}).Compare(&Varchar{val: "invalid"})
+	require.ErrorIs(t, err, ErrNotComparableValues)
+
+	_, err = (&Bool{val: true}).Compare(&Varchar{val: "true"})
+	require.NoError(t, err)
+	require.Zero(t, r)
+
+	_, err = (&Bool{val: true}).Compare(&Varchar{val: "invalid"})
+	require.ErrorIs(t, err, ErrNotComparableValues)
+}


### PR DESCRIPTION
This PR provides automatic type conversion based on column specified type and provided varchar value (for integer and boolean types).

e.g. 
```sql
CREATE TABLE mytable(id INTEGER, name VARCHAR, active BOOLEAN, PRIMARY KEY id);

INSERT INTO mytable(id, name, active) VALUES ('1', 'name1', 'true');
```

Signed-off-by: Jeronimo Irazabal <jeronimo.irazabal@gmail.com>