### PR TITLE
fix(embedded/tbtree): set fixed snapshot ts

### DIFF
--- a/embedded/tbtree/snapshot.go
+++ b/embedded/tbtree/snapshot.go
@@ -34,6 +34,7 @@ const (
 type Snapshot struct {
 	t           *TBtree
 	id          uint64
+	ts          uint64
 	root        node
 	readers     map[int]io.Closer
 	maxReaderID int
@@ -51,9 +52,7 @@ func (s *Snapshot) Set(key, value []byte) error {
 	v := make([]byte, len(value))
 	copy(v, value)
 
-	ts := s.root.ts() + 1
-
-	n1, n2, err := s.root.insertAt(k, v, ts)
+	n1, n2, err := s.root.insertAt(k, v, s.ts)
 	if err != nil {
 		return err
 	}
@@ -66,7 +65,7 @@ func (s *Snapshot) Set(key, value []byte) error {
 			nodes:   []node{n1, n2},
 			_minKey: n1.minKey(),
 			_maxKey: n2.maxKey(),
-			_ts:     ts,
+			_ts:     s.ts,
 			maxSize: s.t.maxNodeSize,
 			mut:     true,
 		}

--- a/embedded/tbtree/tbtree.go
+++ b/embedded/tbtree/tbtree.go
@@ -1206,6 +1206,7 @@ func (t *TBtree) newSnapshot(snapshotID uint64, root node) *Snapshot {
 	return &Snapshot{
 		t:       t,
 		id:      snapshotID,
+		ts:      root.ts() + 1,
 		root:    root,
 		readers: make(map[int]io.Closer),
 	}


### PR DESCRIPTION
This PR fixes tx read conflicts by ensuring all entries in the snapshot get the same logical insertion time i.e. txID

Signed-off-by: Jeronimo Irazabal <jeronimo.irazabal@gmail.com>