### PR TITLE
fix: access tls value in global scope within ingress annotations

### DIFF
--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -16,7 +16,7 @@ metadata:
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
-    {{- if .Values.ingress.tls.enabled }}
+    {{- if $.Values.ingress.tls.enabled }}
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     traefik.ingress.kubernetes.io/router.tls: "true"
     {{- end }}


### PR DESCRIPTION
The helm chart contains a bug within the ingress template. It uses `.Values.ingress.tls.enabled` to check if tls is enabled within the annotations settings. As the annotations section is surrounded with a `with` definition, the scope is changed within it to `.Values.ingress.annotations`. Therefore  `.Values.ingress.tls.enabled` actually looks up `.Values.ingress.annotations.Values.ingress.tls.enabled`, which does not exist.

The fix adds a `$` to actually use the global scope when checking if tls is enabled.