### PR TITLE
Force default password change (or logout) for immuadmin command

### DIFF
--- a/cmd/immuadmin/command/login.go
+++ b/cmd/immuadmin/command/login.go
@@ -19,6 +19,7 @@ package immuadmin
 import (
 	"context"
 	"fmt"
+	"os"
 
 	c "github.com/codenotary/immudb/cmd/helper"
 	"github.com/codenotary/immudb/pkg/auth"
@@ -61,6 +62,9 @@ func (cl *commandline) login(cmd *cobra.Command) {
 
 				changedPassMsg, newPass, err := cl.changeUserPassword(userStr, pass)
 				if err != nil {
+					if err2 := cl.immuClient.Logout(cl.context); err2 != nil {
+						_, _ = fmt.Fprintln(os.Stderr, err.Error())
+					}
 					cl.quit(err)
 					return err
 				}


### PR DESCRIPTION
This ensure that the client, at least tries, to logout if your password change
fail. This only protects the CLI user interface, but still you can use the
default admin account to do all the operations through the underneath API.

Fixes #865