### PR TITLE
non-transactional statements handling

### DIFF
--- a/embedded/sql/engine.go
+++ b/embedded/sql/engine.go
@@ -172,7 +172,7 @@ func (e *Engine) SetCurrentDatabase(dbName string) error {
 
 	db, exists := tx.catalog.dbsByName[dbName]
 	if !exists {
-		return fmt.Errorf("%w (%s)", ErrDatabaseDoesNotExist, dbName)
+		return ErrDatabaseDoesNotExist
 	}
 
 	e.mutex.Lock()

--- a/embedded/sql/stmt.go
+++ b/embedded/sql/stmt.go
@@ -234,12 +234,16 @@ func (stmt *UseDatabaseStmt) inferParameters(tx *SQLTx, params map[string]SQLVal
 }
 
 func (stmt *UseDatabaseStmt) execAt(tx *SQLTx, params map[string]interface{}) (*SQLTx, error) {
+	if stmt.DB == "" {
+		return tx, fmt.Errorf("%w: no database name was provided", ErrIllegalArguments)
+	}
+
 	if tx.engine.multidbHandler != nil {
 		if tx.explicitClose {
 			return nil, fmt.Errorf("%w: database selection can NOT be executed within a transaction block", ErrNonTransactionalStmt)
 		}
 
-		return nil, tx.engine.multidbHandler.UseDatabase(tx.ctx, stmt.DB)
+		return tx, tx.engine.multidbHandler.UseDatabase(tx.ctx, stmt.DB)
 	}
 
 	return tx, tx.useDatabase(stmt.DB)

--- a/embedded/sql/stmt.go
+++ b/embedded/sql/stmt.go
@@ -248,7 +248,7 @@ func (stmt *UseDatabaseStmt) execAt(tx *SQLTx, params map[string]interface{}) (*
 
 	_, exists := tx.catalog.dbsByName[stmt.DB]
 	if !exists {
-		return nil, fmt.Errorf("%w (%s)", ErrDatabaseDoesNotExist, stmt.DB)
+		return nil, ErrDatabaseDoesNotExist
 	}
 
 	tx.engine.mutex.Lock()

--- a/embedded/tools/stress_tool_sql/stress_tool_sql.go
+++ b/embedded/tools/stress_tool_sql/stress_tool_sql.go
@@ -153,7 +153,7 @@ func main() {
 		panic(err)
 	}
 
-	err = engine.SetDefaultDatabase("defaultdb")
+	_, _, err = engine.Exec("USE DATABASE defaultdb;", map[string]interface{}{}, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -96,7 +96,7 @@ type DB interface {
 	NewSQLTx(ctx context.Context) (*sql.SQLTx, error)
 
 	SQLExec(req *schema.SQLExecRequest, tx *sql.SQLTx) (ntx *sql.SQLTx, ctxs []*sql.SQLTx, err error)
-	SQLExecPrepared(stmts []sql.SQLStmt, namedParams []*schema.NamedParam, tx *sql.SQLTx) (ntx *sql.SQLTx, ctxs []*sql.SQLTx, err error)
+	SQLExecPrepared(stmts []sql.SQLStmt, params map[string]interface{}, tx *sql.SQLTx) (ntx *sql.SQLTx, ctxs []*sql.SQLTx, err error)
 
 	InferParameters(sql string, tx *sql.SQLTx) (map[string]sql.SQLValueType, error)
 	InferParametersPrepared(stmt sql.SQLStmt, tx *sql.SQLTx) (map[string]sql.SQLValueType, error)

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -229,7 +229,7 @@ func (d *db) initSQLEngine() error {
 		}
 	}
 
-	err := d.sqlEngine.SetDefaultDatabase(dbInstanceName)
+	err := d.sqlEngine.SetCurrentDatabase(dbInstanceName)
 	if err != nil && err != sql.ErrDatabaseDoesNotExist {
 		return err
 	}
@@ -240,7 +240,7 @@ func (d *db) initSQLEngine() error {
 			return logErr(d.Logger, "Unable to open store: %s", err)
 		}
 
-		err = d.sqlEngine.SetDefaultDatabase(dbInstanceName)
+		err = d.sqlEngine.SetCurrentDatabase(dbInstanceName)
 		if err != nil {
 			return err
 		}
@@ -291,7 +291,7 @@ func NewDB(dbName string, multidbHandler sql.MultiDBHandler, op *Options, log lo
 			return nil, logErr(dbi.Logger, "Unable to open database: %s", err)
 		}
 
-		err = dbi.sqlEngine.SetDefaultDatabase(dbInstanceName)
+		err = dbi.sqlEngine.SetCurrentDatabase(dbInstanceName)
 		if err != nil {
 			return nil, logErr(dbi.Logger, "Unable to open database: %s", err)
 		}

--- a/pkg/database/database_test.go
+++ b/pkg/database/database_test.go
@@ -96,6 +96,10 @@ func (h *dummyMultidbHandler) UseDatabase(ctx context.Context, db string) error 
 	return sql.ErrNoSupported
 }
 
+func (h *dummyMultidbHandler) ExecPreparedStmts(ctx context.Context, stmts []sql.SQLStmt, params map[string]interface{}) (ntx *sql.SQLTx, committedTxs []*sql.SQLTx, err error) {
+	return nil, nil, sql.ErrNoSupported
+}
+
 func TestDefaultDbCreation(t *testing.T) {
 	options := DefaultOption()
 	db, err := NewDB("mydb", nil, options, logger.NewSimpleLogger("immudb ", os.Stderr))

--- a/pkg/database/sql.go
+++ b/pkg/database/sql.go
@@ -31,7 +31,7 @@ import (
 var ErrSQLNotReady = errors.New("SQL catalog not yet replicated")
 
 func (d *db) reloadSQLCatalog() error {
-	err := d.sqlEngine.SetDefaultDatabase(dbInstanceName)
+	err := d.sqlEngine.SetCurrentDatabase(dbInstanceName)
 	if err == sql.ErrDatabaseDoesNotExist {
 		return ErrSQLNotReady
 	}

--- a/pkg/pgsql/server/query_machine.go
+++ b/pkg/pgsql/server/query_machine.go
@@ -280,10 +280,17 @@ func (s *session) query(st *sql.SelectStmt, parameters []*schema.NamedParam, res
 	return nil
 }
 
-func (s *session) exec(st sql.SQLStmt, parameters []*schema.NamedParam, resultColumnFormatCodes []int16, skipRowDesc bool) error {
-	if _, _, err := s.database.SQLExecPrepared([]sql.SQLStmt{st}, parameters, nil); err != nil {
+func (s *session) exec(st sql.SQLStmt, namedParams []*schema.NamedParam, resultColumnFormatCodes []int16, skipRowDesc bool) error {
+	params := make(map[string]interface{}, len(namedParams))
+
+	for _, p := range namedParams {
+		params[p.Name] = schema.RawValue(p.Value)
+	}
+
+	if _, _, err := s.database.SQLExecPrepared([]sql.SQLStmt{st}, params, nil); err != nil {
 		return err
 	}
+
 	return nil
 }
 

--- a/pkg/server/db_dummy_closed.go
+++ b/pkg/server/db_dummy_closed.go
@@ -140,7 +140,7 @@ func (db *closedDB) SQLExec(req *schema.SQLExecRequest, tx *sql.SQLTx) (ntx *sql
 	return nil, nil, store.ErrAlreadyClosed
 }
 
-func (db *closedDB) SQLExecPrepared(stmts []sql.SQLStmt, namedParams []*schema.NamedParam, tx *sql.SQLTx) (ntx *sql.SQLTx, ctxs []*sql.SQLTx, err error) {
+func (db *closedDB) SQLExecPrepared(stmts []sql.SQLStmt, params map[string]interface{}, tx *sql.SQLTx) (ntx *sql.SQLTx, ctxs []*sql.SQLTx, err error) {
 	return nil, nil, store.ErrAlreadyClosed
 }
 

--- a/pkg/server/multidb_handler.go
+++ b/pkg/server/multidb_handler.go
@@ -63,3 +63,17 @@ func (h *multidbHandler) ListDatabases(ctx context.Context) ([]string, error) {
 
 	return dbs, nil
 }
+
+func (h *multidbHandler) ExecPreparedStmts(ctx context.Context, stmts []sql.SQLStmt, params map[string]interface{}) (ntx *sql.SQLTx, committedTxs []*sql.SQLTx, err error) {
+	db, err := h.s.getDBFromCtx(ctx, "SQLExec")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tx, err := db.NewSQLTx(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return db.SQLExecPrepared(stmts, params, tx)
+}


### PR DESCRIPTION
TODO: extract multidb handler from the sql engine

Note:
Database creation  (`CREATE DATABASE`) and selection  (`USE DATABASE`) statements are non-transactional in both, embedded and with external multidb handler (e.g. when using the server for processing these statements).
Therefore, this two statements are not allowed inside a `BEGIN TRANSACTION`/`COMMIT`|`ROLLBACK` block

Signed-off-by: Jeronimo Irazabal <jeronimo.irazabal@gmail.com>