### PR TITLE
fix(helm): set securityContext & podSecurityContext in right location

### DIFF
--- a/helm/templates/statefulset.yaml
+++ b/helm/templates/statefulset.yaml
@@ -32,12 +32,10 @@ spec:
       - name: immudb-storage
         persistentVolumeClaim:
           claimName: {{ include "immudb.fullname" . }}
-      securityContext:
-        {{- toYaml .Values.securityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
-            {{- toYaml .Values.podSecurityContext | nindent 12 }}
+            {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -20,17 +20,14 @@ adminPassword: ""
 
 podAnnotations: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
-
-securityContext:
+podSecurityContext:
    runAsNonRoot: true
    runAsUser: 3322
    runAsGroup: 3322
    fsGroup: 3322
    fsGroupChangePolicy: "OnRootMismatch"
 
-podSecurityContext:
+securityContext:
    readOnlyRootFilesystem: true
    capabilities:
      drop:


### PR DESCRIPTION
This PR fixes  the securityContext and podSecurityContext settings in the helm chart. 

The podSecurityContext can be specified for a pod and has e.g. the fsGroup field, whereas a securityContext can be specified in the scope of a container and contains e.g. the capabilities field. Currently these settings are mixed up in the helm chart. The podSecurityContext fields are assigned to the securityContext key in the values file and vice versa. 

Furthermore the StatefulSet definition contains two times the securityContext key for the pod sec. First time the field is set to the content if the securityContext value and the second time to the podSecurityContext  value. Correspondingly the resulting yaml is invalid. Helm is still able to install the template, but at least in my current version only the first appearance of the securityContext key is used.

See also the official k8s documentation, for podSecurityContext and securityContext.
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#podsecuritycontext-v1-core
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#securitycontext-v1-core