### PR TITLE
chore: Update main go versin to 1.18

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -16,19 +16,22 @@ jobs:
 
           - os: ubuntu-latest
             go: "1.17"
+
+          - os: ubuntu-latest
+            go: &main-go-version "1.18"
             testWithMinio: true
 
           - os: ubuntu-latest
-            go: "1.18"
+            go: "1.19"
             test: true
 
           - os: windows-latest
-            go: "1.17"
+            go: *main-go-version
             testClientOnly: true
             noWebconsole: true
 
           - os: macos-latest
-            go: "1.17"
+            go: *main-go-version
             testClientOnly: true
 
     runs-on: ${{ matrix.os }}
@@ -115,7 +118,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: *main-go-version
       - uses: actions/checkout@v3
       - run: |
           # Spawn minio docker container in the background
@@ -180,7 +183,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.17"
+          go-version: *main-go-version
       - uses: actions/checkout@v3
       - run: go build -o perf-test-suite ./test/performance-test-suite/cmd/perf-test/
       - run: ./perf-test-suite > perf-test-results.json

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,8 +1,8 @@
 name: pushCI
 
 env:
-  GO_VERSION: 1.17
-  MIN_SUPPORTED_GO_VERSION: 1.15
+  GO_VERSION: "1.18"
+  MIN_SUPPORTED_GO_VERSION: "1.15"
 
 on:
   push:

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Setup runner for Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.15
+        go-version: "1.18"
     - uses: actions/checkout@v3
     - name: Build stress tool
       run: |


### PR DESCRIPTION
Go 1.19 has just been released. Switch the main go compiler
version to 1.18 and start testing with 1.19.

Signed-off-by: Bartłomiej Święcki <bart@codenotary.com>