### PR TITLE
Support read replicas

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -49,6 +49,10 @@ Selector labels
 app.kubernetes.io/name: {{ include "immudb.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+{{- define "immudb.rrSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "immudb.name" . }}-rr
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
 
 {{/*
 Create the name of the service account to use

--- a/helm/templates/dashboard.yaml
+++ b/helm/templates/dashboard.yaml
@@ -6,6 +6,6 @@ metadata:
   labels: 
     app: immudb
 spec:
-  url: https://raw.githubusercontent.com/codenotary/immudb/master/tools/monitoring/grafana-dashboard.json
+  url: https://raw.githubusercontent.com/codenotary/immudb/{{- .Values.grafanaDashboard.version | default (printf "v%s" .Chart.AppVersion) -}}/tools/monitoring/grafana-dashboard.json
 {{- end -}}
 

--- a/helm/templates/dashboard.yaml
+++ b/helm/templates/dashboard.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.grafanaDashboard -}}
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata: 
+  name: immudb-grafana-dashboard
+  labels: 
+    app: immudb
+spec:
+  url: https://raw.githubusercontent.com/codenotary/immudb/master/tools/monitoring/grafana-dashboard.json
+{{- end -}}
+

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -1,52 +1,61 @@
 {{- if .Values.ingress.enabled -}}
+{{- $18orHigher := semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion }}
+{{- $19orHigher := semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
 {{- $fullName := include "immudb.fullname" . -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+{{- if and .Values.ingress.className (not $18orHigher) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
   {{- end }}
 {{- end }}
+{{- $services := list $fullName}}
+{{- if gt (.Values.replicaCount | toString | atoi) 1 }}
+  {{- $services = append $services (printf "%s-rr" $fullName) }}
+{{- end }}
 
-
-apiVersion: {{ include "immudb.chart.ingressapiversion" . }}
+{{- range $services }}
+---
+apiVersion: {{ include "immudb.chart.ingressapiversion" $ }}
 kind: Ingress
 metadata:
-  name: {{ $fullName }}-http
+  name: {{ . }}-http
   labels:
-    {{- include "immudb.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
+    {{- include "immudb.labels" $ | nindent 4 }}
+  {{- with $.Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- toYaml $ | nindent 4 }}
     {{- if $.Values.ingress.tls.enabled }}
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
     traefik.ingress.kubernetes.io/router.tls: "true"
     {{- end }}
   {{- end }}
 spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ingress.className }}
+  {{- if and $.Values.ingress.className $18orHigher }}
+  ingressClassName: {{ $.Values.ingress.className }}
   {{- end }}
-  {{- if .Values.ingress.tls.enabled }}
+  {{- if $.Values.ingress.tls.enabled }}
   tls:
     - hosts:
         - {{ $.Values.ingress.hostname | quote }}
-      secretName: {{ .Values.ingress.tls.secretName }}
+      secretName: {{ $.Values.ingress.tls.secretName }}
   {{- end }}
   rules:
     - host: {{ $.Values.ingress.hostname | quote }}
       http:
         paths:
           - path: /
-            {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
+            {{- if $18orHigher }}
             pathType: Prefix
             backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              {{- if $19orHigher }}
               service:
-                name: {{ $fullName }}-http
+                name: {{ . }}-http
                 port:
                   number: {{ $.Values.service.ports.http }}
               {{- else }}
-              serviceName: {{ $fullName }}
+              serviceName: {{ . }}-http
               servicePort: {{ $.Values.service.ports.http }}
               {{- end }}
             {{- end }}
+{{- end }}
+
 {{- end }}

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -35,3 +35,44 @@ spec:
       name: grpc
   selector:
     {{- include "immudb.selectorLabels" . | nindent 4 }}
+{{- if gt (.Values.replicaCount | toString | atoi) 1 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "immudb.fullname" . }}-rr-http
+  labels:
+    {{- include "immudb.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.ports.http }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: {{ .Values.service.ports.metrics }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+  selector:
+    {{- include "immudb.rrSelectorLabels" . | nindent 4 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "immudb.fullname" . }}-rr-grpc
+  labels:
+    {{- include "immudb.labels" . | nindent 4 }}
+  annotations:  
+    traefik.ingress.kubernetes.io/service.serversscheme: h2c
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.ports.grpc }}
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+  selector:
+    {{- include "immudb.rrSelectorLabels" . | nindent 4 }}
+{{- end }}
+

--- a/helm/templates/statefulset.yaml
+++ b/helm/templates/statefulset.yaml
@@ -1,43 +1,43 @@
+{{- $name := include "immudb.fullname" . }}
+{{- $names := list $name }}
 {{- if gt (.Values.replicaCount | toString | atoi) 1 }}
-{{- fail "At the moment, you can just have 1 instance of immudb. We are working to raise that limit."}}
+  {{- $names = append $names (printf "%s-rr" $name) }}
 {{- end }}
+
+{{- range $names }}
+{{- $isMaster := eq . $name }}
+---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "immudb.fullname" . }}
+  name: {{ . }}
   labels:
-    {{- include "immudb.labels" . | nindent 4 }}
+    {{- include "immudb.labels" $ | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ $isMaster | ternary 1 (sub $.Values.replicaCount 1) }}
   selector:
     matchLabels:
-      {{- include "immudb.selectorLabels" . | nindent 6 }}
-  serviceName: {{ include "immudb.fullname" . }}    
+      {{- include ($isMaster | ternary "immudb.selectorLabels" "immudb.rrSelectorLabels") $ | nindent 6 }}
+  serviceName: {{ $name }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{- with $.Values.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "immudb.selectorLabels" . | nindent 8 }}
+        {{- include ($isMaster | ternary "immudb.selectorLabels" "immudb.rrSelectorLabels") $ | nindent 8 }}
     spec:
-      {{- with .Values.imagePullSecrets }}
+      {{- with $.Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      volumes:
-      - name: immudb-storage
-        persistentVolumeClaim:
-          claimName: {{ include "immudb.fullname" . }}
+      securityContext: {{- toYaml $.Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: {{ .Chart.Name }}
-          securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+        - name: {{ $.Chart.Name }}
+          securityContext: {{- toYaml $.Values.securityContext | nindent 12 }}
+          image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}"
+          imagePullPolicy: {{ $.Values.image.pullPolicy }}
           ports:
             - name: http
               containerPort: 8080
@@ -57,28 +57,37 @@ spec:
             httpGet:
               path: /readyz
               port: metrics
-          {{- if $.Values.adminPassword }}
           env:
+          {{- if $.Values.adminPassword }}
           - name: IMMUDB_ADMIN_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: {{ include "immudb.fullname" . }}-credentials
+                name: {{ $name }}-credentials
                 key: immudb-admin-password
-          {{- end}}      
-          resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
+          {{- if (not $isMaster) | and (gt ($.Values.replicaCount | int) 1 )  }}
+          - name: IMMUDB_REPLICATION_ENABLED
+            value: "true"
+          - name: IMMUDB_REPLICATION_FOLLOWER_USERNAME
+            value: {{ $.Values.adminUsername | default "immudb" }}
+          - name: IMMUDB_REPLICATION_FOLLOWER_PASSWORD
+            value: {{ $.Values.adminPassword | default "immudb" }}
+          - name: IMMUDB_REPLICATION_MASTER_ADDRESS
+            value: {{ $name }}-grpc
+          {{- end }}
+          resources: {{- toYaml $.Values.resources | nindent 12 }}
           volumeMounts:
           - mountPath: /var/lib/immudb
             name: immudb-storage
-      {{- with .Values.nodeSelector }}
+      {{- with $.Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with $.Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with $.Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -88,9 +97,10 @@ spec:
     spec:
       accessModes:
       - ReadWriteOnce
-      {{- if .Values.volume.Class }}
-      storageClassName: {{ .Values.volume.Class | quote }}
+      {{- if $.Values.volume.Class }}
+      storageClassName: {{ $.Values.volume.Class | quote }}
       {{- end }}
       resources:
         requests:
-          storage: {{ .Values.volume.size }}
+          storage: {{ $.Values.volume.size }}
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -69,4 +69,6 @@ tolerations: []
 
 affinity: {}
 
-grafanaDashboard: false
+grafanaDashboard:
+  enabled: false
+  version:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -16,6 +16,7 @@ fullnameOverride: ""
 volume:
   class: ""
   size: 5Gi
+adminUsername: ""
 adminPassword: ""
 
 podAnnotations: {}
@@ -67,3 +68,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+grafanaDashboard: false


### PR DESCRIPTION
- Support read replicas by deploying a separate statefulset of N-1 replicas
- Add additional ingresses to the read replica services
- Optionally install grafana dashboard via Grafana Operator CRD

**Test Plan:**

```
k3d cluster create -a3
helm upgrade --install immudb . --set replicaCount=3 --set ingress.enabled=true
kubectl port-forward svc/immudb-rr-grpc 2233:3322 &
kubectl port-forward svc/immudb-grpc 3322:3322 &

# This should succeed
immuclient --username immudb --password immudb exec "UPSERT INTO orders (id, customerid, productid) VALUES ( 2, 1, 1);"
# This should fail
immuclient --immudb-port 2233 --username immudb --password immudb exec "UPSERT INTO orders (id, customerid, productid) VALUES ( 2, 1, 1);"
```