### PR TITLE
Create home directory for user `immu`

### DIFF
--- a/Dockerfile.immuadmin
+++ b/Dockerfile.immuadmin
@@ -21,6 +21,8 @@ RUN addgroup --system --gid $IMMU_GID immu && \
     mkdir -p "$IMMUADMIN_TOKENFILE" && \
     chown -R immu:immu "$IMMUADMIN_TOKENFILE" && \
     chmod +x /usr/local/bin/immuadmin
+	
+RUN mkdir -p /home/immu && chown immu:immu /home/immu
 
 USER immu
 ENTRYPOINT ["/usr/local/bin/immuadmin"]


### PR DESCRIPTION
The home directory of `immu` user is missing in the image, so the following error `open /home/immu/token_admin: no such file or directory` occurred when `./bin/immuadmin login immudb` is done, and it is impossible to use `immuadmin`.
This PR just create the missing directory and set the right owner on it to fix this problem.