### PR TITLE
chore: add dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Dependabot helps to keep all packages and dependencies up to date. This prevents from using vulnerable dependencies. It automatically creates PRs for dependency update, which we can then approve and merge.

Note, this does not automatically merge any PR. It just creates PRs for vulnerable dependencies. More on dependabot here

[Dependabot](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/)