### PR TITLE
fix(pkg/client/clienttest): enforce mock client to interface

### DIFF
--- a/pkg/client/clienttest/homedir_mock.go
+++ b/pkg/client/clienttest/homedir_mock.go
@@ -21,6 +21,10 @@ import (
 	"github.com/codenotary/immudb/pkg/client/homedir"
 )
 
+var (
+	_ homedir.HomedirService = (*HomedirServiceMock)(nil)
+)
+
 // HomedirServiceMock ...
 type HomedirServiceMock struct {
 	homedir.HomedirService

--- a/pkg/client/clienttest/immuServiceClient_mock.go
+++ b/pkg/client/clienttest/immuServiceClient_mock.go
@@ -25,6 +25,10 @@ import (
 	"google.golang.org/grpc"
 )
 
+var (
+	_ schema.ImmuServiceClient = (*ImmuServiceClientMock)(nil)
+)
+
 // ImmuServiceClientMock ...
 type ImmuServiceClientMock struct {
 	schema.ImmuServiceClient

--- a/pkg/client/clienttest/immuclient_mock.go
+++ b/pkg/client/clienttest/immuclient_mock.go
@@ -27,6 +27,10 @@ import (
 	"google.golang.org/grpc"
 )
 
+var (
+	_ client.ImmuClient = (*ImmuClientMock)(nil)
+)
+
 // ImmuClientMock ...
 type ImmuClientMock struct {
 	immuclient.ImmuClient
@@ -39,7 +43,7 @@ type ImmuClientMock struct {
 	DisconnectF           func() error
 	LoginF                func(context.Context, []byte, []byte) (*schema.LoginResponse, error)
 	LogoutF               func(context.Context) error
-	VerifiedGetF          func(context.Context, []byte) (*schema.Entry, error)
+	VerifiedGetF          func(context.Context, []byte, ...client.GetOption) (*schema.Entry, error)
 	VerifiedGetAtF        func(context.Context, []byte, uint64) (*schema.Entry, error)
 	VerifiedSetF          func(context.Context, []byte, []byte) (*schema.TxHeader, error)
 	SetF                  func(context.Context, []byte, []byte) (*schema.TxHeader, error)
@@ -52,7 +56,7 @@ type ImmuClientMock struct {
 	DumpF                 func(context.Context, io.WriteSeeker) (int64, error)
 	CurrentStateF         func(context.Context) (*schema.ImmutableState, error)
 	TxByIDF               func(context.Context, uint64) (*schema.Tx, error)
-	GetF                  func(context.Context, []byte) (*schema.Entry, error)
+	GetF                  func(context.Context, []byte, ...client.GetOption) (*schema.Entry, error)
 	VerifiedTxByIDF       func(context.Context, uint64) (*schema.Tx, error)
 	ListUsersF            func(context.Context) (*schema.UserList, error)
 	SetActiveUserF        func(context.Context, *schema.SetActiveUserRequest) error
@@ -61,7 +65,7 @@ type ImmuClientMock struct {
 	ScanF                 func(context.Context, *schema.ScanRequest) (*schema.Entries, error)
 	CountF                func(context.Context, []byte) (*schema.EntryCount, error)
 	CreateDatabaseF       func(context.Context, *schema.DatabaseSettings) error
-	CreateDatabaseV2F     func(context.Context, string, *schema.DatabaseNullableSettings) (*schema.DatabaseNullableSettings, error)
+	CreateDatabaseV2F     func(context.Context, string, *schema.DatabaseNullableSettings) (*schema.CreateDatabaseResponse, error)
 	UpdateDatabaseF       func(context.Context, *schema.DatabaseSettings) error
 	UpdateDatabaseV2F     func(context.Context, string, *schema.DatabaseNullableSettings) (*schema.UpdateDatabaseResponse, error)
 	DatabaseListF         func(context.Context) (*schema.DatabaseListResponse, error)
@@ -110,8 +114,8 @@ func (icm *ImmuClientMock) Logout(ctx context.Context) error {
 }
 
 // VerifiedGet ...
-func (icm *ImmuClientMock) VerifiedGet(ctx context.Context, key []byte) (*schema.Entry, error) {
-	return icm.VerifiedGetF(ctx, key)
+func (icm *ImmuClientMock) VerifiedGet(ctx context.Context, key []byte, opts ...client.GetOption) (*schema.Entry, error) {
+	return icm.VerifiedGetF(ctx, key, opts...)
 }
 
 // VerifiedGetAt ...
@@ -200,8 +204,8 @@ func (icm *ImmuClientMock) CurrentState(ctx context.Context) (*schema.ImmutableS
 }
 
 // Get ...
-func (icm *ImmuClientMock) Get(ctx context.Context, key []byte) (*schema.Entry, error) {
-	return icm.GetF(ctx, key)
+func (icm *ImmuClientMock) Get(ctx context.Context, key []byte, opts ...client.GetOption) (*schema.Entry, error) {
+	return icm.GetF(ctx, key, opts...)
 }
 
 // TxByID ...
@@ -250,7 +254,7 @@ func (icm *ImmuClientMock) CreateDatabase(ctx context.Context, db *schema.Databa
 }
 
 // CreateDatabaseV2 ...
-func (icm *ImmuClientMock) CreateDatabaseV2(ctx context.Context, db string, setttings *schema.DatabaseNullableSettings) (*schema.DatabaseNullableSettings, error) {
+func (icm *ImmuClientMock) CreateDatabaseV2(ctx context.Context, db string, setttings *schema.DatabaseNullableSettings) (*schema.CreateDatabaseResponse, error) {
 	return icm.CreateDatabaseV2F(ctx, db, setttings)
 }
 

--- a/pkg/client/clienttest/immuclient_mock_test.go
+++ b/pkg/client/clienttest/immuclient_mock_test.go
@@ -38,6 +38,7 @@ func TestImmuClientMock(t *testing.T) {
 	errVerifiedReference := errors.New("VerifiedReferenceF got called")
 	errVerifiedZAdd := errors.New("VerifiedZAddF got called")
 	errHistory := errors.New("HistoryF got called")
+	errCreateDatabase := errors.New("CreateDatabaseV2F got called")
 	icm := &ImmuClientMock{
 		ImmuClient: client.NewClient(),
 		IsConnectedF: func() bool {
@@ -58,7 +59,7 @@ func TestImmuClientMock(t *testing.T) {
 		LogoutF: func(context.Context) error {
 			return errLogout
 		},
-		VerifiedGetF: func(context.Context, []byte) (*schema.Entry, error) {
+		VerifiedGetF: func(context.Context, []byte, ...client.GetOption) (*schema.Entry, error) {
 			return nil, errVerifiedGet
 		},
 		VerifiedSetF: func(context.Context, []byte, []byte) (*schema.TxHeader, error) {
@@ -75,6 +76,9 @@ func TestImmuClientMock(t *testing.T) {
 		},
 		HistoryF: func(context.Context, *schema.HistoryRequest) (*schema.Entries, error) {
 			return nil, errHistory
+		},
+		CreateDatabaseV2F: func(context.Context, string, *schema.DatabaseNullableSettings) (*schema.CreateDatabaseResponse, error) {
+			return nil, errCreateDatabase
 		},
 	}
 	require.True(t, icm.IsConnected())
@@ -109,4 +113,7 @@ func TestImmuClientMock(t *testing.T) {
 	_, err = icm.History(context.TODO(), nil)
 
 	require.Equal(t, errHistory, err)
+
+	_, err = icm.CreateDatabaseV2(context.TODO(), "", nil)
+	require.Equal(t, errCreateDatabase, err)
 }

--- a/pkg/client/clienttest/token_service_mock.go
+++ b/pkg/client/clienttest/token_service_mock.go
@@ -21,6 +21,10 @@ import (
 	"github.com/codenotary/immudb/pkg/client/tokenservice"
 )
 
+var (
+	_ tokenservice.TokenService = (*TokenServiceMock)(nil)
+)
+
 type TokenServiceMock struct {
 	tokenservice.TokenService
 	GetTokenF       func() (string, error)


### PR DESCRIPTION
These changes are required for https://github.com/codenotary/immugw to work, as it depends on mock clients from client test

- add interface assertion for immuclient
- add interface assertion for immuServiceClient
- add interface assertion for tokenservice

References: https://github.com/codenotary/immudb-issues/issues/76