### PR TITLE
chore(pkg/errors): add multiple error aggregation

### DIFF
--- a/pkg/errors/aggregate.go
+++ b/pkg/errors/aggregate.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2022 Codenotary Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"errors"
+)
+
+var (
+	_ error = (*Aggregate)(nil)
+)
+
+type Aggregate []error
+
+// NewAggregate encapsulates an array of errors into a single error. It
+// satisfies the error interface.
+func NewAggregate(errlist []error) Aggregate {
+	var filter []error
+	for _, err := range errlist {
+		if err != nil {
+			filter = append(filter, err)
+		}
+	}
+	if len(filter) == 0 {
+		return nil
+	}
+
+	return Aggregate(filter)
+}
+
+// Error returns a concatenated error message, and satisfies the error interface.
+func (a Aggregate) Error() (res string) {
+	errSet := newSet()
+	a.walk(func(err error) bool {
+		msg := err.Error()
+		if errSet.has(msg) {
+			return false
+		}
+		errSet.add(msg)
+		if errSet.len() > 1 {
+			res += ", "
+		}
+		res += msg
+		return false
+	})
+	if errSet.len() == 0 || errSet.len() == 1 {
+		return res
+	}
+	return "[" + res + "]"
+}
+
+// Is checks if the target error exists in the aggregate.
+func (a Aggregate) Is(target error) bool {
+	return a.walk(func(err error) bool {
+		return errors.Is(err, target)
+	})
+}
+
+func (a Aggregate) walk(f func(err error) bool) bool {
+	for _, err := range a {
+		switch err := err.(type) {
+		case Aggregate:
+			if match := err.walk(f); match {
+				return match
+			}
+		default:
+			if match := f(err); match {
+				return match
+			}
+		}
+	}
+
+	return false
+}
+
+type set map[string]struct{}
+
+func newSet(items ...string) set {
+	ss := make(set, len(items))
+	ss.add(items...)
+	return ss
+}
+
+func (s set) add(items ...string) set {
+	for _, item := range items {
+		s[item] = struct{}{}
+	}
+	return s
+}
+
+func (s set) has(item string) bool {
+	_, ok := s[item]
+	return ok
+}
+
+func (s set) len() int {
+	return len(s)
+}

--- a/pkg/errors/aggregate_test.go
+++ b/pkg/errors/aggregate_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2022 Codenotary Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestAggregateWithNoErrors(t *testing.T) {
+	err := NewAggregate([]error{})
+	if err != nil || err.Error() != "" {
+		t.Errorf("expected nil, got %#v", err)
+	}
+}
+
+func TestAggregateWithNil(t *testing.T) {
+	errs := []error{nil}
+	err := NewAggregate(errs)
+	if err != nil || err.Error() != "" {
+		t.Errorf("expected nil, got %#v", err)
+	}
+}
+
+func TestAggregateWithNilAndError(t *testing.T) {
+	errs := []error{nil, errors.New("foo")}
+	err := NewAggregate(errs)
+	if err.Error() != "foo" {
+		t.Errorf("expected foo, got %#v", err.Error())
+	}
+}
+
+func TestAggregateMultipleErrors(t *testing.T) {
+	errs := []error{nil, errors.New("foo"), errors.New("baz"), errors.New("bar")}
+	err := NewAggregate(errs)
+
+	expected := "[foo, baz, bar]"
+	if err.Error() != expected {
+		t.Errorf("expected %s, got %#v", expected, err.Error())
+	}
+}
+
+func TestAggregateWithErrorIs(t *testing.T) {
+	a, b, c := errors.New("foo"), errors.New("baz"), errors.New("bar")
+	errs := []error{a, b}
+	err := NewAggregate(errs)
+
+	if v := err.Is(a); !v {
+		t.Errorf("expected true, got %#v", v)
+	}
+
+	if v := err.Is(c); v {
+		t.Errorf("expected false, got %#v", v)
+	}
+}
+
+func TestAggregateWithErrorAsAggregate(t *testing.T) {
+	a, b, c := errors.New("foo"), errors.New("baz"), errors.New("bar")
+	err1 := []error{a, b}
+	agg1 := NewAggregate(err1)
+	err2 := []error{c, agg1}
+	agg2 := NewAggregate(err2)
+
+	if v := agg1.Is(a); !v {
+		t.Errorf("expected true, got %#v", v)
+	}
+
+	if v := agg2.Is(c); !v {
+		t.Errorf("expected true, got %#v", v)
+	}
+
+	if v := agg2.Is(a); !v {
+		t.Errorf("expected true, got %#v", v)
+	}
+
+	expected := "[bar, foo, baz]"
+	if agg2.Error() != expected {
+		t.Errorf("expected %s, got %#v", expected, agg2.Error())
+	}
+
+}


### PR DESCRIPTION
This PR adds a helper utility for error aggregation. This is helpful in aggregating multiple errors. It works as follows

```
func doSomething() error{
       err := make([]error,0,1)

        _, err1  := somefunc()
        err = append(err, err1)  // no need to return unless it needs to

        _, err2  := somefunc2()
        err = append(err, err2) // concatenate errors easily
       
        _, err3  := somefunc3()
        err = append(err, err3) // concatenate errors easily

       return NewAggregate(err)
}
```

In a for loop
```
func doSomethingInLoop() error{
       err := make([]error,0,1)

       for i:=range something {
        _, err1  := somefunc()
                err = append(err, err1)  // no need to return unless it needs to
        }
       return NewAggregate(err)
}
```