### PR TITLE
fix(embedded/sql): increase auto_increment pk once per row

### DIFF
--- a/embedded/sql/engine_test.go
+++ b/embedded/sql/engine_test.go
@@ -685,7 +685,14 @@ func TestAutoIncrementPK(t *testing.T) {
 		require.ErrorIs(t, err, ErrLimitedAutoIncrement)
 	})
 
-	_, _, err = engine.Exec("CREATE TABLE table1 (id INTEGER NOT NULL AUTO_INCREMENT, title VARCHAR, PRIMARY KEY id)", nil, nil)
+	_, _, err = engine.Exec(`
+			CREATE TABLE table1 (
+				id INTEGER NOT NULL AUTO_INCREMENT,
+				title VARCHAR,
+				active BOOLEAN,
+				PRIMARY KEY id
+			)
+	`, nil, nil)
 	require.NoError(t, err)
 
 	_, ctxs, err := engine.Exec("INSERT INTO table1(title) VALUES ('name1')", nil, nil)

--- a/embedded/sql/stmt.go
+++ b/embedded/sql/stmt.go
@@ -537,7 +537,7 @@ func (stmt *UpsertIntoStmt) execAt(tx *SQLTx, params map[string]interface{}) (*S
 				}
 
 				// inject auto-incremental pk value
-				if stmt.isInsert && table.autoIncrementPK {
+				if stmt.isInsert && col.autoIncrement {
 					// current implementation assumes only PK can be set as autoincremental
 					table.maxPK++
 


### PR DESCRIPTION
fixes the situation that could let auto_increment columns be increased multiple times per row when nullable columns were defined in the table and no value was specified at insertion time

Signed-off-by: Jeronimo Irazabal <jeronimo.irazabal@gmail.com>