### PR TITLE
bugfix: Transfer timestamp in microseconds to fix timestamp column values.

### DIFF
--- a/embedded/sql/engine.go
+++ b/embedded/sql/engine.go
@@ -858,7 +858,7 @@ func EncodeValue(val interface{}, colType SQLValueType, maxLen int) ([]byte, err
 			// len(v) + v
 			var encv [EncLenLen + 8]byte
 			binary.BigEndian.PutUint32(encv[:], uint32(8))
-			binary.BigEndian.PutUint64(encv[EncLenLen:], uint64(timeToInt64(timeVal)))
+			binary.BigEndian.PutUint64(encv[EncLenLen:], uint64(TimeToInt64(timeVal)))
 
 			return encv[:], nil
 		}

--- a/embedded/sql/engine.go
+++ b/embedded/sql/engine.go
@@ -1058,7 +1058,7 @@ func DecodeValue(b []byte, colType SQLValueType) (TypedValue, int, error) {
 			v := binary.BigEndian.Uint64(b[voff:])
 			voff += vlen
 
-			return &Timestamp{val: timeFromInt64(int64(v))}, voff, nil
+			return &Timestamp{val: TimeFromInt64(int64(v))}, voff, nil
 		}
 	}
 

--- a/embedded/sql/timestamp.go
+++ b/embedded/sql/timestamp.go
@@ -25,6 +25,6 @@ func TimeToInt64(t time.Time) int64 {
 	return unix*1e6 + int64(nano)/1e3
 }
 
-func timeFromInt64(t int64) time.Time {
+func TimeFromInt64(t int64) time.Time {
 	return time.Unix(t/1e6, (t%1e6)*1e3).UTC()
 }

--- a/embedded/sql/timestamp.go
+++ b/embedded/sql/timestamp.go
@@ -18,7 +18,7 @@ package sql
 
 import "time"
 
-func timeToInt64(t time.Time) int64 {
+func TimeToInt64(t time.Time) int64 {
 	unix := t.Unix()
 	nano := t.Nanosecond()
 

--- a/embedded/sql/timestamp_test.go
+++ b/embedded/sql/timestamp_test.go
@@ -35,7 +35,7 @@ func TestTimeConversions(t *testing.T) {
 		{time.Date(0, 1, 1, 0, 0, 0, 0, time.UTC), -62167219200000000},
 	} {
 		t.Run(fmt.Sprintf("convert time (%v) to int64 (%d)", d.t, d.i), func(t *testing.T) {
-			assert.Equal(t, d.i, timeToInt64(d.t))
+			assert.Equal(t, d.i, TimeToInt64(d.t))
 		})
 		t.Run(fmt.Sprintf("convert int64 (%d) to time (%v)", d.i, d.t), func(t *testing.T) {
 			assert.Equal(t, d.t, timeFromInt64(d.i))

--- a/embedded/sql/timestamp_test.go
+++ b/embedded/sql/timestamp_test.go
@@ -38,7 +38,7 @@ func TestTimeConversions(t *testing.T) {
 			assert.Equal(t, d.i, TimeToInt64(d.t))
 		})
 		t.Run(fmt.Sprintf("convert int64 (%d) to time (%v)", d.i, d.t), func(t *testing.T) {
-			assert.Equal(t, d.t, timeFromInt64(d.i))
+			assert.Equal(t, d.t, TimeFromInt64(d.i))
 		})
 	}
 }

--- a/pkg/api/schema/row_value.go
+++ b/pkg/api/schema/row_value.go
@@ -20,7 +20,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strconv"
-	"time"
 
 	"github.com/codenotary/immudb/embedded/sql"
 )
@@ -127,7 +126,7 @@ func RenderValue(op isSQLValue_Value) string {
 		}
 	case *SQLValue_Ts:
 		{
-			t := time.Unix(v.Ts/1e6, (v.Ts%1e6)*1e3).UTC()
+			t := sql.TimeFromInt64(v.Ts)
 			return t.Format("2006-01-02 15:04:05.999999")
 		}
 	}
@@ -159,7 +158,7 @@ func RenderValueAsByte(op isSQLValue_Value) []byte {
 		}
 	case *SQLValue_Ts:
 		{
-			t := time.Unix(v.Ts/1e6, (v.Ts%1e6)*1e3).UTC()
+			t := sql.TimeFromInt64(v.Ts)
 			return []byte(t.Format("2006-01-02 15:04:05.999999"))
 		}
 	}
@@ -195,7 +194,7 @@ func RawValue(v *SQLValue) interface{} {
 		}
 	case *SQLValue_Ts:
 		{
-			return time.Unix(tv.Ts/1e6, (tv.Ts%1e6)*1e3).UTC()
+			return sql.TimeFromInt64(tv.Ts)
 		}
 	}
 

--- a/pkg/api/schema/sql.go
+++ b/pkg/api/schema/sql.go
@@ -101,7 +101,7 @@ func asSQLValue(v interface{}) (*SQLValue, error) {
 		}
 	case time.Time:
 		{
-			return &SQLValue{Value: &SQLValue_Ts{Ts: tv.UnixNano()}}, nil
+			return &SQLValue{Value: &SQLValue_Ts{Ts: sql.TimeToInt64(tv)}}, nil
 		}
 	}
 	return nil, sql.ErrInvalidValue

--- a/pkg/api/schema/sql_test.go
+++ b/pkg/api/schema/sql_test.go
@@ -101,7 +101,7 @@ func TestAsSQLValue(t *testing.T) {
 		},
 		{
 			"timestamp", time.Date(2021, 12, 7, 14, 12, 54, 12345, time.UTC),
-			&SQLValue{Value: &SQLValue_Ts{Ts: 1638886374000012345}}, false,
+			&SQLValue{Value: &SQLValue_Ts{Ts: 1638886374000012}}, false,
 		},
 	} {
 		t.Run(d.n, func(t *testing.T) {

--- a/pkg/client/sql.go
+++ b/pkg/client/sql.go
@@ -329,7 +329,7 @@ func typedValueToRowValue(tv sql.TypedValue) *schema.SQLValue {
 		}
 	case sql.TimestampType:
 		{
-			return &schema.SQLValue{Value: &schema.SQLValue_Ts{Ts: tv.Value().(time.Time).UnixNano()}}
+			return &schema.SQLValue{Value: &schema.SQLValue_Ts{Ts: sql.TimeToInt64(tv.Value().(time.Time))}}
 		}
 	}
 	return nil

--- a/pkg/database/sql.go
+++ b/pkg/database/sql.go
@@ -521,7 +521,7 @@ func typedValueToRowValue(tv sql.TypedValue) *schema.SQLValue {
 		}
 	case sql.TimestampType:
 		{
-			return &schema.SQLValue{Value: &schema.SQLValue_Ts{Ts: tv.Value().(time.Time).UnixNano()}}
+			return &schema.SQLValue{Value: &schema.SQLValue_Ts{Ts: sql.TimeToInt64(tv.Value().(time.Time))}}
 		}
 	}
 	return nil

--- a/pkg/stdlib/rows.go
+++ b/pkg/stdlib/rows.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/codenotary/immudb/embedded/sql"
 	"github.com/codenotary/immudb/pkg/api/schema"
 )
 
@@ -318,7 +319,7 @@ func RenderValue(op interface{}) interface{} {
 		}
 	case *schema.SQLValue_Ts:
 		{
-			return time.Unix(v.Ts/1e6, (v.Ts%1e6)*1e3).UTC()
+			return sql.TimeFromInt64(v.Ts)
 		}
 	}
 	return []byte(fmt.Sprintf("%v", op))

--- a/pkg/stdlib/rows_test.go
+++ b/pkg/stdlib/rows_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/codenotary/immudb/embedded/sql"
 	"github.com/codenotary/immudb/pkg/api/schema"
 	"github.com/stretchr/testify/require"
 )
@@ -107,7 +108,7 @@ func TestRows_ColumnTypeDatabaseTypeName(t *testing.T) {
 				index: 0,
 				rows: []*schema.Row{{
 					Columns: []string{"c1"},
-					Values:  []*schema.SQLValue{{Value: &schema.SQLValue_Ts{Ts: time.Now().UnixNano()}}},
+					Values:  []*schema.SQLValue{{Value: &schema.SQLValue_Ts{Ts: sql.TimeToInt64(time.Now())}}},
 				}},
 			},
 			expected: "TIMESTAMP",
@@ -213,7 +214,7 @@ func TestRows_ColumnTypeLength(t *testing.T) {
 				index: 0,
 				rows: []*schema.Row{{
 					Columns: []string{"c1"},
-					Values:  []*schema.SQLValue{{Value: &schema.SQLValue_Ts{Ts: time.Now().UnixNano()}}},
+					Values:  []*schema.SQLValue{{Value: &schema.SQLValue_Ts{Ts: sql.TimeToInt64(time.Now())}}},
 				}},
 			},
 			lenght:         math.MaxInt64,
@@ -319,7 +320,7 @@ func TestRows_ColumnTypeScanType(t *testing.T) {
 				index: 0,
 				rows: []*schema.Row{{
 					Columns: []string{"c1"},
-					Values:  []*schema.SQLValue{{Value: &schema.SQLValue_Ts{Ts: time.Now().UnixNano()}}},
+					Values:  []*schema.SQLValue{{Value: &schema.SQLValue_Ts{Ts: sql.TimeToInt64(time.Now())}}},
 				}},
 			},
 			expectedType: reflect.TypeOf(time.Now()),


### PR DESCRIPTION
This PR fixes and issues with timestamp columns in sql tables. Although timestamps are stored in microseconds, the sql client sdk converted time.Time argument values into nanoseconds ( pkg/client/sql.go , line 332 ). Afterwards the nanosecond value was converted back into a time.Time value before writing it to the database. But in this instance it was interpreted as microseconds ( pkg/api/schema/row_value.go, line 198 ). Hence a totally wrong timestamp is stored. Similarly the client sdk retrieved timestamps in nanoseconds when queried from the database.

To fix this issue and make timestamp handling more consistent, the PR adjusts all locations setting a value for SQLValue_Ts.Ts to ensure it is always assigned a microsecond value. As the conversion formula was copied to multiple locations, this was also unified to always call the functions sql.timeFromInt64 / sql.timeToInt64.

An additional PR for the webconsole will be necessary, as it apparently expects timestamps in nanoseconds and shows wrong dates at the moment.