### PR TITLE
add <> as alternative to != in sql queries

### DIFF
--- a/embedded/sql/parser.go
+++ b/embedded/sql/parser.go
@@ -115,6 +115,7 @@ var boolValues = map[string]bool{
 var cmpOps = map[string]CmpOperator{
 	"=":  EQ,
 	"!=": NE,
+	"<>": NE,
 	"<":  LT,
 	"<=": LE,
 	">":  GT,

--- a/embedded/sql/parser_test.go
+++ b/embedded/sql/parser_test.go
@@ -744,6 +744,46 @@ func TestSelectStmt(t *testing.T) {
 			expectedError: nil,
 		},
 		{
+			input: "SELECT db1.table1.id, title FROM db1.table1 AS t1 WHERE id <> 1",
+			expectedOutput: []SQLStmt{
+				&SelectStmt{
+					distinct: false,
+					selectors: []Selector{
+						&ColSelector{db: "db1", table: "table1", col: "id"},
+						&ColSelector{col: "title"},
+					},
+					ds: &tableRef{db: "db1", table: "table1", as: "t1"},
+					where: &CmpBoolExp{
+						op: NE,
+						left: &ColSelector{
+							col: "id",
+						},
+						right: &Number{val: 1},
+					},
+				}},
+			expectedError: nil,
+		},
+		{
+			input: "SELECT db1.table1.id, title FROM db1.table1 AS t1 WHERE id != 1",
+			expectedOutput: []SQLStmt{
+				&SelectStmt{
+					distinct: false,
+					selectors: []Selector{
+						&ColSelector{db: "db1", table: "table1", col: "id"},
+						&ColSelector{col: "title"},
+					},
+					ds: &tableRef{db: "db1", table: "table1", as: "t1"},
+					where: &CmpBoolExp{
+						op: NE,
+						left: &ColSelector{
+							col: "id",
+						},
+						right: &Number{val: 1},
+					},
+				}},
+			expectedError: nil,
+		},
+		{
 			input: "SELECT DISTINCT id, time, name FROM table1 WHERE country = 'US' AND time <= NOW() AND name = @pname",
 			expectedOutput: []SQLStmt{
 				&SelectStmt{
@@ -1355,7 +1395,7 @@ func TestMultiLineStmts(t *testing.T) {
 
 			BEGIN TRANSACTION;
 				UPSERT INTO table1 (id, label) VALUES (100, 'label1');
-				
+
 				UPSERT INTO table2 (id) VALUES (10);
 			COMMIT;
 


### PR DESCRIPTION
This PR adds support for using `<>` in a not equal comparison in SQL queries. The current syntax `!=` for the operator is not affected by the change and can still be used.

The ANSI SQL standard defines `<>` as symbol for a not equal operator, but not `!=` (see e.g. https://en.wikipedia.org/wiki/Where_(SQL) ). Nevertheless most database engines (e.g. mysql, postgres)  support both `<>` and `!=` and  both can be used interchangeably.  To improve compatibility with automatic SQL statement generators, it would be advantageous to also support both. For example gorm creates SQL statements with `<>` in where clauses.

A Unit test for parsing `<>` as well as `!=` in a where clause is included in the PR.