### PR TITLE
fix(pkg/client): Use correct response for UpdateDatabaseV2

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -101,7 +101,7 @@ type ImmuClient interface {
 	CreateDatabaseV2(ctx context.Context, database string, settings *schema.DatabaseNullableSettings) (*schema.DatabaseNullableSettings, error)
 	UseDatabase(ctx context.Context, d *schema.Database) (*schema.UseDatabaseReply, error)
 	UpdateDatabase(ctx context.Context, settings *schema.DatabaseSettings) error
-	UpdateDatabaseV2(ctx context.Context, database string, settings *schema.DatabaseNullableSettings) (*schema.DatabaseNullableSettings, error)
+	UpdateDatabaseV2(ctx context.Context, database string, settings *schema.DatabaseNullableSettings) (*schema.UpdateDatabaseResponse, error)
 	GetDatabaseSettings(ctx context.Context) (*schema.DatabaseSettings, error)
 	GetDatabaseSettingsV2(ctx context.Context) (*schema.DatabaseNullableSettings, error)
 
@@ -1525,7 +1525,7 @@ func (c *immuClient) UpdateDatabase(ctx context.Context, settings *schema.Databa
 }
 
 // UpdateDatabaseV2 updates database settings
-func (c *immuClient) UpdateDatabaseV2(ctx context.Context, database string, settings *schema.DatabaseNullableSettings) (*schema.DatabaseNullableSettings, error) {
+func (c *immuClient) UpdateDatabaseV2(ctx context.Context, database string, settings *schema.DatabaseNullableSettings) (*schema.UpdateDatabaseResponse, error) {
 	start := time.Now()
 
 	if !c.IsConnected() {
@@ -1542,7 +1542,7 @@ func (c *immuClient) UpdateDatabaseV2(ctx context.Context, database string, sett
 
 	c.Logger.Debugf("UpdateDatabase finished in %s", time.Since(start))
 
-	return res.Settings, err
+	return res, err
 }
 
 func (c *immuClient) GetDatabaseSettings(ctx context.Context) (*schema.DatabaseSettings, error) {

--- a/pkg/client/clienttest/immuclient_mock.go
+++ b/pkg/client/clienttest/immuclient_mock.go
@@ -63,7 +63,7 @@ type ImmuClientMock struct {
 	CreateDatabaseF       func(context.Context, *schema.DatabaseSettings) error
 	CreateDatabaseV2F     func(context.Context, string, *schema.DatabaseNullableSettings) (*schema.DatabaseNullableSettings, error)
 	UpdateDatabaseF       func(context.Context, *schema.DatabaseSettings) error
-	UpdateDatabaseV2F     func(context.Context, string, *schema.DatabaseNullableSettings) (*schema.DatabaseNullableSettings, error)
+	UpdateDatabaseV2F     func(context.Context, string, *schema.DatabaseNullableSettings) (*schema.UpdateDatabaseResponse, error)
 	DatabaseListF         func(context.Context) (*schema.DatabaseListResponse, error)
 	ChangePasswordF       func(context.Context, []byte, []byte, []byte) error
 	CreateUserF           func(context.Context, []byte, []byte, uint32, string) error
@@ -185,7 +185,7 @@ func (icm *ImmuClientMock) UpdateDatabase(ctx context.Context, s *schema.Databas
 }
 
 // UpdateDatabaseV2 ...
-func (icm *ImmuClientMock) UpdateDatabaseV2(ctx context.Context, db string, setttings *schema.DatabaseNullableSettings) (*schema.DatabaseNullableSettings, error) {
+func (icm *ImmuClientMock) UpdateDatabaseV2(ctx context.Context, db string, setttings *schema.DatabaseNullableSettings) (*schema.UpdateDatabaseResponse, error) {
 	return icm.UpdateDatabaseV2F(ctx, db, setttings)
 }
 


### PR DESCRIPTION
The response from `UpdateDatabaseV2` GRPC endpoint is a dedicated structure currently containing only the current settings.

The pkg/client however did return directly those settings only preventing future extensions for that response without breaking backwards compatibility.