### PR TITLE
Added the pgsql flag and exposed the port 5432

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ ENV IMMUDB_HOME="/usr/share/immudb" \
     IMMUDB_DEVMODE="true" \
     IMMUDB_MAINTENANCE="false" \
     IMMUDB_ADMIN_PASSWORD="immudb" \
-    IMMUADMIN_TOKENFILE="/var/lib/immudb/admin_token"
+    IMMUADMIN_TOKENFILE="/var/lib/immudb/admin_token" \
+	IMMUDB_PGSQL_SERVER="false"
 
 RUN addgroup --system --gid $IMMU_GID immu && \
     adduser --system --uid $IMMU_UID --no-create-home --ingroup immu immu && \
@@ -42,6 +43,7 @@ RUN addgroup --system --gid $IMMU_GID immu && \
 EXPOSE 3322
 EXPOSE 9497
 EXPOSE 8080
+EXPOSE 5432
 
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD [ "/usr/local/bin/immuadmin", "status" ]
 USER immu


### PR DESCRIPTION
This allows the use of pgsql by exposing the port and env variable when immudb is run as docker container.

When run using the docker command --env flag can be used to override the IMMUDB_PGSQL_SERVER. Or when using flux/helm these variables can be overridden