### PR TITLE
fix(build): update go version to 1.18 in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17 as build
+FROM golang:1.18 as build
 WORKDIR /src
 COPY go.mod go.sum /src/
 RUN go mod download -x

--- a/Dockerfile.alma
+++ b/Dockerfile.alma
@@ -1,4 +1,4 @@
-FROM golang:1.17 as build
+FROM golang:1.18 as build
 WORKDIR /src
 COPY . .
 RUN rm -rf /src/webconsole/dist

--- a/Dockerfile.immuadmin
+++ b/Dockerfile.immuadmin
@@ -1,4 +1,4 @@
-FROM golang:1.17 as build
+FROM golang:1.18 as build
 WORKDIR /src
 COPY . .
 RUN GOOS=linux GOARCH=amd64 make immuadmin-static

--- a/Dockerfile.immuclient
+++ b/Dockerfile.immuclient
@@ -1,4 +1,4 @@
-FROM golang:1.17 as build
+FROM golang:1.18 as build
 WORKDIR /src
 COPY . .
 RUN GOOS=linux GOARCH=amd64 make immuclient-static

--- a/Dockerfile.rndpass
+++ b/Dockerfile.rndpass
@@ -1,4 +1,4 @@
-FROM golang:1.17 as build
+FROM golang:1.18 as build
 WORKDIR /src
 COPY . .
 RUN GOOS=linux GOARCH=amd64 WEBCONSOLE=default make immuadmin-static immudb-static


### PR DESCRIPTION
Updates go version to 1.18 in Dockerfile builds

Signed-off-by: Farhan Khan <farhan@codenotary.com>