### PR TITLE
fix(pkg/database): avoid silent returns when the scan limit is reached

### DIFF
--- a/pkg/database/all_ops_test.go
+++ b/pkg/database/all_ops_test.go
@@ -284,7 +284,7 @@ func TestExecAllOps(t *testing.T) {
 		Set: []byte(`mySet`),
 	}
 	zList, err := db.ZScan(zScanOpt)
-	require.ErrorIs(t, err, ErrMaxResultSizeLimitReached)
+	require.ErrorIs(t, err, ErrResultSizeLimitReached)
 	println(len(zList.Entries))
 	require.Len(t, zList.Entries, batchCount*batchSize)
 }
@@ -761,13 +761,13 @@ func TestExecAllNoWait(t *testing.T) {
 
 		// ref became a reference of a reference
 		_, err = db.Get(&schema.KeyRequest{Key: []byte("ref")})
-		require.ErrorIs(t, err, ErrMaxKeyResolutionLimitReached)
+		require.ErrorIs(t, err, ErrKeyResolutionLimitReached)
 
 		// "key" became a reference
 		_, err = db.ZScan(&schema.ZScanRequest{
 			Set: []byte("set"),
 		})
-		require.ErrorIs(t, err, ErrMaxKeyResolutionLimitReached)
+		require.ErrorIs(t, err, ErrKeyResolutionLimitReached)
 	})
 }
 

--- a/pkg/database/all_ops_test.go
+++ b/pkg/database/all_ops_test.go
@@ -284,7 +284,7 @@ func TestExecAllOps(t *testing.T) {
 		Set: []byte(`mySet`),
 	}
 	zList, err := db.ZScan(zScanOpt)
-	require.ErrorIs(t, err, ErrMaxKeyScanLimitReached)
+	require.ErrorIs(t, err, ErrMaxResultSizeLimitReached)
 	println(len(zList.Entries))
 	require.Len(t, zList.Entries, batchCount*batchSize)
 }

--- a/pkg/database/all_ops_test.go
+++ b/pkg/database/all_ops_test.go
@@ -284,7 +284,7 @@ func TestExecAllOps(t *testing.T) {
 		Set: []byte(`mySet`),
 	}
 	zList, err := db.ZScan(zScanOpt)
-	require.NoError(t, err)
+	require.ErrorIs(t, err, ErrMaxKeyScanLimitReached)
 	println(len(zList.Entries))
 	require.Len(t, zList.Entries, batchCount*batchSize)
 }

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -36,6 +36,7 @@ import (
 )
 
 const MaxKeyResolutionLimit = 1
+const MaxKeyScanLimit = 1000
 
 const dbInstanceName = "dbinstance"
 
@@ -129,8 +130,6 @@ type DB interface {
 	Close() error
 }
 
-const defaultMaxResultSize = 1000
-
 //IDB database instance
 type db struct {
 	st *store.ImmuStore
@@ -161,7 +160,7 @@ func OpenDB(dbName string, multidbHandler sql.MultiDBHandler, op *Options, log l
 		Logger:        log,
 		options:       op,
 		name:          dbName,
-		maxResultSize: defaultMaxResultSize,
+		maxResultSize: MaxKeyScanLimit,
 		mutex:         &instrumentedRWMutex{},
 	}
 
@@ -267,7 +266,7 @@ func NewDB(dbName string, multidbHandler sql.MultiDBHandler, op *Options, log lo
 		Logger:        log,
 		options:       op,
 		name:          dbName,
-		maxResultSize: defaultMaxResultSize,
+		maxResultSize: MaxKeyScanLimit,
 		mutex:         &instrumentedRWMutex{},
 	}
 

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -1225,7 +1225,7 @@ func (d *db) TxScan(req *schema.TxScanRequest) (*schema.TxList, error) {
 	}
 
 	if req.Limit > MaxKeyScanLimit {
-		return nil, fmt.Errorf("%w: limit is %d", ErrMaxKeyScanLimitExceeded, MaxKeyScanLimit)
+		return nil, fmt.Errorf("%w: %d is the limit", ErrMaxKeyScanLimitExceeded, MaxKeyScanLimit)
 	}
 
 	limit := int(req.Limit)
@@ -1264,7 +1264,7 @@ func (d *db) TxScan(req *schema.TxScanRequest) (*schema.TxList, error) {
 		txList.Txs = append(txList.Txs, sTx)
 
 		if l == MaxKeyScanLimit {
-			return txList, fmt.Errorf("%w: limit is %d", ErrMaxKeyScanLimitReached, MaxKeyScanLimit)
+			return txList, fmt.Errorf("%w: %d is the limit", ErrMaxKeyScanLimitReached, MaxKeyScanLimit)
 		}
 	}
 
@@ -1278,7 +1278,7 @@ func (d *db) History(req *schema.HistoryRequest) (*schema.Entries, error) {
 	}
 
 	if req.Limit > MaxKeyScanLimit {
-		return nil, fmt.Errorf("%w: limit is %d", ErrMaxKeyScanLimitExceeded, MaxKeyScanLimit)
+		return nil, fmt.Errorf("%w: %d is the limit", ErrMaxKeyScanLimitExceeded, MaxKeyScanLimit)
 	}
 
 	currTxID, _ := d.st.Alh()
@@ -1357,7 +1357,7 @@ func (d *db) History(req *schema.HistoryRequest) (*schema.Entries, error) {
 	}
 
 	if limit == MaxKeyScanLimit && hCount >= MaxKeyScanLimit {
-		return list, fmt.Errorf("%w: limit is %d", ErrMaxKeyScanLimitReached, MaxKeyScanLimit)
+		return list, fmt.Errorf("%w: %d is the limit", ErrMaxKeyScanLimitReached, MaxKeyScanLimit)
 	}
 
 	return list, nil

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -39,9 +39,9 @@ const MaxKeyResolutionLimit = 1
 
 const dbInstanceName = "dbinstance"
 
-var ErrMaxKeyResolutionLimitReached = errors.New("max key resolution limit reached. It may be due to cyclic references")
-var ErrMaxResultSizeLimitExceeded = errors.New("max result size limit exceeded")
-var ErrMaxResultSizeLimitReached = errors.New("max result size limit reached")
+var ErrKeyResolutionLimitReached = errors.New("key resolution limit reached. It may be due to cyclic references")
+var ErrResultSizeLimitExceeded = errors.New("result size limit exceeded")
+var ErrResultSizeLimitReached = errors.New("result size limit reached")
 var ErrIllegalArguments = store.ErrIllegalArguments
 var ErrIllegalState = store.ErrIllegalState
 var ErrIsReplica = errors.New("database is read-only because it's a replica")
@@ -585,7 +585,7 @@ func (d *db) resolveValue(
 			)
 		}
 		if resolved == MaxKeyResolutionLimit {
-			return nil, ErrMaxKeyResolutionLimitReached
+			return nil, ErrKeyResolutionLimitReached
 		}
 
 		atTx := binary.BigEndian.Uint64(TrimPrefix(val))
@@ -1232,7 +1232,7 @@ func (d *db) TxScan(req *schema.TxScanRequest) (*schema.TxList, error) {
 
 	if int(req.Limit) > d.maxResultSize {
 		return nil, fmt.Errorf("%w: the specified limit (%d) is larger than the maximum allowed one (%d)",
-			ErrMaxResultSizeLimitExceeded, req.Limit, d.maxResultSize)
+			ErrResultSizeLimitExceeded, req.Limit, d.maxResultSize)
 	}
 
 	limit := int(req.Limit)
@@ -1274,7 +1274,7 @@ func (d *db) TxScan(req *schema.TxScanRequest) (*schema.TxList, error) {
 			return txList,
 				fmt.Errorf("%w: found at least %d entries (maximum limit). "+
 					"Pagination over large results can be achieved by using the limit and initialTx arguments",
-					ErrMaxResultSizeLimitReached, d.maxResultSize)
+					ErrResultSizeLimitReached, d.maxResultSize)
 		}
 	}
 
@@ -1289,7 +1289,7 @@ func (d *db) History(req *schema.HistoryRequest) (*schema.Entries, error) {
 
 	if int(req.Limit) > d.maxResultSize {
 		return nil, fmt.Errorf("%w: the specified limit (%d) is larger than the maximum allowed one (%d)",
-			ErrMaxResultSizeLimitExceeded, req.Limit, d.maxResultSize)
+			ErrResultSizeLimitExceeded, req.Limit, d.maxResultSize)
 	}
 
 	currTxID, _ := d.st.Alh()
@@ -1371,7 +1371,7 @@ func (d *db) History(req *schema.HistoryRequest) (*schema.Entries, error) {
 		return list,
 			fmt.Errorf("%w: found at least %d entries (the maximum limit). "+
 				"Pagination over large results can be achieved by using the limit and initialTx arguments",
-				ErrMaxResultSizeLimitReached, d.maxResultSize)
+				ErrResultSizeLimitReached, d.maxResultSize)
 	}
 
 	return list, nil

--- a/pkg/database/database_test.go
+++ b/pkg/database/database_test.go
@@ -931,7 +931,7 @@ func TestTxScan(t *testing.T) {
 		InitialTx: 1,
 		Limit:     MaxKeyScanLimit + 1,
 	})
-	require.Equal(t, ErrMaxKeyScanLimitExceeded, err)
+	require.ErrorIs(t, err, ErrMaxKeyScanLimitExceeded)
 
 	t.Run("values should be returned", func(t *testing.T) {
 		txList, err := db.TxScan(&schema.TxScanRequest{
@@ -1006,7 +1006,7 @@ func TestHistory(t *testing.T) {
 		SinceTx: lastTx,
 		Limit:   MaxKeyScanLimit + 1,
 	})
-	require.Equal(t, ErrMaxKeyScanLimitExceeded, err)
+	require.ErrorIs(t, err, ErrMaxKeyScanLimitExceeded)
 
 	inc, err := db.History(&schema.HistoryRequest{
 		Key:     kvs[0].Key,

--- a/pkg/database/database_test.go
+++ b/pkg/database/database_test.go
@@ -936,7 +936,7 @@ func TestTxScan(t *testing.T) {
 		InitialTx: 1,
 		Limit:     uint32(db.MaxResultSize() + 1),
 	})
-	require.ErrorIs(t, err, ErrMaxResultSizeLimitExceeded)
+	require.ErrorIs(t, err, ErrResultSizeLimitExceeded)
 
 	t.Run("values should be returned reaching result size limit", func(t *testing.T) {
 		txList, err := db.TxScan(&schema.TxScanRequest{
@@ -947,7 +947,7 @@ func TestTxScan(t *testing.T) {
 				},
 			},
 		})
-		require.ErrorIs(t, err, ErrMaxResultSizeLimitReached)
+		require.ErrorIs(t, err, ErrResultSizeLimitReached)
 		require.Len(t, txList.Txs, len(kvs))
 
 		for i := 0; i < len(kvs); i++ {
@@ -985,7 +985,7 @@ func TestTxScan(t *testing.T) {
 		txList, err := db.TxScan(&schema.TxScanRequest{
 			InitialTx: initialState.TxId + 1,
 		})
-		require.ErrorIs(t, err, ErrMaxResultSizeLimitReached)
+		require.ErrorIs(t, err, ErrResultSizeLimitReached)
 		require.Len(t, txList.Txs, len(kvs))
 
 		for i := 0; i < len(kvs); i++ {
@@ -1036,13 +1036,13 @@ func TestHistory(t *testing.T) {
 		SinceTx: lastTx,
 		Limit:   int32(db.MaxResultSize() + 1),
 	})
-	require.ErrorIs(t, err, ErrMaxResultSizeLimitExceeded)
+	require.ErrorIs(t, err, ErrResultSizeLimitExceeded)
 
 	inc, err := db.History(&schema.HistoryRequest{
 		Key:     kvs[0].Key,
 		SinceTx: lastTx,
 	})
-	require.ErrorIs(t, err, ErrMaxResultSizeLimitReached)
+	require.ErrorIs(t, err, ErrResultSizeLimitReached)
 
 	for i, val := range inc.Entries {
 		require.Equal(t, kvs[0].Key, val.Key)
@@ -1059,7 +1059,7 @@ func TestHistory(t *testing.T) {
 		SinceTx: lastTx,
 		Desc:    true,
 	})
-	require.ErrorIs(t, err, ErrMaxResultSizeLimitReached)
+	require.ErrorIs(t, err, ErrResultSizeLimitReached)
 
 	for i, val := range dec.Entries {
 		require.Equal(t, kvs[0].Key, val.Key)

--- a/pkg/database/scan.go
+++ b/pkg/database/scan.go
@@ -16,6 +16,8 @@ limitations under the License.
 package database
 
 import (
+	"fmt"
+
 	"github.com/codenotary/immudb/embedded/store"
 	"github.com/codenotary/immudb/pkg/api/schema"
 )
@@ -32,7 +34,7 @@ func (d *db) Scan(req *schema.ScanRequest) (*schema.Entries, error) {
 	}
 
 	if req.Limit > MaxKeyScanLimit {
-		return nil, ErrMaxKeyScanLimitExceeded
+		return nil, fmt.Errorf("%w: limit is %d", ErrMaxKeyScanLimitExceeded, MaxKeyScanLimit)
 	}
 
 	waitUntilTx := req.SinceTx
@@ -47,14 +49,11 @@ func (d *db) Scan(req *schema.ScanRequest) (*schema.Entries, error) {
 		}
 	}
 
-	limit := req.Limit
+	limit := int(req.Limit)
 
 	if req.Limit == 0 {
 		limit = MaxKeyScanLimit
 	}
-
-	var entries []*schema.Entry
-	i := uint64(0)
 
 	snap, err := d.st.SnapshotSince(waitUntilTx)
 	if err != nil {
@@ -90,7 +89,9 @@ func (d *db) Scan(req *schema.ScanRequest) (*schema.Entries, error) {
 
 	tx := d.st.NewTxHolder()
 
-	for {
+	entries := &schema.Entries{}
+
+	for l := 1; l <= limit; l++ {
 		key, valRef, err := r.Read()
 		if err == store.ErrNoMoreEntries {
 			break
@@ -108,13 +109,12 @@ func (d *db) Scan(req *schema.ScanRequest) (*schema.Entries, error) {
 			return nil, err
 		}
 
-		entries = append(entries, e)
-		if i++; i == limit {
-			break
+		entries.Entries = append(entries.Entries, e)
+
+		if l == MaxKeyScanLimit {
+			return entries, fmt.Errorf("%w: limit is %d", ErrMaxKeyScanLimitReached, MaxKeyScanLimit)
 		}
 	}
 
-	return &schema.Entries{
-		Entries: entries,
-	}, nil
+	return entries, nil
 }

--- a/pkg/database/scan.go
+++ b/pkg/database/scan.go
@@ -34,7 +34,7 @@ func (d *db) Scan(req *schema.ScanRequest) (*schema.Entries, error) {
 	}
 
 	if req.Limit > MaxKeyScanLimit {
-		return nil, fmt.Errorf("%w: limit is %d", ErrMaxKeyScanLimitExceeded, MaxKeyScanLimit)
+		return nil, fmt.Errorf("%w: %d is the limit", ErrMaxKeyScanLimitExceeded, MaxKeyScanLimit)
 	}
 
 	waitUntilTx := req.SinceTx
@@ -112,7 +112,7 @@ func (d *db) Scan(req *schema.ScanRequest) (*schema.Entries, error) {
 		entries.Entries = append(entries.Entries, e)
 
 		if l == MaxKeyScanLimit {
-			return entries, fmt.Errorf("%w: limit is %d", ErrMaxKeyScanLimitReached, MaxKeyScanLimit)
+			return entries, fmt.Errorf("%w: %d is the limit", ErrMaxKeyScanLimitReached, MaxKeyScanLimit)
 		}
 	}
 

--- a/pkg/database/scan.go
+++ b/pkg/database/scan.go
@@ -35,7 +35,7 @@ func (d *db) Scan(req *schema.ScanRequest) (*schema.Entries, error) {
 
 	if req.Limit > uint64(d.maxResultSize) {
 		return nil, fmt.Errorf("%w: the specified limit (%d) is larger than the maximum allowed one (%d)",
-			ErrMaxResultSizeLimitExceeded, req.Limit, d.maxResultSize)
+			ErrResultSizeLimitExceeded, req.Limit, d.maxResultSize)
 	}
 
 	waitUntilTx := req.SinceTx
@@ -116,7 +116,7 @@ func (d *db) Scan(req *schema.ScanRequest) (*schema.Entries, error) {
 			return entries,
 				fmt.Errorf("%w: found at least %d entries (the maximum limit). "+
 					"Pagination over large results can be achieved by using the limit and initialTx arguments",
-					ErrMaxResultSizeLimitReached, d.maxResultSize)
+					ErrResultSizeLimitReached, d.maxResultSize)
 		}
 	}
 

--- a/pkg/database/scan_test.go
+++ b/pkg/database/scan_test.go
@@ -58,7 +58,7 @@ func TestStoreScan(t *testing.T) {
 	}
 
 	_, err = db.Scan(&scanOptions)
-	require.ErrorIs(t, err, ErrMaxResultSizeLimitExceeded)
+	require.ErrorIs(t, err, ErrResultSizeLimitExceeded)
 
 	scanOptions = schema.ScanRequest{
 		SeekKey: []byte(`b`),
@@ -83,7 +83,7 @@ func TestStoreScan(t *testing.T) {
 	}
 
 	list1, err := db.Scan(&scanOptions1)
-	require.ErrorIs(t, err, ErrMaxResultSizeLimitReached)
+	require.ErrorIs(t, err, ErrResultSizeLimitReached)
 	require.Exactly(t, 3, len(list1.Entries))
 	require.Equal(t, list1.Entries[0].Key, []byte(`aaa`))
 	require.Equal(t, list1.Entries[0].Value, []byte(`item1`))

--- a/pkg/database/scan_test.go
+++ b/pkg/database/scan_test.go
@@ -56,7 +56,7 @@ func TestStoreScan(t *testing.T) {
 	}
 
 	_, err = db.Scan(&scanOptions)
-	require.Equal(t, ErrMaxKeyScanLimitExceeded, err)
+	require.ErrorIs(t, err, ErrMaxKeyScanLimitExceeded)
 
 	scanOptions = schema.ScanRequest{
 		SeekKey: []byte(`b`),

--- a/pkg/database/sorted_set.go
+++ b/pkg/database/sorted_set.go
@@ -101,7 +101,7 @@ func (d *db) ZScan(req *schema.ZScanRequest) (*schema.ZEntries, error) {
 
 	if req.Limit > uint64(d.maxResultSize) {
 		return nil, fmt.Errorf("%w: the specified limit (%d) is larger than the maximum allowed one (%d)",
-			ErrMaxResultSizeLimitExceeded, req.Limit, d.maxResultSize)
+			ErrResultSizeLimitExceeded, req.Limit, d.maxResultSize)
 	}
 
 	limit := int(req.Limit)
@@ -239,7 +239,7 @@ func (d *db) ZScan(req *schema.ZScanRequest) (*schema.ZEntries, error) {
 		if l == d.maxResultSize {
 			return entries, fmt.Errorf("%w: found at least %d entries (the maximum limit). "+
 				"Pagination over large results can be achieved by using the limit, seekKey, seekScore and seekAtTx arguments",
-				ErrMaxResultSizeLimitReached, d.maxResultSize)
+				ErrResultSizeLimitReached, d.maxResultSize)
 		}
 	}
 

--- a/pkg/database/sorted_set.go
+++ b/pkg/database/sorted_set.go
@@ -100,7 +100,7 @@ func (d *db) ZScan(req *schema.ZScanRequest) (*schema.ZEntries, error) {
 	}
 
 	if req.Limit > MaxKeyScanLimit {
-		return nil, fmt.Errorf("%w: limit is %d", ErrMaxKeyScanLimitExceeded, MaxKeyScanLimit)
+		return nil, fmt.Errorf("%w: %d is the limit", ErrMaxKeyScanLimitExceeded, MaxKeyScanLimit)
 	}
 
 	limit := int(req.Limit)
@@ -236,7 +236,7 @@ func (d *db) ZScan(req *schema.ZScanRequest) (*schema.ZEntries, error) {
 		entries.Entries = append(entries.Entries, zentry)
 
 		if l == MaxKeyScanLimit {
-			return entries, fmt.Errorf("%w: limit is %d", ErrMaxKeyScanLimitReached, MaxKeyScanLimit)
+			return entries, fmt.Errorf("%w: %d is the limit", ErrMaxKeyScanLimitReached, MaxKeyScanLimit)
 		}
 	}
 

--- a/pkg/database/sorted_set_test.go
+++ b/pkg/database/sorted_set_test.go
@@ -83,7 +83,7 @@ func TestStoreIndexExists(t *testing.T) {
 	}
 
 	_, err = db.ZScan(zscanOpts)
-	require.ErrorIs(t, err, ErrMaxResultSizeLimitExceeded)
+	require.ErrorIs(t, err, ErrResultSizeLimitExceeded)
 
 	//try to retrieve directly the value or full scan to debug
 

--- a/pkg/database/sorted_set_test.go
+++ b/pkg/database/sorted_set_test.go
@@ -79,11 +79,11 @@ func TestStoreIndexExists(t *testing.T) {
 
 	zscanOpts := &schema.ZScanRequest{
 		Set:   []byte(`firstIndex`),
-		Limit: MaxKeyScanLimit + 1,
+		Limit: uint64(db.MaxResultSize() + 1),
 	}
 
 	_, err = db.ZScan(zscanOpts)
-	require.ErrorIs(t, err, ErrMaxKeyScanLimitExceeded)
+	require.ErrorIs(t, err, ErrMaxResultSizeLimitExceeded)
 
 	//try to retrieve directly the value or full scan to debug
 

--- a/pkg/database/sorted_set_test.go
+++ b/pkg/database/sorted_set_test.go
@@ -83,7 +83,7 @@ func TestStoreIndexExists(t *testing.T) {
 	}
 
 	_, err = db.ZScan(zscanOpts)
-	require.Equal(t, ErrMaxKeyScanLimitExceeded, err)
+	require.ErrorIs(t, err, ErrMaxKeyScanLimitExceeded)
 
 	//try to retrieve directly the value or full scan to debug
 

--- a/pkg/database/sql.go
+++ b/pkg/database/sql.go
@@ -439,7 +439,7 @@ func (d *db) SQLQueryPrepared(stmt sql.DataSource, namedParams []*schema.NamedPa
 		res.Rows = append(res.Rows, rrow)
 
 		if l == MaxKeyScanLimit {
-			return res, fmt.Errorf("%w: limit is %d", ErrMaxKeyScanLimitReached, MaxKeyScanLimit)
+			return res, fmt.Errorf("%w: %d is the limit", ErrMaxKeyScanLimitReached, MaxKeyScanLimit)
 		}
 	}
 

--- a/pkg/database/sql.go
+++ b/pkg/database/sql.go
@@ -441,7 +441,7 @@ func (d *db) SQLQueryPrepared(stmt sql.DataSource, namedParams []*schema.NamedPa
 		if l == d.maxResultSize {
 			return res, fmt.Errorf("%w: found at least %d rows (the maximum limit). "+
 				"Query constraints can be applied using the LIMIT clause",
-				ErrMaxResultSizeLimitReached, d.maxResultSize)
+				ErrResultSizeLimitReached, d.maxResultSize)
 		}
 	}
 

--- a/pkg/database/sql.go
+++ b/pkg/database/sql.go
@@ -409,11 +409,7 @@ func (d *db) SQLQueryPrepared(stmt sql.DataSource, namedParams []*schema.NamedPa
 
 	res := &schema.SQLQueryResult{Columns: cols}
 
-	for l := 0; ; l++ {
-		if l == MaxKeyScanLimit {
-			return res, ErrMaxKeyScanLimitExceeded
-		}
-
+	for l := 1; ; l++ {
 		row, err := r.Read()
 		if err == sql.ErrNoMoreRows {
 			break
@@ -441,6 +437,10 @@ func (d *db) SQLQueryPrepared(stmt sql.DataSource, namedParams []*schema.NamedPa
 		}
 
 		res.Rows = append(res.Rows, rrow)
+
+		if l == MaxKeyScanLimit {
+			return res, fmt.Errorf("%w: limit is %d", ErrMaxKeyScanLimitReached, MaxKeyScanLimit)
+		}
 	}
 
 	return res, nil

--- a/pkg/database/sql.go
+++ b/pkg/database/sql.go
@@ -438,8 +438,10 @@ func (d *db) SQLQueryPrepared(stmt sql.DataSource, namedParams []*schema.NamedPa
 
 		res.Rows = append(res.Rows, rrow)
 
-		if l == MaxKeyScanLimit {
-			return res, fmt.Errorf("%w: %d is the limit", ErrMaxKeyScanLimitReached, MaxKeyScanLimit)
+		if l == d.maxResultSize {
+			return res, fmt.Errorf("%w: found at least %d rows (the maximum limit). "+
+				"Query constraints can be applied using the LIMIT clause",
+				ErrMaxResultSizeLimitReached, d.maxResultSize)
 		}
 	}
 

--- a/pkg/database/sql_test.go
+++ b/pkg/database/sql_test.go
@@ -92,7 +92,7 @@ func TestSQLExecAndQuery(t *testing.T) {
 
 	q = "SELECT t.id, t.id as id2, title, active, payload FROM table1 t WHERE id <= 3 AND active != @active"
 	res, err = db.SQLQuery(&schema.SQLQueryRequest{Sql: q, Params: params}, nil)
-	require.ErrorIs(t, err, ErrMaxResultSizeLimitReached)
+	require.ErrorIs(t, err, ErrResultSizeLimitReached)
 	require.Len(t, res.Rows, 2)
 
 	inferredParams, err := db.InferParameters(q, nil)

--- a/pkg/server/db_dummy_closed.go
+++ b/pkg/server/db_dummy_closed.go
@@ -52,6 +52,10 @@ func (db *closedDB) IsReplica() bool {
 	return false
 }
 
+func (db *closedDB) MaxResultSize() int {
+	return 1000
+}
+
 func (db *closedDB) UseTimeFunc(timeFunc store.TimeFunc) error {
 	return store.ErrAlreadyClosed
 }

--- a/pkg/server/db_dummy_closed_test.go
+++ b/pkg/server/db_dummy_closed_test.go
@@ -31,6 +31,8 @@ func TestDummyClosedDatabase(t *testing.T) {
 
 	require.False(t, cdb.IsReplica())
 
+	require.Equal(t, 1000, cdb.MaxResultSize())
+
 	err := cdb.UseTimeFunc(nil)
 	require.ErrorIs(t, err, store.ErrAlreadyClosed)
 


### PR DESCRIPTION
Fixes #1202

Signed-off-by: Jeronimo Irazabal <jeronimo.irazabal@gmail.com>