### PR TITLE
chore(metrics): Add better flush / compaction metrics for btree

### DIFF
--- a/embedded/tbtree/metrics.go
+++ b/embedded/tbtree/metrics.go
@@ -7,14 +7,44 @@ import (
 
 // TODO: Those should be put behind abstract metrics system to avoid dependency on
 //       prometheus inside embedded package
-var metricsFlushingNodesProgress = promauto.NewGaugeVec(prometheus.GaugeOpts{
-	Name: "immudb_btree_flushing_nodes_progress",
-	Help: "Numbers of nodes written to disk during current flush process",
+var metricsFlushedNodesLastCycle = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "immudb_btree_flushed_nodes_last_cycle",
+	Help: "Numbers of btree nodes written to disk during the last flush process",
+}, []string{"id", "kind"})
+
+var metricsFlushedNodesTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "immudb_btree_flushed_nodes_total",
+	Help: "Number of btree nodes written to disk during flush since the immudb process was started",
+}, []string{"id", "kind"})
+
+var metricsFlushedEntriesLastCycle = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "immudb_btree_flushed_entries_last_cycle",
+	Help: "Numbers of btree entries written to disk during the last flush process",
 }, []string{"id"})
 
-var metricsFlushingNodesTotal = promauto.NewCounterVec(prometheus.CounterOpts{
-	Name: "immudb_btree_flushing_nodes_total",
-	Help: "Number of nodes written to disk during all flush cycles",
+var metricsFlushedEntriesTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "immudb_btree_flushed_entries_total",
+	Help: "Number of btree entries written to disk during flush since the immudb process was started",
+}, []string{"id"})
+
+var metricsCompactedNodesLastCycle = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "immudb_btree_compacted_nodes_last_cycle",
+	Help: "Numbers of btree nodes written to disk during the last compaction process",
+}, []string{"id", "kind"})
+
+var metricsCompactedNodesTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "immudb_btree_compacted_nodes_total",
+	Help: "Number of btree nodes written to disk during compaction since the immudb process was started",
+}, []string{"id", "kind"})
+
+var metricsCompactedEntriesLastCycle = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	Name: "immudb_btree_compacted_entries_last_cycle",
+	Help: "Numbers of btree entries written to disk during the last compaction process",
+}, []string{"id"})
+
+var metricsCompactedEntriesTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "immudb_btree_compacted_entries_total",
+	Help: "Number of btree entries written to disk during compaction since the immudb process was started",
 }, []string{"id"})
 
 var metricsCacheSizeStats = promauto.NewGaugeVec(prometheus.GaugeOpts{

--- a/embedded/tbtree/snapshot.go
+++ b/embedded/tbtree/snapshot.go
@@ -279,6 +279,7 @@ func (n *innerNode) writeTo(nw, hw io.Writer, writeOpts *WriteOpts) (nOff int64,
 			BaseNLogOffset: writeOpts.BaseNLogOffset + cnw,
 			BaseHLogOffset: writeOpts.BaseHLogOffset + chw,
 			commitLog:      writeOpts.commitLog,
+			reportProgress: writeOpts.reportProgress,
 		}
 
 		no, wn, wh, err := c.writeTo(nw, hw, wopts)
@@ -338,8 +339,7 @@ func (n *innerNode) writeTo(nw, hw io.Writer, writeOpts *WriteOpts) (nOff int64,
 		n.t.cachePut(n)
 	}
 
-	metricsFlushingNodesProgress.WithLabelValues(n.t.path).Inc()
-	metricsFlushingNodesTotal.WithLabelValues(n.t.path).Inc()
+	writeOpts.reportProgress(1, 0, 0)
 
 	return nOff, wN, chw, nil
 }
@@ -437,8 +437,7 @@ func (l *leafNode) writeTo(nw, hw io.Writer, writeOpts *WriteOpts) (nOff int64, 
 		l.t.cachePut(l)
 	}
 
-	metricsFlushingNodesProgress.WithLabelValues(l.t.path).Inc()
-	metricsFlushingNodesTotal.WithLabelValues(l.t.path).Inc()
+	writeOpts.reportProgress(0, 1, len(l.values))
 
 	return nOff, wN, accH, nil
 }

--- a/embedded/tbtree/snapshot_test.go
+++ b/embedded/tbtree/snapshot_test.go
@@ -45,6 +45,7 @@ func TestSnapshotSerialization(t *testing.T) {
 		OnlyMutated:    true,
 		BaseNLogOffset: 0,
 		BaseHLogOffset: 0,
+		reportProgress: func(innerWritten, leafNodesWritten, keysWritten int) {},
 	}
 	_, _, _, err = snapshot.WriteTo(dumpNBuf, dumpHBuf, wopts)
 	require.NoError(t, err)
@@ -74,6 +75,7 @@ func TestSnapshotSerialization(t *testing.T) {
 		OnlyMutated:    false,
 		BaseNLogOffset: 0,
 		BaseHLogOffset: 0,
+		reportProgress: func(innerWritten, leafNodesWritten, keysWritten int) {},
 	}
 	_, _, _, err = snapshot.WriteTo(fulldumpNBuf, fulldumpHBuf, wopts)
 	require.NoError(t, err)

--- a/embedded/tbtree/tbtree_test.go
+++ b/embedded/tbtree/tbtree_test.go
@@ -675,7 +675,7 @@ func TestTBTreeCompactionEdgeCases(t *testing.T) {
 		nLog.AppendFn = func(bs []byte) (off int64, n int, err error) {
 			return 0, 0, injectedError
 		}
-		err = tree.fullDumpTo(snap, nLog, cLog)
+		err = tree.fullDumpTo(snap, nLog, cLog, func(int, int, int) {})
 		require.ErrorIs(t, err, injectedError)
 	})
 
@@ -692,7 +692,7 @@ func TestTBTreeCompactionEdgeCases(t *testing.T) {
 		cLog.AppendFn = func(bs []byte) (off int64, n int, err error) {
 			return 0, 0, injectedError
 		}
-		err = tree.fullDumpTo(snap, nLog, cLog)
+		err = tree.fullDumpTo(snap, nLog, cLog, func(int, int, int) {})
 		require.ErrorIs(t, err, injectedError)
 	})
 
@@ -706,7 +706,7 @@ func TestTBTreeCompactionEdgeCases(t *testing.T) {
 		nLog.FlushFn = func() error {
 			return injectedError
 		}
-		err = tree.fullDumpTo(snap, nLog, cLog)
+		err = tree.fullDumpTo(snap, nLog, cLog, func(int, int, int) {})
 		require.ErrorIs(t, err, injectedError)
 	})
 
@@ -723,7 +723,7 @@ func TestTBTreeCompactionEdgeCases(t *testing.T) {
 		nLog.SyncFn = func() error {
 			return injectedError
 		}
-		err = tree.fullDumpTo(snap, nLog, cLog)
+		err = tree.fullDumpTo(snap, nLog, cLog, func(int, int, int) {})
 		require.ErrorIs(t, err, injectedError)
 	})
 
@@ -743,7 +743,7 @@ func TestTBTreeCompactionEdgeCases(t *testing.T) {
 		cLog.FlushFn = func() error {
 			return injectedError
 		}
-		err = tree.fullDumpTo(snap, nLog, cLog)
+		err = tree.fullDumpTo(snap, nLog, cLog, func(int, int, int) {})
 		require.ErrorIs(t, err, injectedError)
 	})
 
@@ -766,7 +766,7 @@ func TestTBTreeCompactionEdgeCases(t *testing.T) {
 		cLog.SyncFn = func() error {
 			return injectedError
 		}
-		err = tree.fullDumpTo(snap, nLog, cLog)
+		err = tree.fullDumpTo(snap, nLog, cLog, func(int, int, int) {})
 		require.ErrorIs(t, err, injectedError)
 	})
 }


### PR DESCRIPTION
* Add correct compaction metrics (previously merged with flush)
* Add label for nodes count to distinguish between inner and leaf nodes
* Add counters for number of values
* Add progress reporting during compaction

Signed-off-by: Bartłomiej Święcki <bart@codenotary.com>