### PR TITLE
Fix/helm init volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,11 @@ helm install immudb/immudb --generate-name
 
 Immudb helm chart creates a persisten volume for storing immudb database. Those database are now placed in a subdirectory.
 That's for compatibility with ext4 volumes that have a `/lost+found` directory that can confuse immudb. If we placed
-database directory on the root of the volume, that `/lost+found` would be treated as a database. So we now create a
-`immudb` subpath for storing that.
+database directory on the root of the volume, that `/lost+found` would be treated as a database. So we now create a subpath
+(usually `immudb`) subpath for storing that.
+
 This is different from what we did on older (<=1.3.1) helm charts, so if you have already some volumes with data you can set
-value volumeSubPath to false (i.e.: `--set volumeSubPath=false`) when upgrading so that the old way is used.
+value volumeSubPath to false (i.e.: `--set volumeSubPath.enabled=false`) when upgrading so that the old way is used.
 
 You can alternatively migrate the data in a `/immudb` directory. You can use this pod as a reference for the job:
 ```yaml
@@ -148,6 +149,10 @@ spec:
         mkdir -p /data/immudb
         ls /data | grep -v -E 'immudb|lost\+found'|while read i; do mv /data/$i /data/immudb/$i; done
 ```
+
+Note that you can also tune the subfolder path using `volumeSubPath.path` value, if you prefer your data on a
+different directory than the default `immudb`.
+
 ### Enabling Amazon S3 storage
 
 immudb can store its data in the Amazon S3 service (or a compatible alternative).

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ In kubernetes, use helm for an easy deployment: just add our repository and inst
 ```bash
 helm repo add immudb https://packages.codenotary.org/helm
 helm repo update
-helm install immudb --generate-name
+helm install immudb/immudb --generate-name
 ```
 
 ### Enabling Amazon S3 storage

--- a/README.md
+++ b/README.md
@@ -115,12 +115,14 @@ helm repo add immudb https://packages.codenotary.org/helm
 helm repo update
 helm install immudb/immudb --generate-name
 ```
-### Migrating data from older helm installation
+### Using subfolders
 
-Immudb helm chart creates a persisten volume for storing immudb database. Those database are now placed in a subdirectory.
-That's for compatibility with ext4 volumes that have a `/lost+found` directory that can confuse immudb. If we placed
-database directory on the root of the volume, that `/lost+found` would be treated as a database. So we now create a subpath
-(usually `immudb`) subpath for storing that.
+Immudb helm chart creates a persistent volume for storing immudb database.
+Those database are now by default placed in a subdirectory.
+
+That's for compatibility with ext4 volumes that have a `/lost+found` directory that can confuse immudb. Some volume providers,
+like EBS or DigitalOcean, are using this kind of volumes. If we placed database directory on the root of the volume,
+that `/lost+found` would be treated as a database. So we now create a subpath (usually `immudb`) subpath for storing that.
 
 This is different from what we did on older (<=1.3.1) helm charts, so if you have already some volumes with data you can set
 value volumeSubPath to false (i.e.: `--set volumeSubPath.enabled=false`) when upgrading so that the old way is used.
@@ -149,8 +151,8 @@ spec:
         mkdir -p /data/immudb
         ls /data | grep -v -E 'immudb|lost\+found'|while read i; do mv /data/$i /data/immudb/$i; done
 ```
-
-Note that you can also tune the subfolder path using `volumeSubPath.path` value, if you prefer your data on a
+As said before, you can totally disable the use of subPath by setting `volumeSubPath.enabled=false`.
+You can also tune the subfolder path using `volumeSubPath.path` value, if you prefer your data on a
 different directory than the default `immudb`.
 
 ### Enabling Amazon S3 storage

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: immudb
 description: The immutable database
 type: application
-version: 1.0.0
+version: 1.3.2
 appVersion: "1.3.2"

--- a/helm/templates/statefulset.yaml
+++ b/helm/templates/statefulset.yaml
@@ -72,8 +72,8 @@ spec:
           volumeMounts:
           - mountPath: /var/lib/immudb
             name: immudb-storage
-            {{- if $.Values.volumeSubPath }}
-            subPath: immudb
+            {{- if $.Values.volumeSubPath.enabled }}
+            subPath: {{ $.Values.volumeSubPath.path | quote }}
             {{- end}}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/helm/templates/statefulset.yaml
+++ b/helm/templates/statefulset.yaml
@@ -32,20 +32,12 @@ spec:
       - name: immudb-storage
         persistentVolumeClaim:
           claimName: {{ include "immudb.fullname" . }}
-      initContainers:
-        - command: ["/bin/chown", "-R", "3322:3322", "/data"]
-          image: busybox
-          name: permission-fix
-          volumeMounts:
-          - mountPath: /data
-            name: immudb-storage
-            {{- if $.Values.volumeSubPath }}
-            subPath: immudb
-            {{- end}}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml .Values.podSecurityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/helm/templates/statefulset.yaml
+++ b/helm/templates/statefulset.yaml
@@ -12,7 +12,7 @@ spec:
   selector:
     matchLabels:
       {{- include "immudb.selectorLabels" . | nindent 6 }}
-  serviceName: {{ include "immudb.fullname" . }}    
+  serviceName: {{ include "immudb.fullname" . }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -72,13 +72,13 @@ spec:
               secretKeyRef:
                 name: {{ include "immudb.fullname" . }}-credentials
                 key: immudb-admin-password
-          {{- end}}      
+          {{- end}}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
           - mountPath: /var/lib/immudb
             name: immudb-storage
-            subpath: immudb
+            subPath: immudb
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/templates/statefulset.yaml
+++ b/helm/templates/statefulset.yaml
@@ -32,6 +32,14 @@ spec:
       - name: immudb-storage
         persistentVolumeClaim:
           claimName: {{ include "immudb.fullname" . }}
+      initContainers:
+        - command: ["/bin/chown", "-R", "3322:3322", "/data"]
+          image: busybox
+          name: permission-fix
+          volumeMounts:
+          - mountPath: /data
+            name: immudb-storage
+            subPath: immudb
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -70,6 +78,7 @@ spec:
           volumeMounts:
           - mountPath: /var/lib/immudb
             name: immudb-storage
+            subpath: immudb
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/templates/statefulset.yaml
+++ b/helm/templates/statefulset.yaml
@@ -39,7 +39,9 @@ spec:
           volumeMounts:
           - mountPath: /data
             name: immudb-storage
+            {{- if $.Values.volumeSubPath }}
             subPath: immudb
+            {{- end}}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -78,7 +80,9 @@ spec:
           volumeMounts:
           - mountPath: /var/lib/immudb
             name: immudb-storage
+            {{- if $.Values.volumeSubPath }}
             subPath: immudb
+            {{- end}}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -67,3 +67,9 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# by default, we now use a subdirectory inside the volume so that if you are mounting volumes
+# that have a `/lost+found` directory (i.e., ext4), immudb don't get confused assuming that
+# is a database. If you want to disable this, or you have already some data on the root of
+# the volume from an older installation, set it to false.
+volumeSubPath: true

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -24,13 +24,17 @@ podSecurityContext: {}
   # fsGroup: 2000
 
 securityContext:
-   capabilities:
-     drop:
-     - ALL
-   readOnlyRootFilesystem: true
    runAsNonRoot: true
    runAsUser: 3322
    runAsGroup: 3322
+   fsGroup: 3322
+   fsGroupChangePolicy: "OnRootMismatch"
+
+podSecurityContext:
+   readOnlyRootFilesystem: true
+   capabilities:
+     drop:
+     - ALL
 
 service:
   type: ClusterIP
@@ -68,8 +72,10 @@ tolerations: []
 
 affinity: {}
 
-# by default, we now use a subdirectory inside the volume so that if you are mounting volumes
+# We can now use a subdirectory inside the volume so that if you are mounting volumes
 # that have a `/lost+found` directory (i.e., ext4), immudb don't get confused assuming that
-# is a database. If you want to disable this, or you have already some data on the root of
-# the volume from an older installation, set it to false.
-volumeSubPath: true
+# is a database. Enable this in case you are using a ext4 block-based volume provider,
+# like DigitalOcean or EBS. Disable if you already have some data in the volume root.
+volumeSubPath:
+  enabled: true # or false
+  path: /immudb

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -78,4 +78,4 @@ affinity: {}
 # like DigitalOcean or EBS. Disable if you already have some data in the volume root.
 volumeSubPath:
   enabled: true # or false
-  path: /immudb
+  path: immudb


### PR DESCRIPTION
This PR adds an init container which fixes ownership for the persistent volume immudb is mounting to store its databases.

At least with digital ocean, a persisten volume is mounted as root:root with 0755 permissions, and that overrides permissions and ownership of the mountpoint, so it can't be fixed simply in the Dockerfile
Without this fix immudb helm chart can't be successfully deployed on Digital Ocean kubernetes (and probably other providers).
