### PR TITLE
fix(Dockerfile): Add ca-certificates.crt file to immudb image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,7 @@ COPY --from=build /src/immudb /usr/sbin/immudb
 COPY --from=build /src/immuadmin /usr/local/bin/immuadmin
 COPY --from=build --chown="$IMMU_UID:$IMMU_GID" /empty "$IMMUDB_HOME"
 COPY --from=build --chown="$IMMU_UID:$IMMU_GID" /empty "$IMMUDB_DIR"
+COPY --from=build "/etc/ssl/certs/ca-certificates.crt" "/etc/ssl/certs/ca-certificates.crt"
 
 EXPOSE 3322
 EXPOSE 9497


### PR DESCRIPTION
Without CA certificates, immudb is unable to connect
to official S3 servers.

Signed-off-by: Bartłomiej Święcki <bart@codenotary.com>