### PR TITLE
readonly tx entries to ensure no runtime modification

### DIFF
--- a/embedded/store/immustore.go
+++ b/embedded/store/immustore.go
@@ -1694,7 +1694,7 @@ func (s *ImmuStore) ReadTx(txID uint64, tx *Tx) error {
 // ReadValue returns the actual associated value to a key at a specific transaction
 // ErrExpiredEntry is be returned if the specified time has already elapsed
 func (s *ImmuStore) ReadValue(entry *TxEntry) ([]byte, error) {
-	if entry == nil {
+	if entry == nil || !entry.readonly {
 		return nil, ErrIllegalArguments
 	}
 

--- a/embedded/store/immustore_test.go
+++ b/embedded/store/immustore_test.go
@@ -1414,6 +1414,8 @@ func TestImmudbStoreInclusionProof(t *testing.T) {
 		assert.Equal(t, eCount, len(txEntries))
 
 		for j, e := range txEntries {
+			require.True(t, e.readonly)
+
 			proof, err := tx.Proof(e.key())
 			require.NoError(t, err)
 
@@ -1446,6 +1448,11 @@ func TestImmudbStoreInclusionProof(t *testing.T) {
 			require.Equal(t, value, v)
 		}
 	}
+
+	t.Run("reading value from non-readonly entry should fail", func(t *testing.T) {
+		_, err = immuStore.ReadValue(NewTxEntry([]byte("key"), NewKVMetadata(), 0, sha256.Sum256(nil), 0))
+		require.ErrorIs(t, err, ErrIllegalArguments)
+	})
 
 	err = immuStore.Close()
 	require.NoError(t, err)

--- a/embedded/store/tx.go
+++ b/embedded/store/tx.go
@@ -487,6 +487,8 @@ func (tx *Tx) readFrom(r *appendable.Reader) error {
 		if err != nil {
 			return err
 		}
+
+		tx.entries[i].readonly = true
 	}
 
 	var alh [sha256.Size]byte
@@ -508,12 +510,13 @@ func (tx *Tx) readFrom(r *appendable.Reader) error {
 }
 
 type TxEntry struct {
-	k    []byte
-	kLen int
-	md   *KVMetadata
-	vLen int
-	hVal [sha256.Size]byte
-	vOff int64
+	k        []byte
+	kLen     int
+	md       *KVMetadata
+	vLen     int
+	hVal     [sha256.Size]byte
+	vOff     int64
+	readonly bool
 }
 
 func NewTxEntry(key []byte, md *KVMetadata, vLen int, hVal [sha256.Size]byte, vOff int64) *TxEntry {


### PR DESCRIPTION
This PR introduces readonly private attribute on tx entries. This value can only be set internally when loading tx data from storage.

This attribute is then checked when reading a value associated to a key at a specific tx.

Signed-off-by: Jeronimo Irazabal <jeronimo.irazabal@gmail.com>