### PR TITLE
chore: Add empty line between license header and package

### DIFF
--- a/cmd/immuclient/immuc/history.go
+++ b/cmd/immuclient/immuc/history.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package immuc
 
 import (

--- a/cmd/immuclient/immuc/init.go
+++ b/cmd/immuclient/immuc/init.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package immuc
 
 import (

--- a/cmd/immuclient/immuc/misc.go
+++ b/cmd/immuclient/immuc/misc.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package immuc
 
 import (

--- a/cmd/immuclient/immuc/scanners.go
+++ b/cmd/immuclient/immuc/scanners.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package immuc
 
 import (

--- a/cmd/immuclient/immuc/sql.go
+++ b/cmd/immuclient/immuc/sql.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package immuc
 
 import (

--- a/embedded/ahtree/ahtree.go
+++ b/embedded/ahtree/ahtree.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ahtree
 
 import (

--- a/embedded/ahtree/ahtree_test.go
+++ b/embedded/ahtree/ahtree_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ahtree
 
 import (

--- a/embedded/ahtree/options.go
+++ b/embedded/ahtree/options.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ahtree
 
 import (

--- a/embedded/ahtree/options_test.go
+++ b/embedded/ahtree/options_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ahtree
 
 import (

--- a/embedded/ahtree/verification.go
+++ b/embedded/ahtree/verification.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ahtree
 
 import "crypto/sha256"

--- a/embedded/ahtree/verification_test.go
+++ b/embedded/ahtree/verification_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package ahtree
 
 import (

--- a/embedded/appendable/appendable.go
+++ b/embedded/appendable/appendable.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package appendable
 
 import (

--- a/embedded/appendable/metadata.go
+++ b/embedded/appendable/metadata.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package appendable
 
 import (

--- a/embedded/appendable/metadata_test.go
+++ b/embedded/appendable/metadata_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package appendable
 
 import (

--- a/embedded/appendable/mocked/mocked.go
+++ b/embedded/appendable/mocked/mocked.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package mocked
 
 type MockedAppendable struct {

--- a/embedded/appendable/mocked/mocked_test.go
+++ b/embedded/appendable/mocked/mocked_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package mocked
 
 import (

--- a/embedded/appendable/multiapp/appendable_lru_cache.go
+++ b/embedded/appendable/multiapp/appendable_lru_cache.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package multiapp
 
 import (

--- a/embedded/appendable/multiapp/appendable_lru_cache_test.go
+++ b/embedded/appendable/multiapp/appendable_lru_cache_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package multiapp
 
 import (

--- a/embedded/appendable/multiapp/metrics.go
+++ b/embedded/appendable/multiapp/metrics.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package multiapp
 
 import (

--- a/embedded/appendable/multiapp/multi_app.go
+++ b/embedded/appendable/multiapp/multi_app.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package multiapp
 
 import (

--- a/embedded/appendable/multiapp/multi_app_test.go
+++ b/embedded/appendable/multiapp/multi_app_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package multiapp
 
 import (

--- a/embedded/appendable/multiapp/options.go
+++ b/embedded/appendable/multiapp/options.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package multiapp
 
 import (

--- a/embedded/appendable/multiapp/options_test.go
+++ b/embedded/appendable/multiapp/options_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package multiapp
 
 import (

--- a/embedded/appendable/reader.go
+++ b/embedded/appendable/reader.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package appendable
 
 import (

--- a/embedded/appendable/reader_test.go
+++ b/embedded/appendable/reader_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package appendable
 
 import (

--- a/embedded/appendable/remoteapp/chunk_state.go
+++ b/embedded/appendable/remoteapp/chunk_state.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package remoteapp
 
 import "fmt"

--- a/embedded/appendable/remoteapp/chunk_state_test.go
+++ b/embedded/appendable/remoteapp/chunk_state_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package remoteapp
 
 import (

--- a/embedded/appendable/remoteapp/chunked_process.go
+++ b/embedded/appendable/remoteapp/chunked_process.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package remoteapp
 
 import (

--- a/embedded/appendable/remoteapp/chunked_process_test.go
+++ b/embedded/appendable/remoteapp/chunked_process_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package remoteapp
 
 import (

--- a/embedded/appendable/remoteapp/errors.go
+++ b/embedded/appendable/remoteapp/errors.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package remoteapp
 
 import "errors"

--- a/embedded/appendable/remoteapp/metrics.go
+++ b/embedded/appendable/remoteapp/metrics.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package remoteapp
 
 import (

--- a/embedded/appendable/remoteapp/options.go
+++ b/embedded/appendable/remoteapp/options.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package remoteapp
 
 import (

--- a/embedded/appendable/remoteapp/options_test.go
+++ b/embedded/appendable/remoteapp/options_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package remoteapp
 
 import (

--- a/embedded/appendable/remoteapp/remote_app.go
+++ b/embedded/appendable/remoteapp/remote_app.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package remoteapp
 
 import (

--- a/embedded/appendable/remoteapp/remote_app_test.go
+++ b/embedded/appendable/remoteapp/remote_app_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package remoteapp
 
 import (

--- a/embedded/appendable/singleapp/options.go
+++ b/embedded/appendable/singleapp/options.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package singleapp
 
 import (

--- a/embedded/appendable/singleapp/options_test.go
+++ b/embedded/appendable/singleapp/options_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package singleapp
 
 import (

--- a/embedded/appendable/singleapp/single_app.go
+++ b/embedded/appendable/singleapp/single_app.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package singleapp
 
 import (

--- a/embedded/appendable/singleapp/single_app_test.go
+++ b/embedded/appendable/singleapp/single_app_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package singleapp
 
 import (

--- a/embedded/cache/lru_cache.go
+++ b/embedded/cache/lru_cache.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cache
 
 import (

--- a/embedded/cache/lru_cache_test.go
+++ b/embedded/cache/lru_cache_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package cache
 
 import (

--- a/embedded/errors.go
+++ b/embedded/errors.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package embedded
 
 import "errors"

--- a/embedded/htree/htree.go
+++ b/embedded/htree/htree.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package htree
 
 import (

--- a/embedded/htree/htree_test.go
+++ b/embedded/htree/htree_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package htree
 
 import (

--- a/embedded/multierr/multierr.go
+++ b/embedded/multierr/multierr.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package multierr
 
 import (

--- a/embedded/multierr/multierr_test.go
+++ b/embedded/multierr/multierr_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package multierr
 
 import (

--- a/embedded/remotestorage/memory/memory.go
+++ b/embedded/remotestorage/memory/memory.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package memory
 
 import (

--- a/embedded/remotestorage/memory/memory_test.go
+++ b/embedded/remotestorage/memory/memory_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package memory
 
 import (

--- a/embedded/remotestorage/remote_storage.go
+++ b/embedded/remotestorage/remote_storage.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package remotestorage
 
 import (

--- a/embedded/remotestorage/s3/metrics.go
+++ b/embedded/remotestorage/s3/metrics.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package s3
 
 import (

--- a/embedded/remotestorage/s3/s3.go
+++ b/embedded/remotestorage/s3/s3.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package s3
 
 import (

--- a/embedded/sql/catalog.go
+++ b/embedded/sql/catalog.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package sql
 
 import (

--- a/embedded/sql/catalog_test.go
+++ b/embedded/sql/catalog_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package sql
 
 import (

--- a/embedded/sql/cond_row_reader.go
+++ b/embedded/sql/cond_row_reader.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package sql
 
 import "fmt"

--- a/embedded/sql/cond_row_reader_test.go
+++ b/embedded/sql/cond_row_reader_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package sql
 
 import (

--- a/embedded/sql/distinct_row_reader.go
+++ b/embedded/sql/distinct_row_reader.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package sql
 
 import "crypto/sha256"

--- a/embedded/sql/distinct_row_reader_test.go
+++ b/embedded/sql/distinct_row_reader_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package sql
 
 import (

--- a/embedded/sql/dummy_row_reader_test.go
+++ b/embedded/sql/dummy_row_reader_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package sql
 
 import (

--- a/embedded/sql/engine.go
+++ b/embedded/sql/engine.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package sql
 
 import (

--- a/embedded/sql/engine_test.go
+++ b/embedded/sql/engine_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package sql
 
 import (

--- a/embedded/sql/grouped_row_reader.go
+++ b/embedded/sql/grouped_row_reader.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package sql
 
 import (

--- a/embedded/sql/grouped_row_reader_test.go
+++ b/embedded/sql/grouped_row_reader_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package sql
 
 import (

--- a/embedded/sql/limit_row_reader.go
+++ b/embedded/sql/limit_row_reader.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package sql
 
 type limitRowReader struct {

--- a/embedded/sql/limit_row_reader_test.go
+++ b/embedded/sql/limit_row_reader_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package sql
 
 import (

--- a/embedded/sql/offset_row_reader.go
+++ b/embedded/sql/offset_row_reader.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package sql
 
 type offsetRowReader struct {

--- a/embedded/sql/offset_row_reader_test.go
+++ b/embedded/sql/offset_row_reader_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package sql
 
 import (

--- a/embedded/sql/options.go
+++ b/embedded/sql/options.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package sql
 
 var defultDistinctLimit = 1 << 20 // ~ 1mi rows

--- a/embedded/sql/options_test.go
+++ b/embedded/sql/options_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package sql
 
 import (

--- a/embedded/sql/parser_test.go
+++ b/embedded/sql/parser_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package sql
 
 import (

--- a/embedded/sql/proj_row_reader.go
+++ b/embedded/sql/proj_row_reader.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package sql
 
 import "fmt"

--- a/embedded/sql/stmt_test.go
+++ b/embedded/sql/stmt_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package sql
 
 import (

--- a/embedded/sql/union_row_reader.go
+++ b/embedded/sql/union_row_reader.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package sql
 
 import (

--- a/embedded/sql/union_row_reader_test.go
+++ b/embedded/sql/union_row_reader_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package sql
 
 import (

--- a/embedded/sql/values_row_reader.go
+++ b/embedded/sql/values_row_reader.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package sql
 
 import "fmt"

--- a/embedded/sql/values_row_reader_test.go
+++ b/embedded/sql/values_row_reader_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package sql
 
 import (

--- a/embedded/store/immustore.go
+++ b/embedded/store/immustore.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package store
 
 import (

--- a/embedded/store/immustore_test.go
+++ b/embedded/store/immustore_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package store
 
 import (

--- a/embedded/store/indexer.go
+++ b/embedded/store/indexer.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package store
 
 import (

--- a/embedded/store/indexer_test.go
+++ b/embedded/store/indexer_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package store
 
 import (

--- a/embedded/store/key_reader.go
+++ b/embedded/store/key_reader.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package store
 
 import (

--- a/embedded/store/key_reader_test.go
+++ b/embedded/store/key_reader_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package store
 
 import (

--- a/embedded/store/kv_metadata.go
+++ b/embedded/store/kv_metadata.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package store
 
 import (

--- a/embedded/store/kv_metadata_test.go
+++ b/embedded/store/kv_metadata_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package store
 
 import (

--- a/embedded/store/metadata.go
+++ b/embedded/store/metadata.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package store
 
 type attributeCode byte

--- a/embedded/store/ongoing_tx.go
+++ b/embedded/store/ongoing_tx.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package store
 
 import (

--- a/embedded/store/ongoing_tx_test.go
+++ b/embedded/store/ongoing_tx_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package store
 
 import (

--- a/embedded/store/options.go
+++ b/embedded/store/options.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package store
 
 import (

--- a/embedded/store/options_test.go
+++ b/embedded/store/options_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package store
 
 import (

--- a/embedded/store/preconditions.go
+++ b/embedded/store/preconditions.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package store
 
 import (

--- a/embedded/store/tx.go
+++ b/embedded/store/tx.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package store
 
 import (

--- a/embedded/store/tx_metadata.go
+++ b/embedded/store/tx_metadata.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package store
 
 const maxTxMetadataLen = 0

--- a/embedded/store/tx_metadata_test.go
+++ b/embedded/store/tx_metadata_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package store
 
 import (

--- a/embedded/store/tx_reader.go
+++ b/embedded/store/tx_reader.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package store
 
 import (

--- a/embedded/store/tx_reader_test.go
+++ b/embedded/store/tx_reader_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package store
 
 import (

--- a/embedded/store/tx_test.go
+++ b/embedded/store/tx_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package store
 
 import (

--- a/embedded/store/txpool.go
+++ b/embedded/store/txpool.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package store
 
 import (

--- a/embedded/store/txpool_test.go
+++ b/embedded/store/txpool_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package store
 
 import (

--- a/embedded/store/verification.go
+++ b/embedded/store/verification.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package store
 
 import (

--- a/embedded/store/verification_test.go
+++ b/embedded/store/verification_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package store
 
 import (

--- a/embedded/tbtree/history_reader.go
+++ b/embedded/tbtree/history_reader.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package tbtree
 
 type HistoryReaderSpec struct {

--- a/embedded/tbtree/history_reader_test.go
+++ b/embedded/tbtree/history_reader_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package tbtree
 
 import (

--- a/embedded/tbtree/options.go
+++ b/embedded/tbtree/options.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package tbtree
 
 import (

--- a/embedded/tbtree/options_test.go
+++ b/embedded/tbtree/options_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package tbtree
 
 import (

--- a/embedded/tbtree/reader.go
+++ b/embedded/tbtree/reader.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package tbtree
 
 import (

--- a/embedded/tbtree/reader_test.go
+++ b/embedded/tbtree/reader_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package tbtree
 
 import (

--- a/embedded/tbtree/snapshot.go
+++ b/embedded/tbtree/snapshot.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package tbtree
 
 import (

--- a/embedded/tbtree/snapshot_test.go
+++ b/embedded/tbtree/snapshot_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package tbtree
 
 import (

--- a/embedded/tbtree/tbtree.go
+++ b/embedded/tbtree/tbtree.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package tbtree
 
 import (

--- a/embedded/tbtree/tbtree_test.go
+++ b/embedded/tbtree/tbtree_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package tbtree
 
 import (

--- a/embedded/tools/stress_tool/stress_tool.go
+++ b/embedded/tools/stress_tool/stress_tool.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package main
 
 import (

--- a/embedded/tools/stress_tool_sql/stress_tool_sql.go
+++ b/embedded/tools/stress_tool_sql/stress_tool_sql.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package main
 
 import (

--- a/embedded/watchers/watchers.go
+++ b/embedded/watchers/watchers.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package watchers
 
 import (

--- a/embedded/watchers/watchers_test.go
+++ b/embedded/watchers/watchers_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package watchers
 
 import (

--- a/pkg/api/schema/database_protoconv.go
+++ b/pkg/api/schema/database_protoconv.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package schema
 
 import (

--- a/pkg/api/schema/errors.go
+++ b/pkg/api/schema/errors.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package schema
 
 import (

--- a/pkg/api/schema/ops.go
+++ b/pkg/api/schema/ops.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package schema
 
 import (

--- a/pkg/api/schema/ops_test.go
+++ b/pkg/api/schema/ops_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package schema
 
 import (

--- a/pkg/api/schema/preconditions.go
+++ b/pkg/api/schema/preconditions.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package schema
 
 func PreconditionKeyMustExist(key []byte) *Precondition {

--- a/pkg/api/schema/row_value.go
+++ b/pkg/api/schema/row_value.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package schema
 
 import (

--- a/pkg/api/schema/row_value_test.go
+++ b/pkg/api/schema/row_value_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package schema
 
 import (

--- a/pkg/api/schema/sql.go
+++ b/pkg/api/schema/sql.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package schema
 
 import (

--- a/pkg/api/schema/sql_test.go
+++ b/pkg/api/schema/sql_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package schema
 
 import (

--- a/pkg/api/schema/state.go
+++ b/pkg/api/schema/state.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package schema
 
 import (

--- a/pkg/api/schema/unexpected_type.go
+++ b/pkg/api/schema/unexpected_type.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package schema
 
 type Op_Unexpected struct {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package client
 
 import (

--- a/pkg/client/clienttest/immuclient_mock_test.go
+++ b/pkg/client/clienttest/immuclient_mock_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package clienttest
 
 import (

--- a/pkg/client/sql.go
+++ b/pkg/client/sql.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package client
 
 import (

--- a/pkg/client/sql_test.go
+++ b/pkg/client/sql_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package client
 
 import (

--- a/pkg/client/stream_replication.go
+++ b/pkg/client/stream_replication.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package client
 
 import (

--- a/pkg/client/streams_verified_integration_test.go
+++ b/pkg/client/streams_verified_integration_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package client
 
 import (

--- a/pkg/client/streams_zscan_and_history_integration_test.go
+++ b/pkg/client/streams_zscan_and_history_integration_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package client
 
 import (

--- a/pkg/database/all_ops.go
+++ b/pkg/database/all_ops.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package database
 
 import (

--- a/pkg/database/all_ops_test.go
+++ b/pkg/database/all_ops_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package database
 
 import (

--- a/pkg/database/database_test.go
+++ b/pkg/database/database_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package database
 
 import (

--- a/pkg/database/protoconv.go
+++ b/pkg/database/protoconv.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package database
 
 import (

--- a/pkg/database/protoconv_test.go
+++ b/pkg/database/protoconv_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package database
 
 import (

--- a/pkg/database/scan.go
+++ b/pkg/database/scan.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package database
 
 import (

--- a/pkg/database/scan_test.go
+++ b/pkg/database/scan_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package database
 
 import (

--- a/pkg/database/sorted_set.go
+++ b/pkg/database/sorted_set.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package database
 
 import (

--- a/pkg/database/sorted_set_test.go
+++ b/pkg/database/sorted_set_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package database
 
 import (

--- a/pkg/database/sql.go
+++ b/pkg/database/sql.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package database
 
 import (

--- a/pkg/database/sql_test.go
+++ b/pkg/database/sql_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package database
 
 import (

--- a/pkg/integration/client_test.go
+++ b/pkg/integration/client_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package integration
 
 import (

--- a/pkg/integration/database_creation_test.go
+++ b/pkg/integration/database_creation_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package integration
 
 import (

--- a/pkg/integration/database_runtime_test.go
+++ b/pkg/integration/database_runtime_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package integration
 
 import (

--- a/pkg/integration/fuzzing/grpc_fuzz_test.go
+++ b/pkg/integration/fuzzing/grpc_fuzz_test.go
@@ -16,6 +16,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package fuzzing
 
 import (

--- a/pkg/integration/server_recovery_test.go
+++ b/pkg/integration/server_recovery_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package integration
 
 import (

--- a/pkg/integration/signature_verifier_interceptor_test.go
+++ b/pkg/integration/signature_verifier_interceptor_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package integration
 
 import (

--- a/pkg/integration/sql/sql_test.go
+++ b/pkg/integration/sql/sql_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package integration
 
 import (

--- a/pkg/integration/stream/streams_verified_test.go
+++ b/pkg/integration/stream/streams_verified_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package integration
 
 import (

--- a/pkg/integration/stream/streams_zscan_and_history_test.go
+++ b/pkg/integration/stream/streams_zscan_and_history_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package integration
 
 import (

--- a/pkg/server/corruption_checker.go
+++ b/pkg/server/corruption_checker.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package server
 
 /*

--- a/pkg/server/db_dummy_closed_test.go
+++ b/pkg/server/db_dummy_closed_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package server
 
 import (

--- a/pkg/server/db_operations.go
+++ b/pkg/server/db_operations.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package server
 
 import (

--- a/pkg/server/db_runtime_test.go
+++ b/pkg/server/db_runtime_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package server
 
 import (

--- a/pkg/server/multidb_handler.go
+++ b/pkg/server/multidb_handler.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package server
 
 import (

--- a/pkg/server/pid_test.go
+++ b/pkg/server/pid_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package server
 
 import (

--- a/pkg/server/remote_storage.go
+++ b/pkg/server/remote_storage.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package server
 
 import (

--- a/pkg/server/remote_storage_test.go
+++ b/pkg/server/remote_storage_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package server
 
 import (

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package server
 
 import (

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package server
 
 import (

--- a/pkg/server/sql.go
+++ b/pkg/server/sql.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package server
 
 import (

--- a/pkg/server/sql_test.go
+++ b/pkg/server/sql_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package server
 
 import (

--- a/pkg/stdlib/uri.go
+++ b/pkg/stdlib/uri.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package stdlib
 
 import (

--- a/test/performance-test-suite/cmd/perf-test/main.go
+++ b/test/performance-test-suite/cmd/perf-test/main.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package main
 
 import (

--- a/test/performance-test-suite/pkg/benchmarks/benchmark.go
+++ b/test/performance-test-suite/pkg/benchmarks/benchmark.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package benchmarks
 
 import "time"

--- a/test/performance-test-suite/pkg/benchmarks/format.go
+++ b/test/performance-test-suite/pkg/benchmarks/format.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package benchmarks
 
 import "fmt"

--- a/test/performance-test-suite/pkg/benchmarks/format_test.go
+++ b/test/performance-test-suite/pkg/benchmarks/format_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package benchmarks
 
 import (

--- a/test/performance-test-suite/pkg/benchmarks/hwstats.go
+++ b/test/performance-test-suite/pkg/benchmarks/hwstats.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package benchmarks
 
 import (

--- a/test/performance-test-suite/pkg/benchmarks/hwstats_test.go
+++ b/test/performance-test-suite/pkg/benchmarks/hwstats_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package benchmarks
 
 import (

--- a/test/performance-test-suite/pkg/benchmarks/keytracker.go
+++ b/test/performance-test-suite/pkg/benchmarks/keytracker.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package benchmarks
 
 import (

--- a/test/performance-test-suite/pkg/benchmarks/keytracker_test.go
+++ b/test/performance-test-suite/pkg/benchmarks/keytracker_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package benchmarks
 
 import (

--- a/test/performance-test-suite/pkg/benchmarks/rand.go
+++ b/test/performance-test-suite/pkg/benchmarks/rand.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package benchmarks
 
 import (

--- a/test/performance-test-suite/pkg/benchmarks/rand_test.go
+++ b/test/performance-test-suite/pkg/benchmarks/rand_test.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package benchmarks
 
 import (

--- a/test/performance-test-suite/pkg/benchmarks/writetxs/benchmark.go
+++ b/test/performance-test-suite/pkg/benchmarks/writetxs/benchmark.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package writetxs
 
 import (

--- a/test/performance-test-suite/pkg/runner/benchmarks.go
+++ b/test/performance-test-suite/pkg/runner/benchmarks.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package runner
 
 import (

--- a/test/performance-test-suite/pkg/runner/processinfo.go
+++ b/test/performance-test-suite/pkg/runner/processinfo.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package runner
 
 import (

--- a/test/performance-test-suite/pkg/runner/results.go
+++ b/test/performance-test-suite/pkg/runner/results.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package runner
 
 import "time"

--- a/test/performance-test-suite/pkg/runner/runner.go
+++ b/test/performance-test-suite/pkg/runner/runner.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package runner
 
 import (

--- a/test/performance-test-suite/pkg/runner/systeminfo.go
+++ b/test/performance-test-suite/pkg/runner/systeminfo.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package runner
 
 import "os"

--- a/tools/testing/stress_tool_sql.go
+++ b/tools/testing/stress_tool_sql.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package main
 
 import (


### PR DESCRIPTION
By godoc convention, the comment right before `package` declaration in go files is supposed to be a package comment. In our source files we use license comment before such package declaration. Without empty space, this license becomes comment for the package.

Example of license used as package documentation:

https://pkg.go.dev/github.com/codenotary/immudb@v1.3.2/embedded

Signed-off-by: Bartłomiej Święcki <bart@codenotary.com>