### PR TITLE
fix(Dockerfile): Fix HOME variable for podman

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,8 +53,9 @@ LABEL org.opencontainers.image.authors="CodeNotary, Inc. <info@codenotary.com>"
 
 ARG IMMU_UID="3322"
 ARG IMMU_GID="3322"
+ARG IMMUDB_HOME="/usr/share/immudb"
 
-ENV IMMUDB_HOME="/usr/share/immudb" \
+ENV IMMUDB_HOME="${IMMUDB_HOME}" \
     IMMUDB_DIR="/var/lib/immudb" \
     IMMUDB_ADDRESS="0.0.0.0" \
     IMMUDB_PORT="3322" \


### PR DESCRIPTION
With an empty HOME variable, immudb fail to start on podman
with the following message:
"Error: user: Current requires cgo or $HOME set in environment"

This fails here: https://cs.opensource.google/go/go/+/master:src/os/user/lookup_stubs.go;l=58
Because `HOME="${IMMUDB_HOME}"` on line 71 is not set without a prior `ARG`

For some reason docker always sets a HOME variable so it doesn't have this issue.

Signed-off-by: Benjamin Gentil <benjamin@gentil.io>