### PR TITLE
fix(getRandomTable): increase RNG range for table generation

### DIFF
--- a/pkg/pgsql/server/pgsql_integration_test.go
+++ b/pkg/pgsql/server/pgsql_integration_test.go
@@ -22,6 +22,13 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
 	"github.com/codenotary/immudb/pkg/pgsql/errors"
 	"github.com/codenotary/immudb/pkg/pgsql/server/pgmeta"
 	"github.com/codenotary/immudb/pkg/server"
@@ -29,12 +36,6 @@ import (
 	"github.com/jackc/pgx/v4"
 	_ "github.com/lib/pq"
 	"github.com/stretchr/testify/require"
-	"io/ioutil"
-	"math/rand"
-	"os"
-	"sync"
-	"testing"
-	"time"
 )
 
 func TestPgsqlServer_SimpleQuery(t *testing.T) {
@@ -573,7 +574,7 @@ func TestPgsqlServer_SimpleQueryNilValues(t *testing.T) {
 
 func getRandomTableName() string {
 	rand.Seed(time.Now().UnixNano())
-	r := rand.Intn(100)
+	r := rand.Intn(100000)
 	return fmt.Sprintf("table%d", r)
 }
 

--- a/pkg/stdlib/sql_test.go
+++ b/pkg/stdlib/sql_test.go
@@ -35,7 +35,7 @@ import (
 
 func getRandomTableName() string {
 	rand.Seed(time.Now().UnixNano())
-	r := rand.Intn(100)
+	r := rand.Intn(100000)
 	return fmt.Sprintf("table%d", r)
 }
 


### PR DESCRIPTION
- fixes issue with flaky tests which fail due to table already exists error

References: [1324](https://github.com/codenotary/immudb/issues/1324)