### PR TITLE
test(pkg/integration/replication): Speedup sync replication tests

### DIFF
--- a/pkg/integration/replication/server.go
+++ b/pkg/integration/replication/server.go
@@ -1,6 +1,7 @@
 package replication
 
 import (
+	"fmt"
 	"net"
 	"testing"
 	"time"
@@ -54,19 +55,32 @@ func (s *inProcessTestServer) Start(t *testing.T) {
 	err := srv.Initialize()
 	require.NoError(t, err)
 
+	if s.port == 0 {
+		// Save the port for reopening with the same value
+		s.port = srv.Listener.Addr().(*net.TCPAddr).Port
+	}
+
 	go func() {
 		err := srv.Start()
 		require.NoError(t, err)
 	}()
 
-	// Wait for the server to initialize
-	// TODO: Active notification that the server has started
-	time.Sleep(time.Second)
+	require.Eventually(t, func() bool {
+		// Check if we can talk to GRPC server (checking if we can only connect alone is not enough)
+		conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", s.port), 5*time.Millisecond)
+		if err != nil {
+			return false
+		}
+		defer conn.Close()
 
-	if s.port == 0 {
-		// Save the port for reopening with the same value
-		s.port = srv.Listener.Addr().(*net.TCPAddr).Port
-	}
+		err = conn.SetReadDeadline(time.Now().Add(5 * time.Millisecond))
+		if err != nil {
+			return false
+		}
+
+		_, err = conn.Read([]byte{0})
+		return err == nil
+	}, time.Second, 10*time.Millisecond)
 
 	s.srv = srv
 }

--- a/pkg/integration/replication/suite.go
+++ b/pkg/integration/replication/suite.go
@@ -205,9 +205,16 @@ func (suite *baseReplicationTestSuite) WaitForCommittedTx(
 
 func (suite *baseReplicationTestSuite) SetupCluster(replicas int, syncFollowers int) {
 	suite.StartMaster(syncFollowers)
+
+	wg := sync.WaitGroup{}
 	for i := 0; i < replicas; i++ {
-		suite.AddFollower(syncFollowers > 0)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			suite.AddFollower(syncFollowers > 0)
+		}()
 	}
+	wg.Wait()
 }
 
 // SetupSuite initializes the suite


### PR DESCRIPTION
* Actively check if server instance is running instead of 1s sleep
* When setting up cluster, spawn replicas in parallel

Signed-off-by: Bartłomiej Święcki <bart@codenotary.com>