### PR TITLE
Use /usr/bin/env bash for better portability.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ limitations under the License.
 
 export GO111MODULE=on
 
-SHELL=/bin/bash -o pipefail
+SHELL=/usr/bin/env bash -o pipefail
 
 VERSION=1.2.1
 DEFAULT_WEBCONSOLE_VERSION=1.0.14

--- a/build/xgo/build.sh
+++ b/build/xgo/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Patched script of xgo build.sh (MIT license)
 # Fork: https://github.com/techknowlogick/xgo

--- a/tools/autotest/Makefile
+++ b/tools/autotest/Makefile
@@ -1,4 +1,4 @@
-SHELL=/bin/bash -o pipefail
+SHELL=/usr/bin/env bash -o pipefail
 
 .PHONY: all
 all: requirements test1 test2

--- a/tools/autotest/autotest.sh
+++ b/tools/autotest/autotest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 NUM_DATA=5
 NUM_DB=2
 

--- a/tools/autotest/envpasswd.sh
+++ b/tools/autotest/envpasswd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 IMMUCLIENT=../../immuclient
 IMMUADMIN=../../immuadmin

--- a/tools/comparison/mongodb/run.sh
+++ b/tools/comparison/mongodb/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -Eeuo pipefail
 
 docker-entrypoint.sh mongod &

--- a/tools/mtls/generate.sh
+++ b/tools/mtls/generate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 
 # In this script an intermediate certificate is created from a root certificate
 


### PR DESCRIPTION
/bin/bash is not guaranteed to exist on all OSes. NixOS, for example.