### PR TITLE
chore(github): Install qemu using docker/setup-qemu-action

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -88,12 +88,10 @@ jobs:
             selector: '*-darwin-amd64'
           - os: ubuntu-latest
             selector: '*-linux-arm64'
-            qemu-launcher: qemu-aarch64
+            qemu-binfmt: true
           - os: ubuntu-latest
             selector: '*-linux-s390x'
-            qemu-launcher: qemu-s390x
-            extra-immudb-args: "--web-server=false"
-            continue-on-error: true
+            qemu-binfmt: true
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/download-artifact@v3
@@ -110,22 +108,20 @@ jobs:
       shell: bash
       if: runner.os != 'Windows'
 
-    - name: Install qemu-user
-      run: sudo apt update && sudo apt install -qq qemu-user
-      if: matrix.qemu-launcher
+    - name: Install qemu binaries
+      uses: docker/setup-qemu-action@v2
+      if: matrix.qemu-binfmt
 
     - name: Run immudb in the background
       shell: bash
-      continue-on-error: ${{ matrix.continue-on-error || false }}
       run: |
-        IMMUADMIN="${{ matrix.qemu-launcher }} "dist/immudb-${{ matrix.selector }}
-        $IMMUADMIN -d ${{ matrix.extra-immudb-args }}
+        IMMUDB=dist/immudb-${{ matrix.selector }}
+        $IMMUDB -d
 
     - name: immuadmin test
       shell: bash
-      continue-on-error: ${{ matrix.continue-on-error || false }}
       run: |
-        IMMUADMIN="${{ matrix.qemu-launcher }} "dist/immuadmin-${{ matrix.selector }}
+        IMMUADMIN=dist/immuadmin-${{ matrix.selector }}
 
         echo -n "immudb" | $IMMUADMIN login immudb || true
         $IMMUADMIN database create test
@@ -137,7 +133,7 @@ jobs:
       shell: bash
       continue-on-error: ${{ matrix.continue-on-error || false }}
       run: |
-        IMMUCLIENT="${{ matrix.qemu-launcher }} "dist/immuclient-${{ matrix.selector }}
+        IMMUCLIENT=dist/immuclient-${{ matrix.selector }}
 
         $IMMUCLIENT login --username immudb --password immudb
         echo -n "immudb" | $IMMUCLIENT login --username immudb
@@ -145,7 +141,7 @@ jobs:
         $IMMUCLIENT safeset test3 githubaction
         sg=$($IMMUCLIENT safeget test3)
         grep -q "githubaction" <<< $sg
-        grep -q  "verified" <<< $sg
+        grep -q "verified" <<< $sg
         grep -q "true" <<< $sg
 
   stress-tests:

--- a/Makefile
+++ b/Makefile
@@ -222,11 +222,7 @@ dist/sign:
 
 .PHONY: dist/binary.md
 dist/binary.md:
-	@for f in ./dist/*; do \
-		ff=$$(basename $$f); \
-		shm_id=$$(sha256sum $$f | awk '{print $$1}'); \
-		printf "[$$ff](https://github.com/vchain-us/immudb/releases/download/v${VERSION}/$$ff) | $$shm_id \n" ; \
-	done
+	@build/gen-downloads-md.sh "${VERSION}"
 
 ./webconsole/dist:
 ifeq (${WEBCONSOLE}, default)

--- a/build/RELEASING.md
+++ b/build/RELEASING.md
@@ -116,34 +116,8 @@ Use the following template for release notes:
 
 # Downloads
 
-**Docker image**
-https://hub.docker.com/r/codenotary/immudb
-
-**Immudb Binaries**
-
-File | SHA256
-------------- | -------------
 <!--
-    Paste checksums from github step: pushCI / Build binaries and notarize sources/Calculate checksums
-    Ensure to paste as a plain text
--->
-
-
-**Immuclient Binaries**
-
-File | SHA256
-------------- | -------------
-<!--
-    Paste checksums from github step: pushCI / Build binaries and notarize sources/Calculate checksums
-    Ensure to paste as a plain text
--->
-
-**Immuadmin Binaries**
-
-File | SHA256
-------------- | -------------
-<!--
-    Paste checksums from github step: pushCI / Build binaries and notarize sources/Calculate checksums
+    Paste output from github step: pushCI / Build binaries and notarize sources/Calculate checksums
     Ensure to paste as a plain text
 -->
 ```

--- a/build/RELEASING.md
+++ b/build/RELEASING.md
@@ -160,9 +160,6 @@ Following binaries are validated automatically in github actions:
 * windows-amd64
 * darwin-amd64
 
-The linux-s390x build is tested on github but it can occasionally fail due to unknown
-issue with zip checksum mismatch. For that build, repeat the github action job.
-
 The following builds have to be manually tested:
 
 * darwin-arm64

--- a/build/gen-downloads-md.sh
+++ b/build/gen-downloads-md.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+set -eu
+
+cd "$(dirname "$0")/../dist/"
+
+VERSION="$1"
+
+generate_checksums_for()
+{
+    cat <<EOF
+
+**$1 Binaries**
+
+File | SHA256
+------------- | -------------
+$(
+    for f in $1*; do
+        ff="$(basename $f)"
+		shm_id="$(sha256sum "$f" | awk '{print $1}')"
+		printf "[$ff](https://github.com/vchain-us/immudb/releases/download/v${VERSION}/$ff) | $shm_id \n"
+    done
+)
+EOF
+}
+
+cat <<EOF
+# Downloads
+
+**Docker image**
+https://hub.docker.com/r/codenotary/immudb
+
+
+EOF
+
+generate_checksums_for immudb
+generate_checksums_for immuclient
+generate_checksums_for immuadmin


### PR DESCRIPTION
Changes to github actions:

* Install qemu binaries using `docker/setup-qemu-action` GH action - that will install newer qemu that does not cause issues with s390x platform
* Upgrade the way we generate file checksums - the new output does include already split and structured text making it easier to add into release notes