### PR TITLE
fix(github): Run sonarcloud code analysis after cove coverate

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -131,12 +131,6 @@ jobs:
           go-acc ./... --covermode=atomic --ignore test,immuclient,immuadmin,helper,cmdtest,sservice,version,tools || true
           cat coverage.txt | grep -v "schema.pb" | grep -v "immuclient" | grep -v "immuadmin" | grep -v "helper" | grep -v "cmdtest" | grep -v "sservice" | grep -v "version" | grep -v "tools" > coverage.out
           goveralls -coverprofile=coverage.out -service=gh-ci -repotoken ${{ secrets.COVERALLS_TOKEN }}
-
-  sonarcloud:
-    name: SonarCloud
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
       - name: Analyze with SonarCloud
         uses: sonarsource/sonarcloud-github-action@master
         env:


### PR DESCRIPTION
It turns out that sonarcloud requries coverage file generated
during coverage analysis. This change brings back sonarcloud
analysis to the Coverage job where such file is present.

Signed-off-by: Bartłomiej Święcki <bart@codenotary.com>