### PR TITLE
Optimization safe readvalue

### DIFF
--- a/embedded/sql/stmt.go
+++ b/embedded/sql/stmt.go
@@ -836,10 +836,7 @@ func (tx *SQLTx) deprecateIndexEntries(
 		} else {
 			md := store.NewKVMetadata()
 
-			err = md.AsDeleted(true)
-			if err != nil {
-				return nil, err
-			}
+			md.AsDeleted(true)
 
 			err = tx.set(mapKey(tx.sqlPrefix(), prefix, encodedValues...), md, nil)
 			if err != nil {
@@ -1112,12 +1109,9 @@ func (sqlTx *SQLTx) deleteIndexEntries(pkEncVals []byte, valuesByColID map[uint3
 
 		md := store.NewKVMetadata()
 
-		err := md.AsDeleted(true)
-		if err != nil {
-			return err
-		}
+		md.AsDeleted(true)
 
-		err = sqlTx.set(mapKey(sqlTx.sqlPrefix(), prefix, encodedValues...), md, nil)
+		err := sqlTx.set(mapKey(sqlTx.sqlPrefix(), prefix, encodedValues...), md, nil)
 		if err != nil {
 			return err
 		}

--- a/embedded/sql/stmt.go
+++ b/embedded/sql/stmt.go
@@ -834,7 +834,13 @@ func (tx *SQLTx) deprecateIndexEntries(
 		if sameIndexKey {
 			reusableIndexEntries[index.id] = struct{}{}
 		} else {
-			err = tx.set(mapKey(tx.sqlPrefix(), prefix, encodedValues...), store.NewKVMetadata().AsDeleted(true), nil)
+			md := store.NewKVMetadata(false)
+			err = md.AsDeleted(true)
+			if err != nil {
+				return nil, err
+			}
+
+			err = tx.set(mapKey(tx.sqlPrefix(), prefix, encodedValues...), md, nil)
 			if err != nil {
 				return nil, err
 			}
@@ -1103,7 +1109,13 @@ func (sqlTx *SQLTx) deleteIndexEntries(pkEncVals []byte, valuesByColID map[uint3
 			encodedValues[i+3] = encVal
 		}
 
-		err := sqlTx.set(mapKey(sqlTx.sqlPrefix(), prefix, encodedValues...), store.NewKVMetadata().AsDeleted(true), nil)
+		md := store.NewKVMetadata(false)
+		err := md.AsDeleted(true)
+		if err != nil {
+			return err
+		}
+
+		err = sqlTx.set(mapKey(sqlTx.sqlPrefix(), prefix, encodedValues...), md, nil)
 		if err != nil {
 			return err
 		}

--- a/embedded/sql/stmt.go
+++ b/embedded/sql/stmt.go
@@ -834,7 +834,8 @@ func (tx *SQLTx) deprecateIndexEntries(
 		if sameIndexKey {
 			reusableIndexEntries[index.id] = struct{}{}
 		} else {
-			md := store.NewKVMetadata(false)
+			md := store.NewKVMetadata()
+
 			err = md.AsDeleted(true)
 			if err != nil {
 				return nil, err
@@ -1109,7 +1110,8 @@ func (sqlTx *SQLTx) deleteIndexEntries(pkEncVals []byte, valuesByColID map[uint3
 			encodedValues[i+3] = encVal
 		}
 
-		md := store.NewKVMetadata(false)
+		md := store.NewKVMetadata()
+
 		err := md.AsDeleted(true)
 		if err != nil {
 			return err

--- a/embedded/store/immustore.go
+++ b/embedded/store/immustore.go
@@ -1626,7 +1626,7 @@ func (s *ImmuStore) ReplicateTx(exportedTx []byte, waitForIndexing bool) (*TxHea
 		var md *KVMetadata
 
 		if mdLen > 0 {
-			md = NewKVMetadata()
+			md = NewKVMetadata(true)
 
 			err := md.ReadFrom(exportedTx[i : i+mdLen])
 			if err != nil {

--- a/embedded/store/immustore.go
+++ b/embedded/store/immustore.go
@@ -1626,7 +1626,7 @@ func (s *ImmuStore) ReplicateTx(exportedTx []byte, waitForIndexing bool) (*TxHea
 		var md *KVMetadata
 
 		if mdLen > 0 {
-			md = NewReadOnlyKVMetadata()
+			md = newReadOnlyKVMetadata()
 
 			err := md.unsafeReadFrom(exportedTx[i : i+mdLen])
 			if err != nil {
@@ -1695,6 +1695,10 @@ func (s *ImmuStore) ReadTx(txID uint64, tx *Tx) error {
 // ErrExpiredEntry is be returned if the specified time has already elapsed
 func (s *ImmuStore) ReadValue(entry *TxEntry) ([]byte, error) {
 	if entry == nil {
+		return nil, ErrIllegalArguments
+	}
+
+	if entry.md != nil && !entry.md.readonly {
 		return nil, ErrIllegalArguments
 	}
 

--- a/embedded/store/immustore_test.go
+++ b/embedded/store/immustore_test.go
@@ -1058,7 +1058,11 @@ func TestImmudbStoreRWTransactions(t *testing.T) {
 		tx, err := immuStore.NewTx()
 		require.NoError(t, err)
 
-		err = tx.Set([]byte("expirableKey"), NewKVMetadata().ExpiresAt(nearFuture), []byte("expirableValue"))
+		md := NewKVMetadata(false)
+		err = md.ExpiresAt(nearFuture)
+		require.NoError(t, err)
+
+		err = tx.Set([]byte("expirableKey"), md, []byte("expirableValue"))
 		require.NoError(t, err)
 
 		_, err = tx.Commit()
@@ -1089,7 +1093,11 @@ func TestImmudbStoreRWTransactions(t *testing.T) {
 		tx, err := immuStore.NewTx()
 		require.NoError(t, err)
 
-		err = tx.Set([]byte("expirableKey"), NewKVMetadata().ExpiresAt(now), []byte("expirableValue"))
+		md := NewKVMetadata(false)
+		err = md.ExpiresAt(now)
+		require.NoError(t, err)
+
+		err = tx.Set([]byte("expirableKey"), md, []byte("expirableValue"))
 		require.NoError(t, err)
 
 		_, err = tx.Commit()
@@ -1119,7 +1127,11 @@ func TestImmudbStoreKVMetadata(t *testing.T) {
 	err = tx.Set([]byte{1, 2, 3}, nil, []byte{3, 2, 1})
 	require.NoError(t, err)
 
-	err = tx.Set([]byte{1, 2, 3}, NewKVMetadata().AsDeleted(true), []byte{3, 2, 1})
+	md := NewKVMetadata(false)
+	err = md.AsDeleted(true)
+	require.NoError(t, err)
+
+	err = tx.Set([]byte{1, 2, 3}, md, []byte{3, 2, 1})
 	require.NoError(t, err)
 
 	_, err = tx.Commit()
@@ -1350,7 +1362,7 @@ func TestImmudbStoreInclusionProof(t *testing.T) {
 			v := make([]byte, 8)
 			binary.BigEndian.PutUint64(v, uint64(i<<4+(eCount-j)))
 
-			err = tx.Set(k, NewKVMetadata(), v)
+			err = tx.Set(k, NewKVMetadata(false), v)
 			require.NoError(t, err)
 		}
 
@@ -1413,7 +1425,7 @@ func TestImmudbStoreInclusionProof(t *testing.T) {
 			require.Equal(t, k, key)
 			require.Equal(t, v, value)
 
-			e := &EntrySpec{Key: key, Metadata: NewKVMetadata(), Value: value}
+			e := &EntrySpec{Key: key, Metadata: NewKVMetadata(false), Value: value}
 
 			verifies := htree.VerifyInclusion(proof, entrySpecDigest(e), tx.header.Eh)
 			require.True(t, verifies)

--- a/embedded/store/immustore_test.go
+++ b/embedded/store/immustore_test.go
@@ -182,7 +182,7 @@ func TestImmudbStoreConcurrentCommits(t *testing.T) {
 				}
 
 				for _, e := range txHolder.Entries() {
-					_, err := immuStore.ReadValue(txHolder.header.ID, txHolder, e.Key())
+					_, err := immuStore.ReadValue(e)
 					if err != nil {
 						panic(err)
 					}
@@ -1058,7 +1058,7 @@ func TestImmudbStoreRWTransactions(t *testing.T) {
 		tx, err := immuStore.NewTx()
 		require.NoError(t, err)
 
-		md := NewKVMetadata(false)
+		md := NewKVMetadata()
 		err = md.ExpiresAt(nearFuture)
 		require.NoError(t, err)
 
@@ -1093,7 +1093,7 @@ func TestImmudbStoreRWTransactions(t *testing.T) {
 		tx, err := immuStore.NewTx()
 		require.NoError(t, err)
 
-		md := NewKVMetadata(false)
+		md := NewKVMetadata()
 		err = md.ExpiresAt(now)
 		require.NoError(t, err)
 
@@ -1127,7 +1127,7 @@ func TestImmudbStoreKVMetadata(t *testing.T) {
 	err = tx.Set([]byte{1, 2, 3}, nil, []byte{3, 2, 1})
 	require.NoError(t, err)
 
-	md := NewKVMetadata(false)
+	md := NewKVMetadata()
 	err = md.AsDeleted(true)
 	require.NoError(t, err)
 
@@ -1217,10 +1217,16 @@ func TestImmudbStoreCommitWith(t *testing.T) {
 
 	require.Equal(t, uint64(1), immuStore.IndexInfo())
 
-	_, err = immuStore.ReadValue(hdr.ID, nil, nil)
+	_, err = immuStore.ReadValue(nil)
 	require.ErrorIs(t, err, ErrIllegalArguments)
 
-	val, err := immuStore.ReadValue(hdr.ID, immuStore.NewTxHolder(), []byte(fmt.Sprintf("keyInsertedAtTx%d", hdr.ID)))
+	txHolder := immuStore.NewTxHolder()
+	immuStore.ReadTx(hdr.ID, txHolder)
+
+	entry, err := txHolder.EntryOf([]byte(fmt.Sprintf("keyInsertedAtTx%d", hdr.ID)))
+	require.NoError(t, err)
+
+	val, err := immuStore.ReadValue(entry)
 	require.NoError(t, err)
 	require.Equal(t, []byte("value"), val)
 }
@@ -1296,7 +1302,13 @@ func TestImmudbStoreHistoricalValues(t *testing.T) {
 							v := make([]byte, 8)
 							binary.BigEndian.PutUint64(v, txID-1)
 
-							val, err := immuStore.ReadValue(txID, tx, k)
+							err = immuStore.ReadTx(txID, tx)
+							require.NoError(t, err)
+
+							entry, err := tx.EntryOf(k)
+							require.NoError(t, err)
+
+							val, err := immuStore.ReadValue(entry)
 							if err != nil {
 								panic(err)
 							}
@@ -1362,7 +1374,7 @@ func TestImmudbStoreInclusionProof(t *testing.T) {
 			v := make([]byte, 8)
 			binary.BigEndian.PutUint64(v, uint64(i<<4+(eCount-j)))
 
-			err = tx.Set(k, NewKVMetadata(false), v)
+			err = tx.Set(k, NewKVMetadata(), v)
 			require.NoError(t, err)
 		}
 
@@ -1425,12 +1437,12 @@ func TestImmudbStoreInclusionProof(t *testing.T) {
 			require.Equal(t, k, key)
 			require.Equal(t, v, value)
 
-			e := &EntrySpec{Key: key, Metadata: NewKVMetadata(false), Value: value}
+			eSpec := &EntrySpec{Key: key, Metadata: NewKVMetadata(), Value: value}
 
-			verifies := htree.VerifyInclusion(proof, entrySpecDigest(e), tx.header.Eh)
+			verifies := htree.VerifyInclusion(proof, entrySpecDigest(eSpec), tx.header.Eh)
 			require.True(t, verifies)
 
-			v, err = immuStore.ReadValue(tx.header.ID, tx, key)
+			v, err = immuStore.ReadValue(e)
 			require.NoError(t, err)
 			require.Equal(t, value, v)
 		}

--- a/embedded/store/key_reader.go
+++ b/embedded/store/key_reader.go
@@ -230,7 +230,7 @@ func (st *ImmuStore) valueRefFrom(tx, hc uint64, indexedVal []byte) (ValueRef, e
 		}
 
 		if kvmdLen > 0 {
-			kvmd = NewReadOnlyKVMetadata()
+			kvmd = newReadOnlyKVMetadata()
 
 			err := kvmd.unsafeReadFrom(indexedVal[i : i+kvmdLen])
 			if err != nil {

--- a/embedded/store/key_reader.go
+++ b/embedded/store/key_reader.go
@@ -230,7 +230,7 @@ func (st *ImmuStore) valueRefFrom(tx, hc uint64, indexedVal []byte) (ValueRef, e
 		}
 
 		if kvmdLen > 0 {
-			kvmd = NewKVMetadata()
+			kvmd = NewKVMetadata(true)
 
 			err := kvmd.ReadFrom(indexedVal[i : i+kvmdLen])
 			if err != nil {

--- a/embedded/store/key_reader.go
+++ b/embedded/store/key_reader.go
@@ -230,9 +230,9 @@ func (st *ImmuStore) valueRefFrom(tx, hc uint64, indexedVal []byte) (ValueRef, e
 		}
 
 		if kvmdLen > 0 {
-			kvmd = NewKVMetadata(true)
+			kvmd = NewReadOnlyKVMetadata()
 
-			err := kvmd.ReadFrom(indexedVal[i : i+kvmdLen])
+			err := kvmd.unsafeReadFrom(indexedVal[i : i+kvmdLen])
 			if err != nil {
 				return nil, err
 			}

--- a/embedded/store/kv_metadata.go
+++ b/embedded/store/kv_metadata.go
@@ -80,7 +80,15 @@ func (a *expiresAtAttribute) deserialize(b []byte) (int, error) {
 	return tsSize, nil
 }
 
-func NewKVMetadata(readonly bool) *KVMetadata {
+func NewKVMetadata() *KVMetadata {
+	return newKVMetadata(false)
+}
+
+func NewReadOnlyKVMetadata() *KVMetadata {
+	return newKVMetadata(true)
+}
+
+func newKVMetadata(readonly bool) *KVMetadata {
 	return &KVMetadata{
 		attributes: make(map[attributeCode]attribute),
 		readonly:   readonly,
@@ -168,7 +176,7 @@ func (md *KVMetadata) Bytes() []byte {
 	return b.Bytes()
 }
 
-func (md *KVMetadata) ReadFrom(b []byte) error {
+func (md *KVMetadata) unsafeReadFrom(b []byte) error {
 	if len(b) > maxKVMetadataLen {
 		return ErrCorruptedData
 	}

--- a/embedded/store/kv_metadata.go
+++ b/embedded/store/kv_metadata.go
@@ -81,17 +81,15 @@ func (a *expiresAtAttribute) deserialize(b []byte) (int, error) {
 }
 
 func NewKVMetadata() *KVMetadata {
-	return newKVMetadata(false)
-}
-
-func NewReadOnlyKVMetadata() *KVMetadata {
-	return newKVMetadata(true)
-}
-
-func newKVMetadata(readonly bool) *KVMetadata {
 	return &KVMetadata{
 		attributes: make(map[attributeCode]attribute),
-		readonly:   readonly,
+	}
+}
+
+func newReadOnlyKVMetadata() *KVMetadata {
+	return &KVMetadata{
+		attributes: make(map[attributeCode]attribute),
+		readonly:   true,
 	}
 }
 

--- a/embedded/store/kv_metadata_test.go
+++ b/embedded/store/kv_metadata_test.go
@@ -41,7 +41,7 @@ func TestKVMetadata(t *testing.T) {
 	require.False(t, md.ExpiredAt(now))
 
 	t.Run("mutable methods over read-only metadata should fail", func(t *testing.T) {
-		desmd := NewReadOnlyKVMetadata()
+		desmd := newReadOnlyKVMetadata()
 
 		err = desmd.unsafeReadFrom(nil)
 		require.NoError(t, err)

--- a/embedded/store/kv_metadata_test.go
+++ b/embedded/store/kv_metadata_test.go
@@ -25,12 +25,12 @@ import (
 func TestKVMetadata(t *testing.T) {
 	now := time.Now()
 
-	md := NewKVMetadata(false)
+	md := NewKVMetadata()
 
 	bs := md.Bytes()
 	require.Len(t, bs, 0)
 
-	err := md.ReadFrom(bs)
+	err := md.unsafeReadFrom(bs)
 	require.NoError(t, err)
 	require.False(t, md.Deleted())
 	require.False(t, md.IsExpirable())
@@ -41,9 +41,9 @@ func TestKVMetadata(t *testing.T) {
 	require.False(t, md.ExpiredAt(now))
 
 	t.Run("mutable methods over read-only metadata should fail", func(t *testing.T) {
-		desmd := NewKVMetadata(true)
+		desmd := NewReadOnlyKVMetadata()
 
-		err = desmd.ReadFrom(nil)
+		err = desmd.unsafeReadFrom(nil)
 		require.NoError(t, err)
 
 		require.False(t, desmd.Deleted())
@@ -57,9 +57,9 @@ func TestKVMetadata(t *testing.T) {
 		require.ErrorIs(t, err, ErrReadOnly)
 	})
 
-	desmd := NewKVMetadata(false)
+	desmd := NewKVMetadata()
 
-	err = desmd.ReadFrom(nil)
+	err = desmd.unsafeReadFrom(nil)
 	require.NoError(t, err)
 
 	desmd.AsDeleted(false)
@@ -87,7 +87,7 @@ func TestKVMetadata(t *testing.T) {
 	require.NotNil(t, bs)
 	require.Len(t, bs, maxKVMetadataLen)
 
-	err = desmd.ReadFrom(bs)
+	err = desmd.unsafeReadFrom(bs)
 	require.NoError(t, err)
 	require.True(t, desmd.Deleted())
 	require.True(t, desmd.IsExpirable())

--- a/embedded/store/ongoing_tx.go
+++ b/embedded/store/ongoing_tx.go
@@ -204,7 +204,7 @@ func (tx *OngoingTx) Delete(key []byte) error {
 		return ErrKeyNotFound
 	}
 
-	md := NewKVMetadata(false)
+	md := NewKVMetadata()
 
 	md.AsDeleted(true)
 	if err != nil {

--- a/embedded/store/ongoing_tx.go
+++ b/embedded/store/ongoing_tx.go
@@ -207,9 +207,6 @@ func (tx *OngoingTx) Delete(key []byte) error {
 	md := NewKVMetadata()
 
 	md.AsDeleted(true)
-	if err != nil {
-		return err
-	}
 
 	return tx.Set(key, md, nil)
 }

--- a/embedded/store/ongoing_tx.go
+++ b/embedded/store/ongoing_tx.go
@@ -204,7 +204,14 @@ func (tx *OngoingTx) Delete(key []byte) error {
 		return ErrKeyNotFound
 	}
 
-	return tx.Set(key, NewKVMetadata().AsDeleted(true), nil)
+	md := NewKVMetadata(false)
+
+	md.AsDeleted(true)
+	if err != nil {
+		return err
+	}
+
+	return tx.Set(key, md, nil)
 }
 
 func (tx *OngoingTx) Get(key []byte) (ValueRef, error) {

--- a/embedded/store/tx.go
+++ b/embedded/store/tx.go
@@ -450,7 +450,7 @@ func (tx *Tx) readFrom(r *appendable.Reader) error {
 				return err
 			}
 
-			kvmd = NewReadOnlyKVMetadata()
+			kvmd = newReadOnlyKVMetadata()
 
 			err = kvmd.unsafeReadFrom(mdbs)
 			if err != nil {

--- a/embedded/store/tx.go
+++ b/embedded/store/tx.go
@@ -450,9 +450,9 @@ func (tx *Tx) readFrom(r *appendable.Reader) error {
 				return err
 			}
 
-			kvmd = NewKVMetadata(true)
+			kvmd = NewReadOnlyKVMetadata()
 
-			err = kvmd.ReadFrom(mdbs)
+			err = kvmd.unsafeReadFrom(mdbs)
 			if err != nil {
 				return err
 			}

--- a/embedded/store/tx.go
+++ b/embedded/store/tx.go
@@ -450,7 +450,7 @@ func (tx *Tx) readFrom(r *appendable.Reader) error {
 				return err
 			}
 
-			kvmd = NewKVMetadata()
+			kvmd = NewKVMetadata(true)
 
 			err = kvmd.ReadFrom(mdbs)
 			if err != nil {

--- a/embedded/tools/stress_tool/stress_tool.go
+++ b/embedded/tools/stress_tool/stress_tool.go
@@ -306,7 +306,7 @@ func main() {
 								panic(fmt.Errorf("committed tx key does not match input values"))
 							}
 
-							val, err := immuStore.ReadValue(txHolder.Header().ID, txHolder, e.Key())
+							val, err := immuStore.ReadValue(e)
 							if err != nil {
 								panic(err)
 							}
@@ -370,7 +370,7 @@ func main() {
 							panic(err)
 						}
 
-						val, err := immuStore.ReadValue(tx.Header().ID, tx, e.Key())
+						val, err := immuStore.ReadValue(e)
 						if err != nil {
 							panic(err)
 						}

--- a/pkg/api/schema/database_protoconv.go
+++ b/pkg/api/schema/database_protoconv.go
@@ -89,7 +89,9 @@ func KVMetadataFromProto(md *KVMetadata) *store.KVMetadata {
 		return nil
 	}
 
-	kvmd := store.NewKVMetadata().AsDeleted(md.Deleted)
+	kvmd := store.NewKVMetadata()
+
+	kvmd.AsDeleted(md.Deleted)
 
 	if md.Expiration != nil {
 		kvmd.ExpiresAt(time.Unix(md.Expiration.ExpiresAt, 0))

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -468,7 +468,7 @@ func (d *db) readMetadataAndValue(key []byte, atTx uint64, tx *store.Tx) (*store
 		return nil, nil, err
 	}
 
-	v, err := d.st.ReadValue(atTx, tx, key)
+	v, err := d.st.ReadValue(entry)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -662,7 +662,8 @@ func (d *db) Delete(req *schema.DeleteKeysRequest) (*schema.TxHeader, error) {
 			return nil, ErrIllegalArguments
 		}
 
-		md := store.NewKVMetadata(false)
+		md := store.NewKVMetadata()
+
 		err = md.AsDeleted(true)
 		if err != nil {
 			return nil, err
@@ -934,7 +935,7 @@ func (d *db) History(req *schema.HistoryRequest) (*schema.Entries, error) {
 			return nil, err
 		}
 
-		val, err := d.st.ReadValue(txID, tx, key)
+		val, err := d.st.ReadValue(entry)
 		if err != nil && err != store.ErrExpiredEntry {
 			return nil, err
 		}

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -662,7 +662,13 @@ func (d *db) Delete(req *schema.DeleteKeysRequest) (*schema.TxHeader, error) {
 			return nil, ErrIllegalArguments
 		}
 
-		e := EncodeEntrySpec(k, store.NewKVMetadata().AsDeleted(true), nil)
+		md := store.NewKVMetadata(false)
+		err = md.AsDeleted(true)
+		if err != nil {
+			return nil, err
+		}
+
+		e := EncodeEntrySpec(k, md, nil)
 
 		err = tx.Delete(e.Key)
 		if err != nil {

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -664,10 +664,7 @@ func (d *db) Delete(req *schema.DeleteKeysRequest) (*schema.TxHeader, error) {
 
 		md := store.NewKVMetadata()
 
-		err = md.AsDeleted(true)
-		if err != nil {
-			return nil, err
-		}
+		md.AsDeleted(true)
 
 		e := EncodeEntrySpec(k, md, nil)
 


### PR DESCRIPTION
The initial implementation for data expiration was preventing access to values of expired entries but with a significative lost in performance.

This PR aims to solve the performance issue while still ensuring data of expired entries is not reachable.

KVMetadata struct contains a private readonly attribute used to allow or forbid changes. When reading committed data this attribute is automatically set to true, making impossible to dynamically change it using exposed apis.
