### PR TITLE
Fix/scan revision

### DIFF
--- a/pkg/database/scan.go
+++ b/pkg/database/scan.go
@@ -102,7 +102,7 @@ func (d *db) Scan(req *schema.ScanRequest) (*schema.Entries, error) {
 			return nil, err
 		}
 
-		e, err := d.getAtTx(key, valRef.Tx(), 0, snap, tx, 0)
+		e, err := d.getAtTx(key, valRef.Tx(), 0, snap, tx, valRef.HC())
 		if err == store.ErrKeyNotFound {
 			// ignore deleted ones (referenced key may have been deleted)
 			continue


### PR DESCRIPTION
Correctly calculate key revision when doing a Scan request. Closes #1262.