### PR TITLE
Tx Timestamp and SQL NOW function

### DIFF
--- a/embedded/sql/aggregated_values.go
+++ b/embedded/sql/aggregated_values.go
@@ -92,7 +92,7 @@ func (v *CountValue) substitute(params map[string]interface{}) (ValueExp, error)
 	return nil, ErrUnexpected
 }
 
-func (v *CountValue) reduce(catalog *Catalog, row *Row, implicitDB, implicitTable string) (TypedValue, error) {
+func (v *CountValue) reduce(tx *SQLTx, row *Row, implicitDB, implicitTable string) (TypedValue, error) {
 	return nil, ErrUnexpected
 }
 
@@ -182,7 +182,7 @@ func (v *SumValue) substitute(params map[string]interface{}) (ValueExp, error) {
 	return nil, ErrUnexpected
 }
 
-func (v *SumValue) reduce(catalog *Catalog, row *Row, implicitDB, implicitTable string) (TypedValue, error) {
+func (v *SumValue) reduce(tx *SQLTx, row *Row, implicitDB, implicitTable string) (TypedValue, error) {
 	return nil, ErrUnexpected
 }
 
@@ -275,7 +275,7 @@ func (v *MinValue) substitute(params map[string]interface{}) (ValueExp, error) {
 	return nil, ErrUnexpected
 }
 
-func (v *MinValue) reduce(catalog *Catalog, row *Row, implicitDB, implicitTable string) (TypedValue, error) {
+func (v *MinValue) reduce(tx *SQLTx, row *Row, implicitDB, implicitTable string) (TypedValue, error) {
 	return nil, ErrUnexpected
 }
 
@@ -368,7 +368,7 @@ func (v *MaxValue) substitute(params map[string]interface{}) (ValueExp, error) {
 	return nil, ErrUnexpected
 }
 
-func (v *MaxValue) reduce(catalog *Catalog, row *Row, implicitDB, implicitTable string) (TypedValue, error) {
+func (v *MaxValue) reduce(tx *SQLTx, row *Row, implicitDB, implicitTable string) (TypedValue, error) {
 	return nil, ErrUnexpected
 }
 
@@ -462,7 +462,7 @@ func (v *AVGValue) substitute(params map[string]interface{}) (ValueExp, error) {
 	return nil, ErrUnexpected
 }
 
-func (v *AVGValue) reduce(catalog *Catalog, row *Row, implicitDB, implicitTable string) (TypedValue, error) {
+func (v *AVGValue) reduce(tx *SQLTx, row *Row, implicitDB, implicitTable string) (TypedValue, error) {
 	return nil, ErrUnexpected
 }
 

--- a/embedded/sql/cond_row_reader.go
+++ b/embedded/sql/cond_row_reader.go
@@ -98,7 +98,7 @@ func (cr *conditionalRowReader) Read() (*Row, error) {
 			return nil, fmt.Errorf("%w: when evaluating WHERE clause", err)
 		}
 
-		r, err := cond.reduce(cr.Tx().catalog, row, cr.rowReader.Database(), cr.rowReader.TableAlias())
+		r, err := cond.reduce(cr.Tx(), row, cr.rowReader.Database(), cr.rowReader.TableAlias())
 		if err != nil {
 			return nil, fmt.Errorf("%w: when evaluating WHERE clause", err)
 		}

--- a/embedded/sql/engine.go
+++ b/embedded/sql/engine.go
@@ -246,6 +246,10 @@ func (sqlTx *SQLTx) Database() *Database {
 	return sqlTx.currentDB
 }
 
+func (sqlTx *SQLTx) Timestamp() time.Time {
+	return sqlTx.tx.Timestamp()
+}
+
 func (sqlTx *SQLTx) UpdatedRows() int {
 	return sqlTx.updatedRows
 }
@@ -1145,7 +1149,6 @@ func (e *Engine) execPreparedStmts(stmts []SQLStmt, params map[string]interface{
 		return nil, nil, stmts, ErrIllegalArguments
 	}
 
-	// TODO: eval params at once
 	nparams, err := normalizeParams(params)
 	if err != nil {
 		return nil, nil, stmts, err
@@ -1269,7 +1272,6 @@ func (e *Engine) QueryPreparedStmt(stmt DataSource, params map[string]interface{
 		}()
 	}
 
-	// TODO: eval params at once
 	nparams, err := normalizeParams(params)
 	if err != nil {
 		return nil, err

--- a/embedded/sql/engine_test.go
+++ b/embedded/sql/engine_test.go
@@ -428,10 +428,15 @@ func TestNowFunctionEvalsToTxTimestamp(t *testing.T) {
 		for i := 0; i < 10; i++ {
 			row, err := r.Read()
 			require.NoError(t, err)
-			require.EqualValues(t, tx.Timestamp().UTC(), row.ValuesBySelector[EncodeSelector("", "db1", "tx_timestamp", "ts")].Value())
+			require.EqualValues(t, tx.Timestamp(), row.ValuesBySelector[EncodeSelector("", "db1", "tx_timestamp", "ts")].Value())
 		}
 
+		_, err = r.Read()
+		require.ErrorIs(t, err, ErrNoMoreRows)
+
 		currentTs = tx.Timestamp()
+
+		time.Sleep(1 * time.Microsecond)
 	}
 }
 

--- a/embedded/sql/engine_test.go
+++ b/embedded/sql/engine_test.go
@@ -408,6 +408,8 @@ func TestNowFunctionEvalsToTxTimestamp(t *testing.T) {
 	currentTs := time.Now()
 
 	for it := 0; it < 3; it++ {
+		time.Sleep(1 * time.Microsecond)
+
 		tx, _, err := engine.Exec("BEGIN TRANSACTION;", nil, nil)
 		require.NoError(t, err)
 
@@ -435,8 +437,6 @@ func TestNowFunctionEvalsToTxTimestamp(t *testing.T) {
 		require.ErrorIs(t, err, ErrNoMoreRows)
 
 		currentTs = tx.Timestamp()
-
-		time.Sleep(1 * time.Microsecond)
 	}
 }
 

--- a/embedded/sql/engine_test.go
+++ b/embedded/sql/engine_test.go
@@ -413,8 +413,8 @@ func TestNowFunctionEvalsToTxTimestamp(t *testing.T) {
 
 		require.True(t, tx.Timestamp().After(currentTs))
 
-		for i := 1; i < 10; i++ {
-			_, _, err = engine.Exec("INSERT INTO tx_timestamp(ts) VALUES(NOW())", nil, tx)
+		for i := 0; i < 5; i++ {
+			_, _, err = engine.Exec("INSERT INTO tx_timestamp(ts) VALUES (NOW()), (NOW())", nil, tx)
 			require.NoError(t, err)
 		}
 
@@ -425,7 +425,7 @@ func TestNowFunctionEvalsToTxTimestamp(t *testing.T) {
 		require.NoError(t, err)
 		defer r.Close()
 
-		for i := 1; i < 10; i++ {
+		for i := 0; i < 10; i++ {
 			row, err := r.Read()
 			require.NoError(t, err)
 			require.EqualValues(t, tx.Timestamp().UTC(), row.ValuesBySelector[EncodeSelector("", "db1", "tx_timestamp", "ts")].Value())

--- a/embedded/sql/stmt.go
+++ b/embedded/sql/stmt.go
@@ -1820,7 +1820,7 @@ func (v *FnCall) reduce(tx *SQLTx, row *Row, implicitDB, implicitTable string) (
 		if len(v.params) > 0 {
 			return nil, fmt.Errorf("%w: '%s' function does not expect any argument but %d were provided", ErrIllegalArguments, NowFnCall, len(v.params))
 		}
-		return &Timestamp{val: tx.Timestamp().UTC()}, nil
+		return &Timestamp{val: tx.Timestamp().Truncate(time.Microsecond).UTC()}, nil
 	}
 
 	return nil, fmt.Errorf("%w: unkown function %s", ErrIllegalArguments, v.fn)
@@ -1853,7 +1853,7 @@ func getConverter(src, dst SQLValueType) (converterFunc, error) {
 				if val.Value() == nil {
 					return &NullValue{t: TimestampType}, nil
 				}
-				return &Timestamp{val: time.Unix(val.Value().(int64), 0).UTC()}, nil
+				return &Timestamp{val: time.Unix(val.Value().(int64), 0).Truncate(time.Microsecond).UTC()}, nil
 			}, nil
 		}
 
@@ -1871,7 +1871,7 @@ func getConverter(src, dst SQLValueType) (converterFunc, error) {
 				} {
 					t, err := time.ParseInLocation(layout, str, time.UTC)
 					if err == nil {
-						return &Timestamp{val: t.UTC()}, nil
+						return &Timestamp{val: t.Truncate(time.Microsecond).UTC()}, nil
 					}
 				}
 
@@ -2029,7 +2029,7 @@ func (p *Param) substitute(params map[string]interface{}) (ValueExp, error) {
 		}
 	case time.Time:
 		{
-			return &Timestamp{val: v}, nil
+			return &Timestamp{val: v.Truncate(time.Microsecond).UTC()}, nil
 		}
 	}
 

--- a/embedded/sql/values_row_reader.go
+++ b/embedded/sql/values_row_reader.go
@@ -158,7 +158,7 @@ func (vr *valuesRowReader) Read() (*Row, error) {
 			return nil, err
 		}
 
-		rv, err := sv.reduce(vr.tx.catalog, nil, vr.dbAlias, vr.tableAlias)
+		rv, err := sv.reduce(vr.tx, nil, vr.dbAlias, vr.tableAlias)
 		if err != nil {
 			return nil, err
 		}

--- a/embedded/store/ongoing_tx.go
+++ b/embedded/store/ongoing_tx.go
@@ -136,7 +136,7 @@ func (tx *OngoingTx) WithMetadata(md *TxMetadata) *OngoingTx {
 }
 
 func (tx *OngoingTx) Timestamp() time.Time {
-	return tx.ts
+	return tx.ts.Truncate(time.Microsecond).UTC()
 }
 
 func (tx *OngoingTx) Metadata() *TxMetadata {

--- a/embedded/store/ongoing_tx.go
+++ b/embedded/store/ongoing_tx.go
@@ -18,6 +18,7 @@ package store
 import (
 	"crypto/sha256"
 	"fmt"
+	"time"
 )
 
 //OngoingTx (no-thread safe) represents an interactive or incremental transaction with support of RYOW.
@@ -33,6 +34,8 @@ type OngoingTx struct {
 
 	metadata *TxMetadata
 
+	ts time.Time
+
 	closed bool
 }
 
@@ -46,6 +49,7 @@ func newWriteOnlyTx(s *ImmuStore) (*OngoingTx, error) {
 	return &OngoingTx{
 		st:           s,
 		entriesByKey: make(map[[sha256.Size]byte]int),
+		ts:           time.Now(),
 	}, nil
 }
 
@@ -53,6 +57,7 @@ func newReadWriteTx(s *ImmuStore) (*OngoingTx, error) {
 	tx := &OngoingTx{
 		st:           s,
 		entriesByKey: make(map[[sha256.Size]byte]int),
+		ts:           time.Now(),
 	}
 
 	err := s.WaitForIndexingUpto(s.committedTxID, nil)
@@ -128,6 +133,10 @@ func (tx *OngoingTx) IsWriteOnly() bool {
 func (tx *OngoingTx) WithMetadata(md *TxMetadata) *OngoingTx {
 	tx.metadata = md
 	return nil
+}
+
+func (tx *OngoingTx) Timestamp() time.Time {
+	return tx.ts
 }
 
 func (tx *OngoingTx) Metadata() *TxMetadata {


### PR DESCRIPTION
This PR includes a fixed timestamp associated to ongoing transactions.

SQL `now()` function evals to the fixed transaction timestamp. Thus making `now()` an idempotent function in the scope of the same transaction.

```sql
-- column `ts` of the three inserted rows will contain the same value

INSERT INTO mytable(id, ts) VALUES (1, NOW()), (2, NOW()), (3, NOW());

-- or equivalently

BEGIN TRANSACTION;
    INSERT INTO mytable(id, ts) VALUES (1, NOW());
    INSERT INTO mytable(id, ts) VALUES (2, NOW()), (3, NOW());
COMMIT;
```