### PR TITLE
Fix: env variable for immudb password must not be set 

### DIFF
--- a/Dockerfile.rndpass
+++ b/Dockerfile.rndpass
@@ -23,7 +23,6 @@ ENV IMMUDB_HOME="/usr/share/immudb" \
     IMMUDB_DETACHED="false" \
     IMMUDB_DEVMODE="true" \
     IMMUDB_MAINTENANCE="false" \
-    IMMUDB_ADMIN_PASSWORD="immudb" \
     IMMUADMIN_TOKENFILE="/var/lib/immudb/admin_token"
 
 RUN addgroup --system --gid $IMMU_GID immu && \


### PR DESCRIPTION
In order to random generate a password, the environmental variable `IMMUDB_ADMIN_PASSWORD` has to be unset, so I removed the default value in the (specific) Dockerfile

