### PR TITLE
fix(embedded/remotestorage/s3): S3 compatibility fixes

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -16,7 +16,7 @@ jobs:
 
           - os: ubuntu-latest
             go: "1.17"
-            test: true
+            testWithMinio: true
 
           - os: ubuntu-latest
             go: "1.18"
@@ -42,6 +42,27 @@ jobs:
       - name: Test
         run: make test
         if: matrix.test
+
+      - name: Test (with minio)
+        run: |
+          # Spawn minio docker container in the background
+          docker run -d -t -p 9000:9000 --name minio \
+            -e "MINIO_ACCESS_KEY=minioadmin" \
+            -e "MINIO_SECRET_KEY=minioadmin" \
+            minio/minio server /data
+
+          # Create immudb bucket
+          docker run --net=host -t --entrypoint /bin/sh minio/mc -c "
+            mc alias set local http://localhost:9000 minioadmin minioadmin &&
+            mc mb local/immudb
+          "
+
+          # Run go tests with minio
+          GO_TEST_FLAGS="-tags minio" make test
+
+          # Stop minio
+          docker rm -f minio
+        if: matrix.testWithMinio
 
       - name: Test Client
         run: make test-client

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -118,14 +118,29 @@ jobs:
           go-version: 1.17
       - uses: actions/checkout@v3
       - run: |
+          # Spawn minio docker container in the background
+          docker run -d -t -p 9000:9000 --name minio \
+            -e "MINIO_ACCESS_KEY=minioadmin" \
+            -e "MINIO_SECRET_KEY=minioadmin" \
+            minio/minio server /data
+
+          # Create immudb bucket
+          docker run --net=host -t --entrypoint /bin/sh minio/mc -c "
+            mc alias set local http://localhost:9000 minioadmin minioadmin &&
+            mc mb local/immudb
+          "
+
           export PATH=$PATH:$(go env GOPATH)/bin
           go get golang.org/x/tools/cmd/cover
           go get -u github.com/mattn/goveralls
           go get -u github.com/ory/go-acc
           set -o pipefail
-          go-acc ./... --covermode=atomic --ignore test,immuclient,immuadmin,helper,cmdtest,sservice,version,tools || true
+          go-acc ./... --covermode=atomic --ignore test,immuclient,immuadmin,helper,cmdtest,sservice,version,tools --tags minio || true
           cat coverage.txt | grep -v "schema.pb" | grep -v "immuclient" | grep -v "immuadmin" | grep -v "helper" | grep -v "cmdtest" | grep -v "sservice" | grep -v "version" | grep -v "tools" > coverage.out
           goveralls -coverprofile=coverage.out -service=gh-ci -repotoken ${{ secrets.COVERALLS_TOKEN }}
+
+          # Stop minio
+          docker rm -f minio
       - name: Analyze with SonarCloud
         uses: sonarsource/sonarcloud-github-action@master
         env:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -295,14 +295,29 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
       - uses: actions/checkout@v3
       - run: |
+          # Spawn minio docker container in the background
+          docker run -d -t -p 9000:9000 --name minio \
+            -e "MINIO_ACCESS_KEY=minioadmin" \
+            -e "MINIO_SECRET_KEY=minioadmin" \
+            minio/minio server /data
+
+          # Create immudb bucket
+          docker run --net=host -t --entrypoint /bin/sh minio/mc -c "
+            mc alias set local http://localhost:9000 minioadmin minioadmin &&
+            mc mb local/immudb
+          "
+
           export PATH=$PATH:$(go env GOPATH)/bin
           go get golang.org/x/tools/cmd/cover
           go get -u github.com/mattn/goveralls
           go get -u github.com/ory/go-acc
           set -o pipefail
-          go-acc ./... --covermode=atomic --ignore test,immuclient,immuadmin,helper,cmdtest,sservice,version || true
+          go-acc ./... --covermode=atomic --ignore test,immuclient,immuadmin,helper,cmdtest,sservice,version  --tags minio || true
           cat coverage.txt | grep -v "schema.pb" | grep -v "immuclient" | grep -v "immuadmin" | grep -v "helper" | grep -v "cmdtest" | grep -v "sservice" | grep -v "version" > coverage.out
           goveralls -coverprofile=coverage.out -service=gh-ci -repotoken ${{ secrets.COVERALLS_TOKEN }}
+
+          # Stop minio
+          docker rm -f minio
       - name: Analyze with SonarCloud
         uses: sonarsource/sonarcloud-github-action@master
         env:

--- a/Makefile
+++ b/Makefile
@@ -103,11 +103,11 @@ vendor:
 .PHONY: test
 test:
 	$(GO) vet ./...
-	$(GO) test -failfast ./...
+	$(GO) test -failfast ./... ${GO_TEST_FLAGS}
 
 .PHONY: test-client
 test-client:
-	$(GO) test -failfast ./pkg/client
+	$(GO) test -failfast ./pkg/client ${GO_TEST_FLAGS}
 
 # To view coverage as HTML run: go tool cover -html=coverage.txt
 .PHONY: coverage

--- a/embedded/remotestorage/remote_storage.go
+++ b/embedded/remotestorage/remote_storage.go
@@ -34,7 +34,7 @@ type Storage interface {
 	// String returns a human-readable representation of the storage
 	String() string
 
-	// Get opens a remote resource, if offs < 0, read as much as possible
+	// Get opens a remote resource, if size < 0, read as much as possible
 	Get(ctx context.Context, name string, offs, size int64) (io.ReadCloser, error)
 
 	// Put saves a local file to a remote storage

--- a/embedded/remotestorage/s3/s3.go
+++ b/embedded/remotestorage/s3/s3.go
@@ -313,10 +313,10 @@ func (s *Storage) validateName(name string, isFolder bool) error {
 	if strings.HasPrefix(name, "/") {
 		return ErrInvalidArgumentsNameStartSlash
 	}
-	if isFolder && !strings.HasSuffix(name, "/") {
+	if isFolder && name != "" && !strings.HasSuffix(name, "/") {
 		// The path must end with `/` so that we don't match entries in parent directory with same prefix name
 		// e.g. when scanning /some/entry directory it must not match /some/entry-file object name.
-		// That's because in s3, the scan is prefix-based without clear notion of directories
+		// That's because in s3, the scan is prefix-based without clear notion of directories.
 		return ErrInvalidArgumentsPathNoEndSlash
 	}
 	if !isFolder && strings.HasSuffix(name, "/") {

--- a/embedded/remotestorage/s3/s3_test.go
+++ b/embedded/remotestorage/s3/s3_test.go
@@ -50,6 +50,8 @@ func TestValidateName(t *testing.T) {
 		isFolder bool
 		err      error
 	}{
+		{"", false, nil},
+		{"", true, nil},
 		{"test", false, nil},
 		{"test/", true, nil},
 		{"test/name", false, nil},

--- a/embedded/remotestorage/s3/s3_test.go
+++ b/embedded/remotestorage/s3/s3_test.go
@@ -18,9 +18,12 @@ package s3
 
 import (
 	"context"
+	"fmt"
+	"io/fs"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
@@ -161,6 +164,54 @@ func TestCornerCases(t *testing.T) {
 		require.ErrorIs(t, err, ErrInvalidArguments)
 		require.ErrorIs(t, err, ErrInvalidArgumentsOffsSize)
 	})
+
+	t.Run("invalid list path", func(t *testing.T) {
+		s, err := Open(
+			"https://localhost:9000",
+			"minioadmin",
+			"minioadmin",
+			"bucket",
+			"",
+			"",
+		)
+		require.NoError(t, err)
+
+		_, _, err = s.ListEntries(context.Background(), "prefix-no-slash")
+		require.ErrorIs(t, err, ErrInvalidArguments)
+
+		_, _, err = s.ListEntries(context.Background(), "prefix-double-slash//")
+		require.ErrorIs(t, err, ErrInvalidArguments)
+	})
+
+	t.Run("invalid http status code from the server", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "test error", http.StatusInternalServerError)
+		}))
+		defer ts.Close()
+
+		s, err := Open(ts.URL, "", "", "bucket", "", "")
+		require.NoError(t, err)
+
+		ctx := context.Background()
+
+		_, err = s.Get(ctx, "object1", 0, -1)
+		require.ErrorIs(t, err, ErrInvalidResponse)
+	})
+
+	t.Run("invalid upload file path", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Fail(t, "Should not call the server")
+		}))
+		defer ts.Close()
+
+		s, err := Open(ts.URL, "", "", "bucket", "", "")
+		require.NoError(t, err)
+
+		ctx := context.Background()
+
+		err = s.Put(ctx, "object1", "/invalid/file/path/that/does/not/exist")
+		require.IsType(t, &fs.PathError{}, err)
+	})
 }
 
 func TestSignatureV4(t *testing.T) {
@@ -236,6 +287,14 @@ func TestHandlingRedirects(t *testing.T) {
 			require.Equal(t, "GET", r.Method)
 			http.Redirect(w, r, "h**p://invalid", http.StatusTemporaryRedirect)
 
+		case "/bucket/object7":
+			require.Equal(t, "PUT", r.Method)
+			http.Redirect(w, r, "h**p://invalid", http.StatusSeeOther)
+
+		case "/bucket/object8":
+			require.Equal(t, "PUT", r.Method)
+			http.Redirect(w, r, "h**p://invalid", http.StatusTemporaryRedirect)
+
 		default:
 			require.Fail(t, "Unknown request")
 		}
@@ -269,14 +328,276 @@ func TestHandlingRedirects(t *testing.T) {
 
 	t.Run("error getting 303 redirect", func(t *testing.T) {
 		_, err := s.Get(ctx, "object5", 0, -1)
-		require.Error(t, err)
+		require.ErrorIs(t, err, ErrInvalidResponse)
 		require.Contains(t, err.Error(), "failed to parse Location header")
 	})
 
 	t.Run("error getting 307 redirect", func(t *testing.T) {
 		_, err := s.Get(ctx, "object6", 0, -1)
-		require.Error(t, err)
+		require.ErrorIs(t, err, ErrInvalidResponse)
 		require.Contains(t, err.Error(), "failed to parse Location header")
+	})
+
+	t.Run("error getting 303 redirect while PUT request", func(t *testing.T) {
+		fl, err := ioutil.TempFile("", "")
+		require.NoError(t, err)
+		fmt.Fprintf(fl, "Hello world")
+		fl.Close()
+		defer os.Remove(fl.Name())
+
+		err = s.Put(ctx, "object7", fl.Name())
+		require.ErrorIs(t, err, ErrInvalidResponse)
+		require.Contains(t, err.Error(), "failed to parse Location header")
+	})
+
+	t.Run("error getting 307 redirect", func(t *testing.T) {
+		fl, err := ioutil.TempFile("", "")
+		require.NoError(t, err)
+		fmt.Fprintf(fl, "Hello world")
+		fl.Close()
+		defer os.Remove(fl.Name())
+
+		err = s.Put(ctx, "object8", fl.Name())
+		require.ErrorIs(t, err, ErrInvalidResponse)
+		require.Contains(t, err.Error(), "failed to parse Location header")
+	})
+}
+
+func TestListEntries(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/bucket/", r.URL.Path)
+
+		switch r.URL.Query().Get("prefix") {
+		case "path1/":
+			w.Write([]byte(`
+				<?xml version="1.0" encoding="UTF-8"?>
+				<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+					<IsTruncated>false</IsTruncated>
+					<Contents>
+						<Key>ExampleObject1.txt</Key>
+					</Contents>
+					<Contents>
+						<Key>ExampleObject2.txt</Key>
+					</Contents>
+					<CommonPrefixes>
+						<Prefix>path1/photos1/</Prefix>
+					</CommonPrefixes>
+					<CommonPrefixes>
+						<Prefix>path1/photos2/</Prefix>
+					</CommonPrefixes>
+				</ListBucketResult>
+			`))
+
+		case "path2/":
+			w.Write([]byte(`
+				< this is not a valid xml >
+			`))
+
+		case "path3/":
+			w.Write([]byte(`
+				<?xml version="1.0" encoding="UTF-8"?>
+				<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+					<IsTruncated>false</IsTruncated>
+					<Contents>
+						<Key>ExampleObject2.txt</Key>
+					</Contents>
+					<Contents>
+						<Key>ExampleObject1.txt</Key>
+					</Contents>
+					<CommonPrefixes>
+						<Prefix>path3/photos1/</Prefix>
+					</CommonPrefixes>
+					<CommonPrefixes>
+						<Prefix>path3/photos2/</Prefix>
+					</CommonPrefixes>
+				</ListBucketResult>
+			`))
+
+		case "path4/":
+			w.Write([]byte(`
+				<?xml version="1.0" encoding="UTF-8"?>
+				<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+					<IsTruncated>false</IsTruncated>
+					<Contents>
+						<Key>ExampleObject1.txt</Key>
+					</Contents>
+					<Contents>
+						<Key>ExampleObject2.txt</Key>
+					</Contents>
+					<CommonPrefixes>
+						<Prefix>path4/photos2/</Prefix>
+					</CommonPrefixes>
+					<CommonPrefixes>
+						<Prefix>path4/photos1/</Prefix>
+					</CommonPrefixes>
+				</ListBucketResult>
+			`))
+
+		case "path5/":
+			w.Write([]byte(`
+				<?xml version="1.0" encoding="UTF-8"?>
+				<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+					<IsTruncated>false</IsTruncated>
+					<Contents>
+						<Key>ExampleObject1.txt</Key>
+					</Contents>
+					<Contents>
+						<Key>ExampleObject2.txt</Key>
+					</Contents>
+					<CommonPrefixes>
+						<Prefix>invalid-prefix/photos1/</Prefix>
+					</CommonPrefixes>
+					<CommonPrefixes>
+						<Prefix>invalid-prefix/photos2/</Prefix>
+					</CommonPrefixes>
+				</ListBucketResult>
+			`))
+
+		case "path6/":
+			w.Write([]byte(`
+				<?xml version="1.0" encoding="UTF-8"?>
+				<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+					<IsTruncated>false</IsTruncated>
+					<Contents>
+						<Key>ExampleObject1.txt</Key>
+					</Contents>
+					<Contents>
+						<Key>ExampleObject2.txt</Key>
+					</Contents>
+					<CommonPrefixes>
+						<Prefix>path6/photos1</Prefix>
+					</CommonPrefixes>
+					<CommonPrefixes>
+						<Prefix>path6/photos2</Prefix>
+					</CommonPrefixes>
+				</ListBucketResult>
+			`))
+
+		case "path7/":
+			w.Write([]byte(`
+				<?xml version="1.0" encoding="UTF-8"?>
+				<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+					<IsTruncated>false</IsTruncated>
+					<Contents>
+						<Key>ExampleObject1.txt</Key>
+					</Contents>
+					<Contents>
+						<Key>ExampleObject2.txt</Key>
+					</Contents>
+					<CommonPrefixes>
+						<Prefix>path7/photos1/</Prefix>
+					</CommonPrefixes>
+					<CommonPrefixes>
+						<Prefix>path7/../photos2/</Prefix>
+					</CommonPrefixes>
+				</ListBucketResult>
+			`))
+
+		case "path8/":
+			switch r.URL.Query().Get("continuation-token") {
+			case "":
+				w.Write([]byte(`
+					<?xml version="1.0" encoding="UTF-8"?>
+					<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+						<IsTruncated>true</IsTruncated>
+						<NextContinuationToken>cont-token</NextContinuationToken>
+						<Contents>
+							<Key>ExampleObject1.txt</Key>
+						</Contents>
+						<Contents>
+							<Key>ExampleObject2.txt</Key>
+						</Contents>
+						<CommonPrefixes>
+							<Prefix>path8/photos1/</Prefix>
+						</CommonPrefixes>
+						<CommonPrefixes>
+							<Prefix>path8/photos2/</Prefix>
+						</CommonPrefixes>
+					</ListBucketResult>
+				`))
+			case "cont-token":
+				w.Write([]byte(`
+					<?xml version="1.0" encoding="UTF-8"?>
+					<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+						<IsTruncated>false</IsTruncated>
+						<Contents>
+							<Key>ExampleObject3.txt</Key>
+						</Contents>
+						<Contents>
+							<Key>ExampleObject4.txt</Key>
+						</Contents>
+						<CommonPrefixes>
+							<Prefix>path8/photos3/</Prefix>
+						</CommonPrefixes>
+						<CommonPrefixes>
+							<Prefix>path8/photos4/</Prefix>
+						</CommonPrefixes>
+					</ListBucketResult>
+				`))
+			default:
+				require.Fail(t, "invalid continuation token")
+			}
+
+		default:
+			require.Fail(t, "Invalid request")
+		}
+
+	}))
+	defer ts.Close()
+
+	s, err := Open(ts.URL, "", "", "bucket", "", "")
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	t.Run("correct response", func(t *testing.T) {
+		entries, subPaths, err := s.ListEntries(ctx, "path1/")
+		require.NoError(t, err)
+		require.Len(t, entries, 2)
+		require.Len(t, subPaths, 2)
+	})
+
+	t.Run("invalid xml response when listing", func(t *testing.T) {
+		_, _, err := s.ListEntries(ctx, "path2/")
+		require.ErrorIs(t, err, ErrInvalidResponse)
+		require.ErrorIs(t, err, ErrInvalidResponseXmlDecodeError)
+	})
+
+	t.Run("entries not sorted", func(t *testing.T) {
+		_, _, err := s.ListEntries(ctx, "path3/")
+		require.ErrorIs(t, err, ErrInvalidResponse)
+		require.ErrorIs(t, err, ErrInvalidResponseEntriesNotSorted)
+	})
+
+	t.Run("sub paths not sorted", func(t *testing.T) {
+		_, _, err := s.ListEntries(ctx, "path4/")
+		require.ErrorIs(t, err, ErrInvalidResponse)
+		require.ErrorIs(t, err, ErrInvalidResponseSubPathsNotSorted)
+	})
+
+	t.Run("sub paths incorrectly prefixed", func(t *testing.T) {
+		_, _, err := s.ListEntries(ctx, "path5/")
+		require.ErrorIs(t, err, ErrInvalidResponse)
+		require.ErrorIs(t, err, ErrInvalidResponseSubPathsWrongPrefix)
+	})
+
+	t.Run("sub paths incorrectly prefixed", func(t *testing.T) {
+		_, _, err := s.ListEntries(ctx, "path6/")
+		require.ErrorIs(t, err, ErrInvalidResponse)
+		require.ErrorIs(t, err, ErrInvalidResponseSubPathsWrongSuffix)
+	})
+
+	t.Run("sub paths contain incorrect characters", func(t *testing.T) {
+		_, _, err := s.ListEntries(ctx, "path7/")
+		require.ErrorIs(t, err, ErrInvalidResponse)
+		require.ErrorIs(t, err, ErrInvalidResponseSubPathMalicious)
+	})
+
+	t.Run("query with continuation token", func(t *testing.T) {
+		entries, subPaths, err := s.ListEntries(ctx, "path8/")
+		require.NoError(t, err)
+		require.Len(t, entries, 4)
+		require.Len(t, subPaths, 4)
 	})
 
 }

--- a/embedded/remotestorage/s3/s3_test.go
+++ b/embedded/remotestorage/s3/s3_test.go
@@ -374,10 +374,10 @@ func TestListEntries(t *testing.T) {
 				<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
 					<IsTruncated>false</IsTruncated>
 					<Contents>
-						<Key>ExampleObject1.txt</Key>
+						<Key>path1/ExampleObject1.txt</Key>
 					</Contents>
 					<Contents>
-						<Key>ExampleObject2.txt</Key>
+						<Key>path1/ExampleObject2.txt</Key>
 					</Contents>
 					<CommonPrefixes>
 						<Prefix>path1/photos1/</Prefix>
@@ -399,10 +399,10 @@ func TestListEntries(t *testing.T) {
 				<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
 					<IsTruncated>false</IsTruncated>
 					<Contents>
-						<Key>ExampleObject2.txt</Key>
+						<Key>path3/ExampleObject2.txt</Key>
 					</Contents>
 					<Contents>
-						<Key>ExampleObject1.txt</Key>
+						<Key>path3/ExampleObject1.txt</Key>
 					</Contents>
 					<CommonPrefixes>
 						<Prefix>path3/photos1/</Prefix>
@@ -419,10 +419,10 @@ func TestListEntries(t *testing.T) {
 				<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
 					<IsTruncated>false</IsTruncated>
 					<Contents>
-						<Key>ExampleObject1.txt</Key>
+						<Key>path4/ExampleObject1.txt</Key>
 					</Contents>
 					<Contents>
-						<Key>ExampleObject2.txt</Key>
+						<Key>path4/ExampleObject2.txt</Key>
 					</Contents>
 					<CommonPrefixes>
 						<Prefix>path4/photos2/</Prefix>
@@ -439,10 +439,10 @@ func TestListEntries(t *testing.T) {
 				<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
 					<IsTruncated>false</IsTruncated>
 					<Contents>
-						<Key>ExampleObject1.txt</Key>
+						<Key>path5/ExampleObject1.txt</Key>
 					</Contents>
 					<Contents>
-						<Key>ExampleObject2.txt</Key>
+						<Key>path5/ExampleObject2.txt</Key>
 					</Contents>
 					<CommonPrefixes>
 						<Prefix>invalid-prefix/photos1/</Prefix>
@@ -459,10 +459,10 @@ func TestListEntries(t *testing.T) {
 				<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
 					<IsTruncated>false</IsTruncated>
 					<Contents>
-						<Key>ExampleObject1.txt</Key>
+						<Key>path6/ExampleObject1.txt</Key>
 					</Contents>
 					<Contents>
-						<Key>ExampleObject2.txt</Key>
+						<Key>path6/ExampleObject2.txt</Key>
 					</Contents>
 					<CommonPrefixes>
 						<Prefix>path6/photos1</Prefix>
@@ -479,10 +479,10 @@ func TestListEntries(t *testing.T) {
 				<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
 					<IsTruncated>false</IsTruncated>
 					<Contents>
-						<Key>ExampleObject1.txt</Key>
+						<Key>path7/ExampleObject1.txt</Key>
 					</Contents>
 					<Contents>
-						<Key>ExampleObject2.txt</Key>
+						<Key>path7/ExampleObject2.txt</Key>
 					</Contents>
 					<CommonPrefixes>
 						<Prefix>path7/photos1/</Prefix>
@@ -502,10 +502,10 @@ func TestListEntries(t *testing.T) {
 						<IsTruncated>true</IsTruncated>
 						<NextContinuationToken>cont-token</NextContinuationToken>
 						<Contents>
-							<Key>ExampleObject1.txt</Key>
+							<Key>path8/ExampleObject1.txt</Key>
 						</Contents>
 						<Contents>
-							<Key>ExampleObject2.txt</Key>
+							<Key>path8/ExampleObject2.txt</Key>
 						</Contents>
 						<CommonPrefixes>
 							<Prefix>path8/photos1/</Prefix>
@@ -521,10 +521,10 @@ func TestListEntries(t *testing.T) {
 					<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
 						<IsTruncated>false</IsTruncated>
 						<Contents>
-							<Key>ExampleObject3.txt</Key>
+							<Key>path8/ExampleObject3.txt</Key>
 						</Contents>
 						<Contents>
-							<Key>ExampleObject4.txt</Key>
+							<Key>path8/ExampleObject4.txt</Key>
 						</Contents>
 						<CommonPrefixes>
 							<Prefix>path8/photos3/</Prefix>
@@ -537,6 +537,106 @@ func TestListEntries(t *testing.T) {
 			default:
 				require.Fail(t, "invalid continuation token")
 			}
+
+		case "path9/":
+			w.Write([]byte(`
+				<?xml version="1.0" encoding="UTF-8"?>
+				<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+					<IsTruncated>false</IsTruncated>
+					<Contents>
+						<Key>ExampleObject1.txt</Key>
+					</Contents>
+					<Contents>
+						<Key>path9/ExampleObject2.txt</Key>
+					</Contents>
+					<CommonPrefixes>
+						<Prefix>path9/photos1/</Prefix>
+					</CommonPrefixes>
+					<CommonPrefixes>
+						<Prefix>path9/photos2/</Prefix>
+					</CommonPrefixes>
+				</ListBucketResult>
+			`))
+
+		case "path10/":
+			w.Write([]byte(`
+				<?xml version="1.0" encoding="UTF-8"?>
+				<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+					<IsTruncated>false</IsTruncated>
+					<Contents>
+						<Key>path10/sub/ExampleObject1.txt</Key>
+					</Contents>
+					<Contents>
+						<Key>path10/ExampleObject2.txt</Key>
+					</Contents>
+					<CommonPrefixes>
+						<Prefix>path10/photos1/</Prefix>
+					</CommonPrefixes>
+					<CommonPrefixes>
+						<Prefix>path10/photos2/</Prefix>
+					</CommonPrefixes>
+				</ListBucketResult>
+			`))
+
+		case "path11/":
+			w.Write([]byte(`
+				<?xml version="1.0" encoding="UTF-8"?>
+				<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+					<IsTruncated>false</IsTruncated>
+					<Contents>
+						<Key>path11/ExampleObject1.txt%</Key>
+					</Contents>
+					<Contents>
+						<Key>path11/ExampleObject2.txt</Key>
+					</Contents>
+					<CommonPrefixes>
+						<Prefix>path11/photos1/</Prefix>
+					</CommonPrefixes>
+					<CommonPrefixes>
+						<Prefix>path11/photos2/</Prefix>
+					</CommonPrefixes>
+				</ListBucketResult>
+			`))
+
+		case "path12/":
+			w.Write([]byte(`
+				<?xml version="1.0" encoding="UTF-8"?>
+				<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+					<IsTruncated>false</IsTruncated>
+					<Contents>
+						<Key>path12/ExampleObject1.txt</Key>
+					</Contents>
+					<Contents>
+						<Key>path12/ExampleObject2.txt</Key>
+					</Contents>
+					<CommonPrefixes>
+						<Prefix>path12/photos1/%</Prefix>
+					</CommonPrefixes>
+					<CommonPrefixes>
+						<Prefix>path12/photos2/</Prefix>
+					</CommonPrefixes>
+				</ListBucketResult>
+			`))
+
+		case "path13/":
+			w.Write([]byte(`
+			<?xml version="1.0" encoding="UTF-8"?>
+			<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+				<IsTruncated>false</IsTruncated>
+				<Contents>
+					<Key>path13%2FExampleObject1.txt</Key>
+				</Contents>
+				<Contents>
+					<Key>path13%2FExampleObject2.txt</Key>
+				</Contents>
+				<CommonPrefixes>
+					<Prefix>path13%2Fphotos1%2F</Prefix>
+				</CommonPrefixes>
+				<CommonPrefixes>
+					<Prefix>path13%2Fphotos2%2F</Prefix>
+				</CommonPrefixes>
+			</ListBucketResult>
+		`))
 
 		default:
 			require.Fail(t, "Invalid request")
@@ -598,6 +698,39 @@ func TestListEntries(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, entries, 4)
 		require.Len(t, subPaths, 4)
+	})
+
+	t.Run("entry name does not start with prefix", func(t *testing.T) {
+		_, _, err := s.ListEntries(ctx, "path9/")
+		require.ErrorIs(t, err, ErrInvalidResponse)
+		require.ErrorIs(t, err, ErrInvalidResponseEntryNameWrongPrefix)
+	})
+
+	t.Run("entry name contains / character", func(t *testing.T) {
+		_, _, err := s.ListEntries(ctx, "path10/")
+		require.ErrorIs(t, err, ErrInvalidResponse)
+		require.ErrorIs(t, err, ErrInvalidResponseEntryNameMalicious)
+	})
+
+	t.Run("entry name not correctly url encoded", func(t *testing.T) {
+		_, _, err := s.ListEntries(ctx, "path11/")
+		require.ErrorIs(t, err, ErrInvalidResponse)
+		require.ErrorIs(t, err, ErrInvalidResponseEntryNameUnescape)
+	})
+
+	t.Run("subpath not correctly url encoded", func(t *testing.T) {
+		_, _, err := s.ListEntries(ctx, "path12/")
+		require.ErrorIs(t, err, ErrInvalidResponse)
+		require.ErrorIs(t, err, ErrInvalidResponseSubPathUnescape)
+	})
+
+	t.Run("correctly handle url encoded entry names", func(t *testing.T) {
+		entries, subPaths, err := s.ListEntries(ctx, "path13/")
+		require.NoError(t, err)
+		require.Len(t, entries, 2)
+		require.Len(t, subPaths, 2)
+		require.Equal(t, "ExampleObject1.txt", entries[0].Name)
+		require.Equal(t, []string{"photos1", "photos2"}, subPaths)
 	})
 
 }

--- a/embedded/remotestorage/s3/s3_test.go
+++ b/embedded/remotestorage/s3/s3_test.go
@@ -1,41 +1,166 @@
-// +build minio
+/*
+Copyright 2022 CodeNotary, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package s3
 
 import (
 	"context"
-	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestSimpleUpload(t *testing.T) {
-
+func TestOpen(t *testing.T) {
 	s, err := Open(
 		"http://localhost:9000",
 		"minioadmin",
 		"minioadmin",
 		"immudb",
 		"",
-		"",
+		"prefix",
 	)
 	require.NoError(t, err)
+	require.NotNil(t, s)
+	require.Equal(t, "s3:http://localhost:9000/immudb/prefix/", s.String())
+}
 
-	ctx := context.Background()
+func TestCornerCases(t *testing.T) {
+	t.Run("bucket name can not be empty", func(t *testing.T) {
+		s, err := Open(
+			"http://localhost:9000",
+			"minioadmin",
+			"minioadmin",
+			"",
+			"",
+			"",
+		)
+		require.ErrorIs(t, err, ErrInvalidArguments)
+		require.ErrorIs(t, err, ErrInvalidArgumentsBucketEmpty)
+		require.Nil(t, s)
+	})
 
-	// Reader is wrapped to ensure it's not recognized as the in-memory buffer.
-	// Standard http lib in golang detect Content-Length headers for bytes.Buffer readers.
-	fl, err := ioutil.TempFile("", "")
-	require.NoError(t, err)
-	fmt.Fprintf(fl, "Hello world")
-	fl.Close()
+	t.Run("bucket name can not contain /", func(t *testing.T) {
+		s, err := Open(
+			"http://localhost:9000",
+			"minioadmin",
+			"minioadmin",
+			"immudb/test",
+			"",
+			"",
+		)
+		require.ErrorIs(t, err, ErrInvalidArguments)
+		require.ErrorIs(t, err, ErrInvalidArgumentsBucketSlash)
+		require.Nil(t, s)
+	})
 
-	err = s.Put(ctx, "test1", fl.Name())
-	require.NoError(t, err)
+	t.Run("prefix must be correctly normalized", func(t *testing.T) {
+		s, err := Open(
+			"http://localhost:9000",
+			"minioadmin",
+			"minioadmin",
+			"immudb",
+			"",
+			"",
+		)
+		require.NoError(t, err)
+		require.Equal(t, "", s.(*Storage).prefix)
+
+		s, err = Open(
+			"http://localhost:9000",
+			"minioadmin",
+			"minioadmin",
+			"immudb",
+			"",
+			"/test/",
+		)
+		require.NoError(t, err)
+		require.Equal(t, "test/", s.(*Storage).prefix)
+
+		s, err = Open(
+			"http://localhost:9000",
+			"minioadmin",
+			"minioadmin",
+			"immudb",
+			"",
+			"/test",
+		)
+		require.NoError(t, err)
+		require.Equal(t, "test/", s.(*Storage).prefix)
+	})
+
+	t.Run("invalid url", func(t *testing.T) {
+		s, err := Open(
+			"h**s://localhost:9000",
+			"minioadmin",
+			"minioadmin",
+			"bucket",
+			"",
+			"",
+		)
+		require.NoError(t, err)
+		require.Equal(t, "s3(misconfigured)", s.String())
+	})
+
+	t.Run("invalid get / put path", func(t *testing.T) {
+		s, err := Open(
+			"htts://localhost:9000",
+			"minioadmin",
+			"minioadmin",
+			"bucket",
+			"",
+			"",
+		)
+		require.NoError(t, err)
+
+		_, err = s.Get(context.Background(), "/file", 0, -1)
+		require.ErrorIs(t, err, ErrInvalidArguments)
+		require.ErrorIs(t, err, ErrInvalidArgumentsNameSlash)
+
+		_, err = s.Get(context.Background(), "file/", 0, -1)
+		require.ErrorIs(t, err, ErrInvalidArguments)
+		require.ErrorIs(t, err, ErrInvalidArgumentsNameSlash)
+
+		err = s.Put(context.Background(), "/file", "/tmp/test.txt")
+		require.ErrorIs(t, err, ErrInvalidArguments)
+		require.ErrorIs(t, err, ErrInvalidArgumentsNameSlash)
+
+		err = s.Put(context.Background(), "file/", "/tmp/test.txt")
+		require.ErrorIs(t, err, ErrInvalidArguments)
+		require.ErrorIs(t, err, ErrInvalidArgumentsNameSlash)
+	})
+
+	t.Run("invalid get offset / size", func(t *testing.T) {
+		s, err := Open(
+			"htts://localhost:9000",
+			"minioadmin",
+			"minioadmin",
+			"bucket",
+			"",
+			"",
+		)
+		require.NoError(t, err)
+
+		_, err = s.Get(context.Background(), "file", 0, 0)
+		require.ErrorIs(t, err, ErrInvalidArguments)
+		require.ErrorIs(t, err, ErrInvalidArgumentsOffsSize)
+	})
 }
 
 func TestSignatureV4(t *testing.T) {
@@ -79,4 +204,79 @@ func TestSignatureV4(t *testing.T) {
 			"Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41",
 		req.Header.Get("Authorization"),
 	)
+}
+
+func TestHandlingRedirects(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		switch r.URL.Path {
+		case "/bucket/object1":
+			require.Equal(t, "GET", r.Method)
+			http.Redirect(w, r, "/bucket/object2", http.StatusSeeOther)
+
+		case "/bucket/object2":
+			require.Equal(t, "GET", r.Method)
+			http.Redirect(w, r, "/bucket/object3", http.StatusPermanentRedirect)
+
+		case "/bucket/object3":
+			require.Equal(t, "GET", r.Method)
+
+			_, err := w.Write([]byte("Hello world"))
+			require.NoError(t, err)
+
+		case "/bucket/object4":
+			require.Equal(t, "GET", r.Method)
+			http.Redirect(w, r, "/bucket/object4", http.StatusTemporaryRedirect)
+
+		case "/bucket/object5":
+			require.Equal(t, "GET", r.Method)
+			http.Redirect(w, r, "h**p://invalid", http.StatusSeeOther)
+
+		case "/bucket/object6":
+			require.Equal(t, "GET", r.Method)
+			http.Redirect(w, r, "h**p://invalid", http.StatusTemporaryRedirect)
+
+		default:
+			require.Fail(t, "Unknown request")
+		}
+
+	}))
+	defer ts.Close()
+
+	s, err := Open(ts.URL, "", "", "bucket", "", "")
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	t.Run("open bucket with redirects", func(t *testing.T) {
+
+		io, err := s.Get(ctx, "object1", 0, -1)
+		require.NoError(t, err)
+
+		b, err := ioutil.ReadAll(io)
+		require.NoError(t, err)
+
+		err = io.Close()
+		require.NoError(t, err)
+
+		require.Equal(t, []byte("Hello world"), b)
+	})
+
+	t.Run("detect infinite redirect loop", func(t *testing.T) {
+		_, err := s.Get(ctx, "object4", 0, -1)
+		require.ErrorIs(t, err, ErrTooManyRedirects)
+	})
+
+	t.Run("error getting 303 redirect", func(t *testing.T) {
+		_, err := s.Get(ctx, "object5", 0, -1)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to parse Location header")
+	})
+
+	t.Run("error getting 307 redirect", func(t *testing.T) {
+		_, err := s.Get(ctx, "object6", 0, -1)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to parse Location header")
+	})
+
 }

--- a/embedded/remotestorage/s3/s3_with_minio_test.go
+++ b/embedded/remotestorage/s3/s3_with_minio_test.go
@@ -1,0 +1,127 @@
+//go:build minio
+// +build minio
+
+/*
+Copyright 2022 CodeNotary, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package s3
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestS3WithServer(t *testing.T) {
+	randomBytes := make([]byte, 8)
+	_, err := rand.Read(randomBytes)
+	require.NoError(t, err)
+
+	s, err := Open(
+		"http://localhost:9000",
+		"minioadmin",
+		"minioadmin",
+		"immudb",
+		"",
+		fmt.Sprintf("prefix_%x", randomBytes),
+	)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	t.Run("check exist if file was not created", func(t *testing.T) {
+		exists, err := s.Exists(ctx, "test1")
+		require.NoError(t, err)
+		require.False(t, exists)
+	})
+
+	t.Run("store a file", func(t *testing.T) {
+		fl, err := ioutil.TempFile("", "")
+		require.NoError(t, err)
+		fmt.Fprintf(fl, "Hello world")
+		fl.Close()
+		defer os.Remove(fl.Name())
+
+		err = s.Put(ctx, "test1", fl.Name())
+		require.NoError(t, err)
+	})
+
+	t.Run("check exist after file was created", func(t *testing.T) {
+		exists, err := s.Exists(ctx, "test1")
+		require.NoError(t, err)
+		require.True(t, exists)
+	})
+
+	t.Run("read whole file", func(t *testing.T) {
+		in, err := s.Get(ctx, "test1", 0, -1)
+		require.NoError(t, err)
+		data, err := ioutil.ReadAll(in)
+		require.NoError(t, err)
+		err = in.Close()
+		require.NoError(t, err)
+		require.Equal(t, []byte("Hello world"), data)
+	})
+
+	t.Run("read file partially", func(t *testing.T) {
+		in, err := s.Get(ctx, "test1", 1, 5)
+		require.NoError(t, err)
+		data, err := ioutil.ReadAll(in)
+		require.NoError(t, err)
+		err = in.Close()
+		require.NoError(t, err)
+		require.Equal(t, []byte("ello "), data)
+	})
+
+	t.Run("create multiple file-s in multiple folders", func(t *testing.T) {
+
+		const foldersCount = 3
+		const entriesCount = 20
+
+		for i := 0; i < foldersCount; i++ {
+			for j := 0; j < entriesCount; j++ {
+				fl, err := ioutil.TempFile("", "")
+				require.NoError(t, err)
+				fmt.Fprintf(fl, "Hello world_%d_%d", i, j)
+				fl.Close()
+				defer os.Remove(fl.Name())
+
+				err = s.Put(ctx, fmt.Sprintf("test2/folder%d/file%d", i, j), fl.Name())
+				require.NoError(t, err)
+			}
+		}
+
+		entries, sub, err := s.ListEntries(ctx, "test2/")
+		require.NoError(t, err)
+		require.Empty(t, entries)
+		require.Len(t, sub, foldersCount)
+
+		entries, sub, err = s.ListEntries(ctx, "test2/folder0/")
+		require.NoError(t, err)
+		require.Empty(t, sub)
+		require.Len(t, entries, entriesCount)
+		require.EqualValues(t, "file1", entries[1].Name)
+		require.EqualValues(t, "file0", entries[0].Name)
+		require.EqualValues(t, "file10", entries[2].Name)
+		require.EqualValues(t, 15, entries[0].Size)
+		require.EqualValues(t, 15, entries[1].Size)
+		require.EqualValues(t, 16, entries[2].Size)
+	})
+}

--- a/pkg/server/remote_storage.go
+++ b/pkg/server/remote_storage.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2022 CodeNotary, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package server
 
 import (

--- a/pkg/server/remote_storage_test.go
+++ b/pkg/server/remote_storage_test.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2022 CodeNotary, Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package server
 
 import (

--- a/pkg/server/remote_storage_test.go
+++ b/pkg/server/remote_storage_test.go
@@ -94,7 +94,8 @@ func TestCreateRemoteStorage(t *testing.T) {
 	// Set remote storage options
 	s.WithOptions(DefaultOptions().WithRemoteStorageOptions(
 		DefaultRemoteStorageOptions().
-			WithS3Storage(true),
+			WithS3Storage(true).
+			WithS3BucketName("bucket"),
 	))
 
 	storage, err = s.createRemoteStorageInstance()


### PR DESCRIPTION
In some setups (elest.io minio containers) HEAD requets fail
when talking to the container. Workaround the HEAD request
by using object lists instead.

Also correctly handle URL-encoded object names and paths when
getting the list, fixes #1207.

Signed-off-by: Bartłomiej Święcki <bart@codenotary.com>