### PR TITLE
fix(embedded/watchers): Fix invariant violation in watchers

### DIFF
--- a/embedded/watchers/watchers.go
+++ b/embedded/watchers/watchers.go
@@ -138,14 +138,19 @@ func (w *WatchersHub) WaitFor(t uint64, cancellation <-chan struct{}) error {
 
 	if cancelled {
 
-		if wp.count == 1 {
-			close(wp.ch)
-			delete(w.wpoints, t)
-		}
-
+		// `wp.count` will be zeroed if the `t` point was already processed in
+		// `DoneUpTo` call (a situation when both cancellation and call to `DoneUpTo`
+		// happen simultaneously), otherwise its necessary to cleanup after we stopped waiting.
 		if wp.count > 0 {
 			w.waiting--
 			wp.count--
+
+			if wp.count == 0 {
+				// This was the last `WaitFor`` caller waiting for the point `t``,
+				// cleanup the `w.wpoints` array to avoid holding idle entries there.
+				close(wp.ch)
+				delete(w.wpoints, t)
+			}
 		}
 
 		return ErrCancellationRequested

--- a/pkg/integration/replication/synchronous_replication_test.go
+++ b/pkg/integration/replication/synchronous_replication_test.go
@@ -500,7 +500,7 @@ func (suite *SyncTestWithAsyncFollowersSuite) TestSyncReplicationAlongWithAsyncF
 				ctx, client, cleanup := suite.ClientForReplica(i)
 				defer cleanup()
 
-				suite.WaitForCommittedTx(ctx, client, state.TxId, 5*time.Second)
+				suite.WaitForCommittedTx(ctx, client, state.TxId, 20*time.Second)
 			})
 		}
 	})


### PR DESCRIPTION
Invariant is broken if at the same time both the cancellation occurs and fulfilment of the condition happen.

Signed-off-by: Bartłomiej Święcki <bart@codenotary.com>