### PR TITLE
no cache update during compaction reads

### DIFF
--- a/embedded/tbtree/consistency_error_test.go
+++ b/embedded/tbtree/consistency_error_test.go
@@ -44,7 +44,7 @@ func consistencyCheck(t *testing.T, tbtree *TBtree, n node) {
 
 	case *nodeRef:
 		// check if reference is consistent with the node
-		sub, err := tbtree.nodeAt(n.off)
+		sub, err := tbtree.nodeAt(n.off, true)
 		require.NoError(t, err)
 		require.True(t, bytes.Equal(n._minKey, sub.minKey()))
 		require.True(t, bytes.Equal(n._maxKey, sub.maxKey()))

--- a/embedded/tbtree/snapshot.go
+++ b/embedded/tbtree/snapshot.go
@@ -452,7 +452,7 @@ func (n *nodeRef) writeTo(nw, hw io.Writer, writeOpts *WriteOpts) (nOff int64, w
 		return n.offset(), 0, 0, nil
 	}
 
-	node, err := n.t.nodeAt(n.off)
+	node, err := n.t.nodeAt(n.off, false)
 	if err != nil {
 		return 0, 0, 0, err
 	}


### PR DESCRIPTION
This PR includes ensures cache is not affected when reading nodes during compaction


Signed-off-by: Jeronimo Irazabal <jeronimo.irazabal@gmail.com>