### PR TITLE
restricted and optimized ExecAll

### DIFF
--- a/pkg/api/schema/ops_test.go
+++ b/pkg/api/schema/ops_test.go
@@ -53,7 +53,7 @@ func TestOps_ValidateErrDuplicatedKeysNotSupported(t *testing.T) {
 		},
 	}
 	err := aOps.Validate()
-	require.Equal(t, err, ErrDuplicatedKeysNotSupported)
+	require.ErrorIs(t, err, ErrDuplicatedKeysNotSupported)
 
 }
 

--- a/pkg/database/all_ops.go
+++ b/pkg/database/all_ops.go
@@ -41,10 +41,14 @@ func (d *db) ExecAll(req *schema.ExecAllRequest) (*schema.TxHeader, error) {
 		return nil, ErrIsReplica
 	}
 
-	lastTxID, _ := d.st.Alh()
-	err := d.st.WaitForIndexingUpto(lastTxID, nil)
-	if err != nil {
-		return nil, err
+	const unsafe bool = true
+
+	if !unsafe {
+		lastTxID, _ := d.st.Alh()
+		err := d.st.WaitForIndexingUpto(lastTxID, nil)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	callback := func(txID uint64, index store.KeyIndex) ([]*store.EntrySpec, error) {
@@ -82,26 +86,28 @@ func (d *db) ExecAll(req *schema.ExecAllRequest) (*schema.TxHeader, error) {
 					return nil, store.ErrIllegalArguments
 				}
 
-				// check key does not exists or it's already a reference
-				entry, err := d.getAt(EncodeKey(x.Ref.Key), 0, 0, index, tx)
-				if err != nil && err != store.ErrKeyNotFound {
-					return nil, err
-				}
-				if entry != nil && entry.ReferencedBy == nil {
-					return nil, ErrFinalKeyCannotBeConvertedIntoReference
-				}
-
-				// reference arguments are converted in regular key value items and then atomically inserted
-				_, exists := kmap[sha256.Sum256(x.Ref.ReferencedKey)]
-
-				if !exists || x.Ref.AtTx > 0 {
-					// check referenced key exists and it's not a reference
-					refEntry, err := d.getAt(EncodeKey(x.Ref.ReferencedKey), x.Ref.AtTx, 0, index, tx)
-					if err != nil {
+				if !unsafe {
+					// check key does not exists or it's already a reference
+					entry, err := d.getAt(EncodeKey(x.Ref.Key), 0, 0, index, tx)
+					if err != nil && err != store.ErrKeyNotFound {
 						return nil, err
 					}
-					if refEntry.ReferencedBy != nil {
-						return nil, ErrReferencedKeyCannotBeAReference
+					if entry != nil && entry.ReferencedBy == nil {
+						return nil, ErrFinalKeyCannotBeConvertedIntoReference
+					}
+
+					// reference arguments are converted in regular key value items and then atomically inserted
+					_, exists := kmap[sha256.Sum256(x.Ref.ReferencedKey)]
+
+					if !exists || x.Ref.AtTx > 0 {
+						// check referenced key exists and it's not a reference
+						refEntry, err := d.getAt(EncodeKey(x.Ref.ReferencedKey), x.Ref.AtTx, 0, index, tx)
+						if err != nil {
+							return nil, err
+						}
+						if refEntry.ReferencedBy != nil {
+							return nil, ErrReferencedKeyCannotBeAReference
+						}
 					}
 				}
 
@@ -120,17 +126,19 @@ func (d *db) ExecAll(req *schema.ExecAllRequest) (*schema.TxHeader, error) {
 					return nil, store.ErrIllegalArguments
 				}
 
-				// zAdd arguments are converted in regular key value items and then atomically inserted
-				_, exists := kmap[sha256.Sum256(x.ZAdd.Key)]
+				if !unsafe {
+					// zAdd arguments are converted in regular key value items and then atomically inserted
+					_, exists := kmap[sha256.Sum256(x.ZAdd.Key)]
 
-				if !exists || x.ZAdd.AtTx > 0 {
-					// check referenced key exists and it's not a reference
-					refEntry, err := d.getAt(EncodeKey(x.ZAdd.Key), x.ZAdd.AtTx, 0, index, tx)
-					if err != nil {
-						return nil, err
-					}
-					if refEntry.ReferencedBy != nil {
-						return nil, ErrReferencedKeyCannotBeAReference
+					if !exists || x.ZAdd.AtTx > 0 {
+						// check referenced key exists and it's not a reference
+						refEntry, err := d.getAt(EncodeKey(x.ZAdd.Key), x.ZAdd.AtTx, 0, index, tx)
+						if err != nil {
+							return nil, err
+						}
+						if refEntry.ReferencedBy != nil {
+							return nil, ErrReferencedKeyCannotBeAReference
+						}
 					}
 				}
 

--- a/pkg/database/all_ops.go
+++ b/pkg/database/all_ops.go
@@ -60,7 +60,11 @@ func (d *db) ExecAll(req *schema.ExecAllRequest) (*schema.TxHeader, error) {
 		// we build a map in which we store sha256 sum as key and the index as value
 		kmap := make(map[[sha256.Size]byte]bool)
 
-		tx := d.st.NewTxHolder()
+		var tx *store.Tx
+
+		if !unsafe {
+			tx = d.st.NewTxHolder()
+		}
 
 		for i, op := range req.Operations {
 

--- a/pkg/database/all_ops.go
+++ b/pkg/database/all_ops.go
@@ -17,6 +17,7 @@ package database
 
 import (
 	"crypto/sha256"
+	"fmt"
 
 	"github.com/codenotary/immudb/embedded/store"
 	"github.com/codenotary/immudb/pkg/api/schema"
@@ -89,13 +90,17 @@ func (d *db) ExecAll(req *schema.ExecAllRequest) (*schema.TxHeader, error) {
 				}
 
 				if req.NoWait && (x.Ref.AtTx != 0 || !x.Ref.BoundRef) {
-					return nil, ErrNoWaitOperationMustBeSelfContained
+					return nil, fmt.Errorf(
+						"%w: can only set references to keys added within same transaction, please use bound references with AtTx set to 0",
+						ErrNoWaitOperationMustBeSelfContained)
 				}
 
 				_, exists := kmap[sha256.Sum256(x.Ref.ReferencedKey)]
 
 				if req.NoWait && !exists {
-					return nil, ErrNoWaitOperationMustBeSelfContained
+					return nil, fmt.Errorf(
+						"%w: can not create a reference to a key that was not set in the same transaction",
+						ErrNoWaitOperationMustBeSelfContained)
 				}
 
 				if !req.NoWait {
@@ -137,13 +142,17 @@ func (d *db) ExecAll(req *schema.ExecAllRequest) (*schema.TxHeader, error) {
 				}
 
 				if req.NoWait && (x.ZAdd.AtTx != 0 || !x.ZAdd.BoundRef) {
-					return nil, ErrNoWaitOperationMustBeSelfContained
+					return nil, fmt.Errorf(
+						"%w: can only set references to keys added within same transaction, please use bound references with AtTx set to 0",
+						ErrNoWaitOperationMustBeSelfContained)
 				}
 
 				_, exists := kmap[sha256.Sum256(x.ZAdd.Key)]
 
 				if req.NoWait && !exists {
-					return nil, ErrNoWaitOperationMustBeSelfContained
+					return nil, fmt.Errorf(
+						"%w: can not create a reference into a set for a key that was not set in the same transaction",
+						ErrNoWaitOperationMustBeSelfContained)
 				}
 
 				if !req.NoWait {

--- a/pkg/database/all_ops_test.go
+++ b/pkg/database/all_ops_test.go
@@ -550,7 +550,7 @@ func TestExecAllOpsDuplicatedKey(t *testing.T) {
 		},
 	}
 	_, err := db.ExecAll(aOps)
-	require.Equal(t, schema.ErrDuplicatedKeysNotSupported, err)
+	require.ErrorIs(t, err, schema.ErrDuplicatedKeysNotSupported)
 }
 
 func TestExecAllOpsDuplicatedKeyZAdd(t *testing.T) {

--- a/pkg/database/reference.go
+++ b/pkg/database/reference.go
@@ -18,6 +18,7 @@ package database
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/codenotary/immudb/embedded/store"
 	"github.com/codenotary/immudb/pkg/api/schema"
@@ -25,6 +26,7 @@ import (
 
 var ErrReferencedKeyCannotBeAReference = errors.New("referenced key cannot be a reference")
 var ErrFinalKeyCannotBeConvertedIntoReference = errors.New("final key cannot be converted into a reference")
+var ErrNoWaitOperationMustBeSelfContained = fmt.Errorf("no wait operation must be self-contained: %w", store.ErrIllegalArguments)
 
 //Reference ...
 func (d *db) SetReference(req *schema.ReferenceRequest) (*schema.TxHeader, error) {

--- a/pkg/database/sorted_set.go
+++ b/pkg/database/sorted_set.go
@@ -208,7 +208,7 @@ func (d *db) ZScan(req *schema.ZScanRequest) (*schema.ZEntries, error) {
 
 		atTx := binary.BigEndian.Uint64(zKey[keyOff+len(key):])
 
-		e, err := d.getAt(key, atTx, 0, snap, tx)
+		e, err := d.getAt(key, atTx, 1, snap, tx)
 		if err == store.ErrKeyNotFound {
 			// ignore deleted ones (referenced key may have been deleted)
 			continue


### PR DESCRIPTION
ExecAll operation provides the capability to atomically insert key-value pairs, references and sorted set entries. Even the possibility to bind references to the entries inserted into the ongoing transaction.

Due to the presence of references, the indexing must be up to date, degrading performance when execAll request is self-contained i.e. references are only created to entries written in the same request.

This PR leverages NoWait parameter to avoid waiting for the indexing to be up to date (faster processing time) at the expense of restricting references to be made to entries specified in the ongoing request.

As a side effect, not only a reference of references may be created in the database but also a reference entry can be switched to a plain key-value entry or the other way around. So to mitigate this situation, validations are incorporated when a reference or key is resolved.