### PR TITLE
Add S3 support and multiple-replicas to Helm Chart

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: immudb
 description: The immutable database
 type: application
-version: 1.0.0
+version: 1.1.0
 appVersion: "1.3.1"

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: immudb-configs
+  labels:
+    {{- include "immudb.labels" . | nindent 4 }}
+data:
+  IMMUDB_S3_STORAGE: "{{$.Values.s3.enabled }}"
+  IMMUDB_S3_BUCKET_NAME: {{ .Values.s3.bucket_name }}
+  IMMUDB_S3_LOCATION: {{ .Values.s3.location }}
+  IMMUDB_S3_PATH_PREFIX: {{ .Values.s3.path_prefix }}
+  IMMUDB_S3_ENDPOINT: "https://{{$.Values.s3.bucket_name}}.s3.{{$.Values.s3.location}}.amazonaws.com"
+  IMMUDB_DBNAME: {{ .Values.databaseName }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: immudb
+  labels:
+    {{- include "immudb.labels" . | nindent 4 }}
+data:
+  primary.cnf: |
+    dir = "./data/master"
+    network = "tcp"
+    address = "0.0.0.0"
+    port = 3322
+    dbname = "immudb"
+    pgsql-server = true # enable or disable pgsql server
+    pgsql-server-port = 5432  
+    web-server-port = 8080
+  replica.cnf: |
+    replication-enabled = true
+    replication-master-address="immudb-0.immudb"
+    replication-master-port=3322 
+    replication-follower-username="immudb"
+    replication-follower-password="immudb"
+    port=3334
+    pgsql-server-port=5434
+    dir="./data/replica"
+    pgsql-server = true # enable or disable pgsql server
+    web-server-port = 9090

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -16,20 +16,10 @@ metadata:
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
-    {{- if .Values.ingress.tls.enabled }}
-    traefik.ingress.kubernetes.io/router.entrypoints: websecure
-    traefik.ingress.kubernetes.io/router.tls: "true"
-    {{- end }}
   {{- end }}
 spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
   ingressClassName: {{ .Values.ingress.className }}
-  {{- end }}
-  {{- if .Values.ingress.tls.enabled }}
-  tls:
-    - hosts:
-        - {{ $.Values.ingress.hostname | quote }}
-      secretName: {{ .Values.ingress.tls.secretName }}
   {{- end }}
   rules:
     - host: {{ $.Values.ingress.hostname | quote }}

--- a/helm/templates/pvc.yaml
+++ b/helm/templates/pvc.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.persistence.enabled }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: immudb-claim
+spec:
+  accessModes:
+    - ReadWriteMany
+  volumeMode: {{ .Values.persistence.volumeMode }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.storage }}
+{{- end }}

--- a/helm/templates/secret.yaml
+++ b/helm/templates/secret.yaml
@@ -2,10 +2,12 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "immudb.fullname" . }}-credentials
+  name: immudb-credentials
   labels:
     {{- include "immudb.labels" . | nindent 4 }}
 type: Opaque 
 data: 
-  immudb-admin-password: "{{$.Values.adminPassword|b64enc}}"
+  IMMUDB_S3_ACCESS_KEY_ID: "{{$.Values.s3.access_key|b64enc}}"
+  IMMUDB_S3_SECRET_KEY: "{{$.Values.s3.secret_key|b64enc}}"
+  IMMUDB_ADMIN_PASSWORD: "{{$.Values.adminPassword|b64enc}}"
 {{ end }}

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -24,12 +24,46 @@ metadata:
   name: {{ include "immudb.fullname" . }}-grpc
   labels:
     {{- include "immudb.labels" . | nindent 4 }}
-  annotations:  
-    traefik.ingress.kubernetes.io/service.serversscheme: h2c
 spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.ports.grpc }}
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+  selector:
+    {{- include "immudb.selectorLabels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "immudb.fullname" . }}-replica-http
+  labels:
+    {{- include "immudb.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.replicaService.ports.http }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: {{ .Values.replicaService.ports.metrics }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+  selector:
+    {{- include "immudb.selectorLabels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "immudb.fullname" . }}-replica-grpc
+  labels:
+    {{- include "immudb.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.replicaService.ports.grpc }}
       targetPort: grpc
       protocol: TCP
       name: grpc

--- a/helm/templates/statefulset.yaml
+++ b/helm/templates/statefulset.yaml
@@ -1,6 +1,3 @@
-{{- if gt (.Values.replicaCount | toString | atoi) 1 }}
-{{- fail "At the moment, you can just have 1 instance of immudb. We are working to raise that limit."}}
-{{- end }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -31,13 +28,45 @@ spec:
       volumes:
       - name: immudb-storage
         persistentVolumeClaim:
-          claimName: {{ include "immudb.fullname" . }}
+          claimName: immudb-claim
+      - name: conf
+        emptyDir: { }
+      - name: scripts
+        emptyDir: { }
+      - name: config-map
+        configMap:
+          name: immudb
+      initContainers:
+        - name: init-immudb
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          command:
+            - bash
+            - "-c"
+            - |
+              set -ex
+              # Generate immudb server-id from pod ordinal index.
+              [[ `hostname` =~ -([0-9]+)$ ]] || exit 1
+              ordinal=${BASH_REMATCH[1]}
+              if [[ $ordinal -eq 0 ]]; then
+                cp /mnt/config-map/primary.cnf /mnt/configs/immudb.toml
+              else
+                cp /mnt/config-map/replica.cnf /mnt/configs/immudb.toml
+              fi
+          volumeMounts:
+          - name: conf
+            mountPath: /mnt/configs
+            subPath: immudb.toml
+          - name: config-map
+            mountPath: /mnt/config-map
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          command: [ "immudb","--config","/mnt/configs/immudb.toml" ]
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            {{- toYaml .Values.envFrom | nindent 12 }}
           ports:
             - name: http
               containerPort: 8080
@@ -57,19 +86,18 @@ spec:
             httpGet:
               path: /readyz
               port: metrics
-          {{- if $.Values.adminPassword }}
-          env:
-          - name: IMMUDB_ADMIN_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ include "immudb.fullname" . }}-credentials
-                key: immudb-admin-password
-          {{- end}}      
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
-          - mountPath: /var/lib/immudb
-            name: immudb-storage
+            - mountPath: /var/lib/immudb
+              name: immudb-storage
+            - name: immudb-storage
+              mountPath: /data/master
+            - name: immudb-storage
+              mountPath: /data/replica
+            - name: conf
+              mountPath: /mnt/configs
+              subPath: immudb.toml
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -82,15 +110,3 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-  volumeClaimTemplates:
-  - metadata:
-      name: immudb-storage
-    spec:
-      accessModes:
-      - ReadWriteOnce
-      {{- if .Values.volume.Class }}
-      storageClassName: {{ .Values.volume.Class | quote }}
-      {{- end }}
-      resources:
-        requests:
-          storage: {{ .Values.volume.size }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -13,9 +13,13 @@ image:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
-volume:
-  class: ""
-  size: 5Gi
+
+persistence:
+  enabled: true
+  storageClass: gp2
+  storage: 1Gi
+
+databaseName: "immudb"
 adminPassword: ""
 
 podAnnotations: {}
@@ -39,16 +43,20 @@ service:
     metrics: 9497
     http: 8080
 
+replicaService:
+  type: ClusterIP
+  ports:
+    grpc: 3334
+    http: 9090
+    metrics: 9498
+
 ingress:
-  enabled: false
+  enabled: "false"
   className: ""
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hostname: immudb-example.localhost
-  tls:
-    enabled: false
-    secretName: immudb-tls
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
@@ -67,3 +75,17 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+envFrom:
+  - configMapRef:
+      name: immudb-configs
+  - secretRef:
+      name: immudb-credentials
+
+s3:
+  enabled: "false"
+  access_key: ""
+  secret_key: ""
+  bucket_name: ""
+  location: ""
+  path_prefix: ""


### PR DESCRIPTION
This pull request adds two important features to the helm chart deployment strategy.

- ✅ S3 Storage support
- ✅ Multiple read-replicas support

These features are so important for in-cluster deployment using AWS Cloud. 