### PR TITLE
test(pkg/integration/replicatino): Add WaitForCommittedTx

### DIFF
--- a/pkg/integration/replication/synchronous_replication_test.go
+++ b/pkg/integration/replication/synchronous_replication_test.go
@@ -40,6 +40,8 @@ func (suite *SyncTestSuite) TestSyncFromMasterToAllFollowers() {
 			ctx, client, cleanup := suite.ClientForReplica(i)
 			defer cleanup()
 
+			suite.WaitForCommittedTx(ctx, client, tx2.Id, time.Second)
+
 			val, err := client.GetAt(ctx, []byte("key1"), tx1.Id)
 			require.NoError(suite.T(), err)
 			suite.Require().Equal([]byte("value1"), val.Value)
@@ -63,6 +65,8 @@ func (suite *SyncTestSuite) TestMasterRestart() {
 	for i := 0; i < suite.GetFollowersCount(); i++ {
 		ctx, client, cleanup := suite.ClientForReplica(i)
 		defer cleanup()
+
+		suite.WaitForCommittedTx(ctx, client, tx.Id, time.Second)
 
 		val, err := client.GetAt(ctx, []byte("key3"), tx.Id)
 		require.NoError(suite.T(), err)


### PR DESCRIPTION
This method is a useful utility to ensure that the replica committed given transaction id. This is necessary because shortly after replica confirms the write to primary that transaction will still be in a precommitted state thus we have to wait for another sync cycle on replica to make it committed.

Signed-off-by: Bartłomiej Święcki <bart@codenotary.com>