### PR TITLE
fix(pkg/client): replace keepAlive context from the original one to the background, avoiding parent expiration

### DIFF
--- a/pkg/client/session.go
+++ b/pkg/client/session.go
@@ -76,7 +76,7 @@ func (c *immuClient) OpenSession(ctx context.Context, user []byte, pass []byte, 
 	c.SessionID = resp.GetSessionID()
 
 	c.HeartBeater = heartbeater.NewHeartBeater(c.SessionID, c.ServiceClient, c.Options.HeartBeatFrequency)
-	c.HeartBeater.KeepAlive(ctx)
+	c.HeartBeater.KeepAlive(context.Background())
 
 	c.WithStateService(stateService)
 


### PR DESCRIPTION
- Original parent context comes from OpenSession which uses timeout scope of 60 seconds
- Once original context gets cancel it will force keepAlive loop to fail on each iteration
- The background context passed to keepAlive release it from parent context limitation