### PR TITLE
fix heartbeater keepAlive context, add errorHandler to notify upper layers on keepAlive error

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -518,6 +518,8 @@ type ImmuClient interface {
 
 const DefaultDB = "defaultdb"
 
+type ErrorHandler func(sessionID string, err error)
+
 type immuClient struct {
 	Dir                  string
 	Logger               logger.Logger
@@ -530,6 +532,7 @@ type immuClient struct {
 	StreamServiceFactory stream.ServiceFactory
 	SessionID            string
 	HeartBeater          heartbeater.HeartBeater
+	errorHandler         ErrorHandler
 }
 
 // Ensure immuClient implements the ImmuClient interface

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -622,6 +622,7 @@ func NewImmuClient(options *Options) (*immuClient, error) {
 	}
 
 	c.WithStateService(stateService)
+	c.WithErrorHandler(c.keepAliveErrorHandler)
 
 	return c, nil
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -518,8 +518,6 @@ type ImmuClient interface {
 
 const DefaultDB = "defaultdb"
 
-type ErrorHandler func(sessionID string, err error)
-
 type immuClient struct {
 	Dir                  string
 	Logger               logger.Logger
@@ -532,7 +530,7 @@ type immuClient struct {
 	StreamServiceFactory stream.ServiceFactory
 	SessionID            string
 	HeartBeater          heartbeater.HeartBeater
-	errorHandler         ErrorHandler
+	errorHandler         heartbeater.ErrorHandler
 }
 
 // Ensure immuClient implements the ImmuClient interface
@@ -622,7 +620,6 @@ func NewImmuClient(options *Options) (*immuClient, error) {
 	}
 
 	c.WithStateService(stateService)
-	c.WithErrorHandler(c.keepAliveErrorHandler)
 
 	return c, nil
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -43,7 +43,6 @@ import (
 	"github.com/codenotary/immudb/pkg/auth"
 	"github.com/codenotary/immudb/pkg/client/cache"
 	"github.com/codenotary/immudb/pkg/client/errors"
-	"github.com/codenotary/immudb/pkg/client/heartbeater"
 	"github.com/codenotary/immudb/pkg/client/state"
 	"github.com/codenotary/immudb/pkg/client/tokenservice"
 	"github.com/codenotary/immudb/pkg/database"
@@ -516,6 +515,8 @@ type ImmuClient interface {
 	TruncateDatabase(ctx context.Context, db string, retentionPeriod time.Duration) error
 }
 
+type ErrorHandler func(sessionID string, err error)
+
 const DefaultDB = "defaultdb"
 
 type immuClient struct {
@@ -529,8 +530,8 @@ type immuClient struct {
 	serverSigningPubKey  *ecdsa.PublicKey
 	StreamServiceFactory stream.ServiceFactory
 	SessionID            string
-	HeartBeater          heartbeater.HeartBeater
-	errorHandler         heartbeater.ErrorHandler
+	HeartBeater          HeartBeater
+	errorHandler         ErrorHandler
 }
 
 // Ensure immuClient implements the ImmuClient interface

--- a/pkg/client/heartbeater.go
+++ b/pkg/client/heartbeater.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package heartbeater
+package client
 
 import (
 	"context"
@@ -25,8 +25,6 @@ import (
 	"github.com/codenotary/immudb/pkg/logger"
 	"github.com/golang/protobuf/ptypes/empty"
 )
-
-type ErrorHandler func(sessionID string, err error)
 
 type heartBeater struct {
 	sessionID     string

--- a/pkg/client/heartbeater/heartbeater.go
+++ b/pkg/client/heartbeater/heartbeater.go
@@ -22,10 +22,11 @@ import (
 	"time"
 
 	"github.com/codenotary/immudb/pkg/api/schema"
-	"github.com/codenotary/immudb/pkg/client"
 	"github.com/codenotary/immudb/pkg/logger"
 	"github.com/golang/protobuf/ptypes/empty"
 )
+
+type ErrorHandler func(sessionID string, err error)
 
 type heartBeater struct {
 	sessionID     string
@@ -33,7 +34,7 @@ type heartBeater struct {
 	serviceClient schema.ImmuServiceClient
 	done          chan struct{}
 	t             *time.Ticker
-	errorHandler  client.ErrorHandler
+	errorHandler  ErrorHandler
 }
 
 type HeartBeater interface {
@@ -41,7 +42,7 @@ type HeartBeater interface {
 	Stop()
 }
 
-func NewHeartBeater(sessionID string, sc schema.ImmuServiceClient, keepAliveInterval time.Duration, h client.ErrorHandler) *heartBeater {
+func NewHeartBeater(sessionID string, sc schema.ImmuServiceClient, keepAliveInterval time.Duration, h ErrorHandler) *heartBeater {
 	return &heartBeater{
 		sessionID:     sessionID,
 		logger:        logger.NewSimpleLogger("immuclient", stdos.Stdout),

--- a/pkg/client/session.go
+++ b/pkg/client/session.go
@@ -80,7 +80,7 @@ func (c *immuClient) OpenSession(ctx context.Context, user []byte, pass []byte, 
 	c.Options.DialOptions = dialOptions
 	c.SessionID = resp.GetSessionID()
 
-	c.HeartBeater = heartbeater.NewHeartBeater(c.SessionID, c.ServiceClient, c.Options.HeartBeatFrequency)
+	c.HeartBeater = heartbeater.NewHeartBeater(c.SessionID, c.ServiceClient, c.Options.HeartBeatFrequency, c.errorHandler)
 	c.HeartBeater.KeepAlive(context.Background())
 
 	c.WithStateService(stateService)

--- a/pkg/client/session.go
+++ b/pkg/client/session.go
@@ -3,14 +3,12 @@ package client
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/codenotary/immudb/pkg/api/schema"
 	"github.com/codenotary/immudb/pkg/client/cache"
 	"github.com/codenotary/immudb/pkg/client/errors"
 	"github.com/codenotary/immudb/pkg/client/heartbeater"
 	"github.com/codenotary/immudb/pkg/client/state"
-	"github.com/codenotary/immudb/pkg/server/sessions"
 	"github.com/codenotary/immudb/pkg/signer"
 	"github.com/codenotary/immudb/pkg/stream"
 	"github.com/golang/protobuf/ptypes/empty"
@@ -82,7 +80,6 @@ func (c *immuClient) OpenSession(ctx context.Context, user []byte, pass []byte, 
 	c.Options.DialOptions = dialOptions
 	c.SessionID = resp.GetSessionID()
 
-	c.WithErrorHandler(c.keepAliveErrorHandler)
 	c.HeartBeater = heartbeater.NewHeartBeater(c.SessionID, c.ServiceClient, c.Options.HeartBeatFrequency, c.errorHandler)
 	c.HeartBeater.KeepAlive(context.Background())
 
@@ -125,12 +122,4 @@ func (c *immuClient) CloseSession(ctx context.Context) error {
 // GetSessionID returns the current internal session identifier.
 func (c *immuClient) GetSessionID() string {
 	return c.SessionID
-}
-
-func (c *immuClient) keepAliveErrorHandler(sessionID string, err error) {
-	if err == sessions.ErrSessionNotFound || err == ErrNotConnected || strings.Contains(err.Error(), "session not found") {
-		c.Logger.Errorf("heartbeater KeepAlive error, sessionID %s error %v", sessionID, err)
-
-		panic(fmt.Errorf("heartbeater KeepAlive error, sessionID %s error %v", sessionID, err))
-	}
 }

--- a/pkg/client/session.go
+++ b/pkg/client/session.go
@@ -7,7 +7,6 @@ import (
 	"github.com/codenotary/immudb/pkg/api/schema"
 	"github.com/codenotary/immudb/pkg/client/cache"
 	"github.com/codenotary/immudb/pkg/client/errors"
-	"github.com/codenotary/immudb/pkg/client/heartbeater"
 	"github.com/codenotary/immudb/pkg/client/state"
 	"github.com/codenotary/immudb/pkg/signer"
 	"github.com/codenotary/immudb/pkg/stream"
@@ -80,7 +79,7 @@ func (c *immuClient) OpenSession(ctx context.Context, user []byte, pass []byte, 
 	c.Options.DialOptions = dialOptions
 	c.SessionID = resp.GetSessionID()
 
-	c.HeartBeater = heartbeater.NewHeartBeater(c.SessionID, c.ServiceClient, c.Options.HeartBeatFrequency, c.errorHandler)
+	c.HeartBeater = NewHeartBeater(c.SessionID, c.ServiceClient, c.Options.HeartBeatFrequency, c.errorHandler)
 	c.HeartBeater.KeepAlive(context.Background())
 
 	c.WithStateService(stateService)

--- a/pkg/client/types.go
+++ b/pkg/client/types.go
@@ -19,7 +19,6 @@ package client
 import (
 	"crypto/ecdsa"
 
-	"github.com/codenotary/immudb/pkg/client/heartbeater"
 	"github.com/codenotary/immudb/pkg/client/tokenservice"
 	"github.com/codenotary/immudb/pkg/stream"
 
@@ -77,7 +76,7 @@ func (c *immuClient) WithOptions(options *Options) *immuClient {
 	return c
 }
 
-func (c *immuClient) WithErrorHandler(handler heartbeater.ErrorHandler) *immuClient {
+func (c *immuClient) WithErrorHandler(handler ErrorHandler) *immuClient {
 	c.errorHandler = handler
 	return c
 }

--- a/pkg/client/types.go
+++ b/pkg/client/types.go
@@ -19,6 +19,7 @@ package client
 import (
 	"crypto/ecdsa"
 
+	"github.com/codenotary/immudb/pkg/client/heartbeater"
 	"github.com/codenotary/immudb/pkg/client/tokenservice"
 	"github.com/codenotary/immudb/pkg/stream"
 
@@ -76,7 +77,7 @@ func (c *immuClient) WithOptions(options *Options) *immuClient {
 	return c
 }
 
-func (c *immuClient) WithErrorHandler(handler ErrorHandler) *immuClient {
+func (c *immuClient) WithErrorHandler(handler heartbeater.ErrorHandler) *immuClient {
 	c.errorHandler = handler
 	return c
 }

--- a/pkg/client/types.go
+++ b/pkg/client/types.go
@@ -75,3 +75,8 @@ func (c *immuClient) WithOptions(options *Options) *immuClient {
 	c.Options = options
 	return c
 }
+
+func (c *immuClient) WithErrorHandler(handler ErrorHandler) *immuClient {
+	c.errorHandler = handler
+	return c
+}

--- a/pkg/database/database_test.go
+++ b/pkg/database/database_test.go
@@ -2211,7 +2211,8 @@ func Test_database_truncate(t *testing.T) {
 		}
 	}
 
-	for i := hdr.ID - 1; i > 0; i-- {
+	// ensure that the earlier txs are truncated
+	for i := uint64(5); i > 0; i-- {
 		tx := store.NewTx(db.st.MaxTxEntries(), db.st.MaxKeyLen())
 
 		err = db.st.ReadTx(i, false, tx)

--- a/pkg/database/truncator_test.go
+++ b/pkg/database/truncator_test.go
@@ -126,7 +126,7 @@ func Test_vlogCompactor_WithSingleIO(t *testing.T) {
 
 	db := makeDbWith(t, "db", options)
 
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 20; i++ {
 		kv := &schema.KeyValue{
 			Key:   []byte(fmt.Sprintf("key_%d", i)),
 			Value: make([]byte, fileSize),
@@ -135,7 +135,7 @@ func Test_vlogCompactor_WithSingleIO(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	deletePointTx := uint64(5)
+	deletePointTx := uint64(15)
 
 	hdr, err := db.st.ReadTxHeader(deletePointTx, false, false)
 	require.NoError(t, err)
@@ -144,7 +144,7 @@ func Test_vlogCompactor_WithSingleIO(t *testing.T) {
 
 	require.NoError(t, c.TruncateUptoTx(context.Background(), hdr.ID))
 
-	for i := deletePointTx; i < 10; i++ {
+	for i := deletePointTx; i < 20; i++ {
 		tx := store.NewTx(db.st.MaxTxEntries(), db.st.MaxKeyLen())
 
 		err = db.st.ReadTx(i, false, tx)
@@ -156,7 +156,8 @@ func Test_vlogCompactor_WithSingleIO(t *testing.T) {
 		}
 	}
 
-	for i := deletePointTx - 1; i > 0; i-- {
+	// ensure earlier transactions are deleted
+	for i := uint64(5); i > 0; i-- {
 		tx := store.NewTx(db.st.MaxTxEntries(), db.st.MaxKeyLen())
 
 		err = db.st.ReadTx(i, false, tx)
@@ -225,7 +226,8 @@ func Test_vlogCompactor_WithConcurrentWritersOnSingleIO(t *testing.T) {
 		}
 	}
 
-	for i := deletePointTx - 1; i > 0; i-- {
+	// ensure earlier transactions are deleted
+	for i := uint64(5); i > 0; i-- {
 		tx := store.NewTx(db.st.MaxTxEntries(), db.st.MaxKeyLen())
 
 		err = db.st.ReadTx(i, false, tx)


### PR DESCRIPTION
- PR created in top of v.1.3.2 release
- Fix Heartbeater KeepAlive context, original context has 60 seconds timeout scope, use context.Background as context base
- Add ErrorHandler callback to allow upper layers react on Heartbeater KeepAlive failure