### PR TITLE
chore(embedded/sql): support for escaped strings

### DIFF
--- a/embedded/sql/engine_test.go
+++ b/embedded/sql/engine_test.go
@@ -787,7 +787,7 @@ func TestUpdate(t *testing.T) {
 	_, _, err = engine.Exec("CREATE DATABASE db1", nil, nil)
 	require.NoError(t, err)
 
-	_, _, err = engine.Exec("UPDATE table1 SET title = 'title11' WHERE title = 'title", nil, nil)
+	_, _, err = engine.Exec("UPDATE table1 SET title = 'title11' WHERE title = 'title'", nil, nil)
 	require.ErrorIs(t, err, ErrNoDatabaseSelected)
 
 	err = engine.SetDefaultDatabase("db1")
@@ -1368,7 +1368,7 @@ func TestQuery(t *testing.T) {
 	r, err = engine.Query(fmt.Sprintf(`
 		SELECT id, title, active
 		FROM table1
-		WHERE active = @some_param AND title > 'title' AND payload >= x'%s' AND title LIKE 't`, encPayloadPrefix), params, nil)
+		WHERE active = @some_param AND title > 'title' AND payload >= x'%s' AND title LIKE 't'`, encPayloadPrefix), params, nil)
 	require.NoError(t, err)
 
 	for i := 0; i < rowCount/2; i += 2 {
@@ -1427,7 +1427,7 @@ func TestQuery(t *testing.T) {
 	require.NoError(t, err)
 
 	r, err = engine.Query("INVALID QUERY", nil, nil)
-	require.EqualError(t, err, "syntax error: unexpected IDENTIFIER")
+	require.EqualError(t, err, "syntax error: unexpected IDENTIFIER at position 7")
 	require.Nil(t, r)
 
 	r, err = engine.Query("UPSERT INTO table1 (id) VALUES(1)", nil, nil)
@@ -2201,7 +2201,7 @@ func TestExecCornerCases(t *testing.T) {
 	require.NoError(t, err)
 
 	tx, _, err := engine.Exec("INVALID STATEMENT", nil, nil)
-	require.EqualError(t, err, "syntax error: unexpected IDENTIFIER")
+	require.EqualError(t, err, "syntax error: unexpected IDENTIFIER at position 7")
 	require.Nil(t, tx)
 }
 
@@ -3506,7 +3506,7 @@ func TestInferParameters(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = engine.InferParameters("invalid sql stmt", nil)
-	require.EqualError(t, err, "syntax error: unexpected IDENTIFIER")
+	require.EqualError(t, err, "syntax error: unexpected IDENTIFIER at position 7")
 
 	_, err = engine.InferParametersPreparedStmts(nil, nil)
 	require.ErrorIs(t, err, ErrIllegalArguments)

--- a/embedded/sql/parser_test.go
+++ b/embedded/sql/parser_test.go
@@ -298,7 +298,7 @@ func TestInsertIntoStmt(t *testing.T) {
 		expectedError  error
 	}{
 		{
-			input: "UPSERT INTO table1(id, time, title, active, compressed, payload, note) VALUES (2, now(), 'untitled row', TRUE, false, x'AED0393F', @param1)",
+			input: "UPSERT INTO table1(id, time, title, active, compressed, payload, note) VALUES (2, now(), 'untitled\"row', TRUE, false, x'AED0393F', @param1)",
 			expectedOutput: []SQLStmt{
 				&UpsertIntoStmt{
 					tableRef: &tableRef{table: "table1"},
@@ -307,7 +307,7 @@ func TestInsertIntoStmt(t *testing.T) {
 						{Values: []ValueExp{
 							&Number{val: 2},
 							&SysFn{fn: "now"},
-							&Varchar{val: "untitled row"},
+							&Varchar{val: "untitled\"row"},
 							&Bool{val: true},
 							&Bool{val: false},
 							&Blob{val: decodedBLOB},

--- a/embedded/sql/sql_parser.go
+++ b/embedded/sql/sql_parser.go
@@ -428,7 +428,7 @@ var yyErrorMessages = [...]struct {
 
 var (
 	yyDebug        = 0
-	yyErrorVerbose = false
+	yyErrorVerbose = true
 )
 
 type yyLexer interface {


### PR DESCRIPTION
The PR was modified to provide sql standard escaping with single quotes

```sql
create table mytable(title varchar[50], primary key title)
insert into mytable(title) values ('my escaped ''string''')

select * from mytable

+---------------------------+
| (DEFAULTDB MYTABLE TITLE) |
+---------------------------+
| "my escaped 'string'"     |
+---------------------------+
```

While we can support both escaping methods, the previous one was not correctly covering all the cases.

Signed-off-by: Jeronimo Irazabal <jeronimo.irazabal@gmail.com>