### PR TITLE
test: Fix unclean test runs

### DIFF
--- a/cmd/docs/man/generate_test.go
+++ b/cmd/docs/man/generate_test.go
@@ -18,7 +18,6 @@ package man
 
 import (
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -33,8 +32,7 @@ func TestGenerate(t *testing.T) {
 		Short: "somme command short description",
 		Long:  "some command long description",
 	}
-	dir := "./test_generate_output"
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	cmd := Generate(rootCmd, rootCmd.Use, dir)
 	cmd.SetArgs([]string{dir})
 	require.NoError(t, cmd.Execute())

--- a/cmd/helper/config_test.go
+++ b/cmd/helper/config_test.go
@@ -70,7 +70,7 @@ func TestConfig_Load(t *testing.T) {
 	cmd := cobra.Command{}
 	cmd.Flags().StringVar(&o.CfgFn, "config", "", "config file")
 	err := o.LoadConfig(&cmd)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestConfig_LoadError(t *testing.T) {

--- a/cmd/helper/config_test.go
+++ b/cmd/helper/config_test.go
@@ -18,7 +18,6 @@ package helper
 
 import (
 	"io/ioutil"
-	"log"
 	"os"
 	"os/user"
 	"testing"
@@ -26,14 +25,14 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOptions_InitConfig(t *testing.T) {
 	input, _ := ioutil.ReadFile("../../test/immudb.toml")
 	user, err := user.Current()
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	fn := user.HomeDir + "/immudbtest9990.toml"
 	_ = ioutil.WriteFile(fn, input, 0644)
 	defer os.RemoveAll(fn)

--- a/cmd/helper/detached_test.go
+++ b/cmd/helper/detached_test.go
@@ -38,7 +38,7 @@ func (e execsmock) Command(name string, arg ...string) *exec.Cmd {
 func TestDetached(t *testing.T) {
 	pl := plauncher{execsmock{}}
 	err := pl.Detached()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestNewPlauncher(t *testing.T) {

--- a/cmd/helper/terminal_test.go
+++ b/cmd/helper/terminal_test.go
@@ -27,26 +27,26 @@ import (
 func TestTerminalReader_ReadFromTerminalYN(t *testing.T) {
 	tr := NewTerminalReader(strings.NewReader("Y"))
 	resp, err := tr.ReadFromTerminalYN("Y")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "y", resp)
 	tr.r = strings.NewReader("sgdf")
 	resp, err = tr.ReadFromTerminalYN("Y")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "", resp)
 	tr.r = strings.NewReader("N")
 	resp, err = tr.ReadFromTerminalYN("Y")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "n", resp)
 	tr.r = strings.NewReader("")
 	resp, err = tr.ReadFromTerminalYN("Y")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "y", resp)
 }
 
 func TestStdinPasswordReader_Read(t *testing.T) {
 	pr := stdinPasswordReader{&terminalReadPwMock{}}
 	pw, err := pr.Read("paxword")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, []byte(`fake`), pw)
 }
 

--- a/cmd/immuadmin/command/backup_test.go
+++ b/cmd/immuadmin/command/backup_test.go
@@ -207,7 +207,7 @@ func TestDumpToFile(t *testing.T) {
 	require.NoError(t, collector.Start())
 	require.Nil(t, cmd.Execute())
 	dumpLog, err := collector.Stop()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, "Database is empty.\n", dumpLog)
 
 	immuClientMock.DumpF = func(ctx context.Context, f io.WriteSeeker) (int64, error) {
@@ -216,7 +216,7 @@ func TestDumpToFile(t *testing.T) {
 	require.NoError(t, collector.Start())
 	require.Nil(t, cmd.Execute())
 	dumpLog, err = collector.Stop()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, fmt.Sprintf("SUCCESS: 1 key-value entries were backed-up to file %s\n", dumpFile), dumpLog)
 }
 
@@ -828,7 +828,7 @@ func TestCommandlineBck_Register(t *testing.T) {
 func TestNewCommandLineBck(t *testing.T) {
 	cml, err := newCommandlineBck(immuos.NewStandardOS())
 	assert.IsType(t, &commandlineBck{}, cml)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCommandlineBck_ConfigChain(t *testing.T) {
@@ -842,7 +842,7 @@ func TestCommandlineBck_ConfigChain(t *testing.T) {
 	cmd.Flags().StringVar(&c.config.CfgFn, "config", "", "config file")
 	cc := c.ConfigChain(f)
 	err := cc(cmd, []string{})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCommandlineBck_ConfigChainErr(t *testing.T) {

--- a/cmd/immuadmin/command/commandline_test.go
+++ b/cmd/immuadmin/command/commandline_test.go
@@ -126,7 +126,7 @@ func TestCommandline_ConfigChain(t *testing.T) {
 	cmd.Flags().StringVar(&c.config.CfgFn, "config", "", "config file")
 	cc := c.ConfigChain(f)
 	err := cc(cmd, []string{})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCommandline_ConfigChainErr(t *testing.T) {

--- a/cmd/immuadmin/command/database_test.go
+++ b/cmd/immuadmin/command/database_test.go
@@ -50,9 +50,7 @@ func TestDatabaseList(t *testing.T) {
 	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
 	require.NoError(t, err)
-	if !strings.Contains(string(msg), "defaultdb") {
-		t.Fatal(err)
-	}
+	require.Contains(t, string(msg), "defaultdb")
 }
 
 func TestDatabaseCreate(t *testing.T) {
@@ -105,8 +103,6 @@ func TestDatabaseCreate(t *testing.T) {
 	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
 	require.NoError(t, err)
-	if !strings.Contains(string(msg), "database successfully created") {
-		t.Fatal(string(msg))
-	}
+	require.Contains(t, string(msg), "database successfully created")
 }
 */

--- a/cmd/immuadmin/command/database_test.go
+++ b/cmd/immuadmin/command/database_test.go
@@ -23,9 +23,7 @@ func TestDatabaseList(t *testing.T) {
 	cliopt.DialOptions = dialOptions
 	clientb, _ := client.NewImmuClient(cliopt)
 	token, err := clientb.Login(ctx, []byte("immudb"), []byte("immudb"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	md := metadata.Pairs("authorization", token.Token)
 	ctx = metadata.NewOutgoingContext(context.Background(), md)
@@ -49,13 +47,9 @@ func TestDatabaseList(t *testing.T) {
 
 	cmd.SetArgs([]string{"database", "list"})
 	err = cmd.Execute()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !strings.Contains(string(msg), "defaultdb") {
 		t.Fatal(err)
 	}
@@ -83,9 +77,7 @@ func TestDatabaseCreate(t *testing.T) {
 	cliopt.DialOptions = dialOptions
 	clientb, _ := client.NewImmuClient(cliopt)
 	token, err := clientb.Login(ctx, []byte("immudb"), []byte("immudb"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	md := metadata.Pairs("authorization", token.Token)
 	ctx = metadata.NewOutgoingContext(context.Background(), md)
@@ -110,13 +102,9 @@ func TestDatabaseCreate(t *testing.T) {
 
 	cmd.SetArgs([]string{"database", "create", "mynewdb"})
 	err = cmd.Execute()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !strings.Contains(string(msg), "database successfully created") {
 		t.Fatal(string(msg))
 	}

--- a/cmd/immuadmin/command/init_test.go
+++ b/cmd/immuadmin/command/init_test.go
@@ -30,8 +30,8 @@ func TestOptions(t *testing.T) {
 }
 
 func TestOptionsMtls(t *testing.T) {
+	defer viper.Reset()
 	viper.Set("mtls", true)
 	opts := Options()
 	assert.IsType(t, &client.Options{}, opts)
-	viper.Reset()
 }

--- a/cmd/immuadmin/command/login_test.go
+++ b/cmd/immuadmin/command/login_test.go
@@ -79,7 +79,7 @@ func TestCommandLine_Connect(t *testing.T) {
 		options: opts,
 	}
 	err = cmdl.connect(&cobra.Command{}, []string{})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCommandLine_Disconnect(t *testing.T) {
@@ -247,7 +247,7 @@ func TestCommandLine_CheckLoggedIn(t *testing.T) {
 	cl1.options = Options()
 	cl1.options.DialOptions = dialOptions1
 	err := cl1.checkLoggedIn(&cmd1, nil)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func newHomedirServiceMock() *clienttest.HomedirServiceMock {

--- a/cmd/immuadmin/command/login_test.go
+++ b/cmd/immuadmin/command/login_test.go
@@ -168,9 +168,7 @@ func TestCommandLine_LoginLogout(t *testing.T) {
 
 	cmd.Execute()
 	out, err := ioutil.ReadAll(b)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	assert.Contains(t, string(out), "logged in")
 	cmdlo := commandline{
 		config:         helper.Config{Name: "immuadmin"},

--- a/cmd/immuadmin/command/serverconfig_test.go
+++ b/cmd/immuadmin/command/serverconfig_test.go
@@ -29,9 +29,7 @@ import (
 func TestCommandLine_ServerconfigAuth(t *testing.T) {
 	input, _ := ioutil.ReadFile("../../../test/immudb.toml")
 	err := ioutil.WriteFile("/tmp/immudb.toml", input, 0644)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 
 	options := (&server.Options{}).WithAuth(false).WithConfig("/tmp/immudb.toml").WithAdminPassword(auth.SysAdminPassword)
 	bs := servertest.NewBufconnServer(options)
@@ -76,9 +74,7 @@ func TestCommandLine_ServerconfigAuth(t *testing.T) {
 
 	cmdso.Execute()
 	out, err := ioutil.ReadAll(b)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	assert.Contains(t, string(out), "Server auth config updated")
 	os.RemoveAll("/tmp/immudb.toml")
 }
@@ -86,9 +82,7 @@ func TestCommandLine_ServerconfigAuth(t *testing.T) {
 func TestCommandLine_ServerconfigMtls(t *testing.T) {
 	input, _ := ioutil.ReadFile("../../../test/immudb.toml")
 	err := ioutil.WriteFile("/tmp/immudb.toml", input, 0644)
-	if err != nil {
-		panic(err)
-	}
+	require.NoError(t, err)
 
 	options := (&server.Options{}).WithAuth(false).WithConfig("/tmp/immudb.toml").WithAdminPassword(auth.SysAdminPassword)
 	bs := servertest.NewBufconnServer(options)
@@ -127,9 +121,7 @@ func TestCommandLine_ServerconfigMtls(t *testing.T) {
 
 	cmdso.Execute()
 	out, err := ioutil.ReadAll(b)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	assert.Contains(t, string(out), "Server MTLS config updated")
 
 	os.RemoveAll("/tmp/immudb.toml")

--- a/cmd/immuadmin/command/serverconfig_test.go
+++ b/cmd/immuadmin/command/serverconfig_test.go
@@ -62,7 +62,7 @@ func TestCommandLine_ServerconfigAuth(t *testing.T) {
 	}
 
 	cmdso, err := cl.NewCmd()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	cl.serverConfig(cmdso)
 
 	b := bytes.NewBufferString("")

--- a/cmd/immuadmin/command/stats/ui_test.go
+++ b/cmd/immuadmin/command/stats/ui_test.go
@@ -28,7 +28,7 @@ import (
 func TestRunUI(t *testing.T) {
 	sui := statsui{Loader: metricsLoaderMock{}, Tui: tuiMock{}}
 	err := sui.runUI(true)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 type metricsLoaderMock struct{}

--- a/cmd/immuadmin/command/stats_test.go
+++ b/cmd/immuadmin/command/stats_test.go
@@ -22,7 +22,6 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,19 +37,17 @@ import (
 )
 
 func TestStats_Status(t *testing.T) {
-	options := server.DefaultOptions().WithAuth(true)
+
+	options := server.DefaultOptions().WithAuth(true).WithDir(t.TempDir())
 	bs := servertest.NewBufconnServer(options)
 
 	bs.Start()
 	defer bs.Stop()
 
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
-
 	dialOptions := []grpc.DialOption{
 		grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure(),
 	}
-	cliopt := Options()
+	cliopt := Options().WithDir(t.TempDir())
 	cliopt.DialOptions = dialOptions
 	clientb, _ := client.NewImmuClient(cliopt)
 	tkf := cmdtest.RandString()
@@ -83,14 +80,11 @@ func TestStats_Status(t *testing.T) {
 }
 
 func TestStats_StatsText(t *testing.T) {
-	options := server.DefaultOptions().WithAuth(true)
+	options := server.DefaultOptions().WithAuth(true).WithDir(t.TempDir())
 	bs := servertest.NewBufconnServer(options)
 
 	bs.Start()
 	defer bs.Stop()
-
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
 
 	handler := http.NewServeMux()
 	handler.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {
@@ -105,7 +99,7 @@ func TestStats_StatsText(t *testing.T) {
 	dialOptions := []grpc.DialOption{
 		grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure(),
 	}
-	cliopt := Options()
+	cliopt := Options().WithDir(t.TempDir())
 	cliopt.DialOptions = dialOptions
 	cliopt.Address = "127.0.0.1"
 	clientb, _ := client.NewImmuClient(cliopt)
@@ -139,14 +133,11 @@ func TestStats_StatsText(t *testing.T) {
 }
 
 func TestStats_StatsRaw(t *testing.T) {
-	options := server.DefaultOptions().WithAuth(true)
+	options := server.DefaultOptions().WithAuth(true).WithDir(t.TempDir())
 	bs := servertest.NewBufconnServer(options)
 
 	bs.Start()
 	defer bs.Stop()
-
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
 
 	handler := http.NewServeMux()
 	handler.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {
@@ -160,7 +151,7 @@ func TestStats_StatsRaw(t *testing.T) {
 	dialOptions := []grpc.DialOption{
 		grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure(),
 	}
-	cliopt := Options()
+	cliopt := Options().WithDir(t.TempDir())
 	cliopt.DialOptions = dialOptions
 	cliopt.Address = "127.0.0.1"
 	clientb, _ := client.NewImmuClient(cliopt)

--- a/cmd/immuadmin/command/stats_test.go
+++ b/cmd/immuadmin/command/stats_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
 	"github.com/codenotary/immudb/cmd/cmdtest"
@@ -73,9 +74,7 @@ func TestStats_Status(t *testing.T) {
 
 	cmd.Execute()
 	out, err := ioutil.ReadAll(b)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	assert.Contains(t, string(out), "OK - server is reachable and responding to queries")
 }
 
@@ -126,9 +125,7 @@ func TestStats_StatsText(t *testing.T) {
 
 	cmd.Execute()
 	out, err := ioutil.ReadAll(b)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	assert.Contains(t, string(out), "Database")
 }
 
@@ -177,8 +174,6 @@ func TestStats_StatsRaw(t *testing.T) {
 
 	cmd.Execute()
 	out, err := ioutil.ReadAll(b)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	assert.Contains(t, string(out), "go_gc_duration_seconds")
 }

--- a/cmd/immuadmin/command/user_test.go
+++ b/cmd/immuadmin/command/user_test.go
@@ -83,9 +83,7 @@ defer bs.Stop()
 	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
 	require.NoError(t, err)
-	if !strings.Contains(string(msg), "immudb") {
-		t.Fatal(msg)
-	}
+	require.Contains(t, string(msg), "immudb")
 }
 
 func TestUserListErrors(t *testing.T) {
@@ -179,9 +177,7 @@ defer bs.Stop()
 	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
 	require.NoError(t, err)
-	if !strings.Contains(string(msg), "immudb's password has been changed") {
-		t.Fatal(msg)
-	}
+	require.Contains(t, string(msg), "immudb's password has been changed")
 }
 
 func TestUserChangePasswordErrors(t *testing.T) {
@@ -301,9 +297,7 @@ defer bs.Stop()
 	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
 	require.NoError(t, err)
-	if !strings.Contains(string(msg), "Created user newuser") {
-		t.Fatal(msg)
-	}
+	require.Contains(t, string(msg), "Created user newuser")
 }
 
 func TestUserCreateErrors(t *testing.T) {
@@ -473,9 +467,7 @@ defer bs.Stop()
 	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
 	require.NoError(t, err)
-	if !strings.Contains(string(msg), "User status changed successfully") {
-		t.Fatal(string(msg))
-	}
+	require.Contains(t, string(msg), "User status changed successfully")
 }
 
 func TestUserDeactivate(t *testing.T) {
@@ -532,9 +524,7 @@ defer bs.Stop()
 	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
 	require.NoError(t, err)
-	if !strings.Contains(string(msg), "User status changed successfully") {
-		t.Fatal(string(msg))
-	}
+	require.Contains(t, string(msg), "User status changed successfully")
 }
 
 func TestUserActivateErrors(t *testing.T) {
@@ -607,9 +597,7 @@ defer bs.Stop()
 	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
 	require.NoError(t, err)
-	if !strings.Contains(string(msg), "Permission changed successfully") {
-		t.Fatal(string(msg))
-	}
+	require.Contains(t, string(msg), "Permission changed successfully")
 }
 
 func TestUserPermissionErrors(t *testing.T) {

--- a/cmd/immuadmin/command/user_test.go
+++ b/cmd/immuadmin/command/user_test.go
@@ -55,9 +55,7 @@ defer bs.Stop()
 
 	clientb, _ := client.NewImmuClient(cliopt)
 	token, err := clientb.Login(ctx, []byte("immudb"), []byte("immudb"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	md := metadata.Pairs("authorization", token.Token)
 	ctx = metadata.NewOutgoingContext(context.Background(), md)
 
@@ -82,13 +80,9 @@ defer bs.Stop()
 	usrcmd.PersistentPreRunE = nil
 
 	err = cmd.Execute()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !strings.Contains(string(msg), "immudb") {
 		t.Fatal(msg)
 	}
@@ -157,9 +151,7 @@ defer bs.Stop()
 
 	clientb, _ := client.NewImmuClient(cliopt)
 	token, err := clientb.Login(ctx, []byte("immudb"), []byte("immudb"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	md := metadata.Pairs("authorization", token.Token)
 	ctx = metadata.NewOutgoingContext(context.Background(), md)
 
@@ -184,13 +176,9 @@ defer bs.Stop()
 	usrcmd.PersistentPreRunE = nil
 
 	err = cmd.Execute()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !strings.Contains(string(msg), "immudb's password has been changed") {
 		t.Fatal(msg)
 	}
@@ -281,9 +269,7 @@ defer bs.Stop()
 
 	clientb, _ := client.NewImmuClient(cliopt)
 	token, err := clientb.Login(ctx, []byte("immudb"), []byte("immudb"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	md := metadata.Pairs("authorization", token.Token)
 	ctx = metadata.NewOutgoingContext(context.Background(), md)
@@ -312,13 +298,9 @@ defer bs.Stop()
 	usrcmd.PersistentPreRunE = nil
 
 	err = cmd.Execute()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !strings.Contains(string(msg), "Created user newuser") {
 		t.Fatal(msg)
 	}
@@ -455,9 +437,7 @@ defer bs.Stop()
 
 	clientb, _ := client.NewImmuClient(cliopt)
 	token, err := clientb.Login(ctx, []byte("immudb"), []byte("immudb"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	md := metadata.Pairs("authorization", token.Token)
 	ctx = metadata.NewOutgoingContext(context.Background(), md)
@@ -466,13 +446,9 @@ defer bs.Stop()
 	err = clientb.CreateDatabase(ctx, &schema.Database{
 		Databasename: "mydb",
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	err = clientb.CreateUser(ctx, []byte("myuser"), []byte("MyUser@9"), auth.PermissionAdmin, "defaultdb")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	cmdl := commandline{
 		options:        cliopt,
 		immuClient:     clientb,
@@ -494,13 +470,9 @@ defer bs.Stop()
 	usrcmd.PersistentPreRunE = nil
 
 	err = cmd.Execute()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !strings.Contains(string(msg), "User status changed successfully") {
 		t.Fatal(string(msg))
 	}
@@ -524,9 +496,7 @@ defer bs.Stop()
 
 	clientb, _ := client.NewImmuClient(cliopt)
 	token, err := clientb.Login(ctx, []byte("immudb"), []byte("immudb"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	md := metadata.Pairs("authorization", token.Token)
 	ctx = metadata.NewOutgoingContext(context.Background(), md)
@@ -535,13 +505,9 @@ defer bs.Stop()
 	err = clientb.CreateDatabase(ctx, &schema.Database{
 		Databasename: "mydb",
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	err = clientb.CreateUser(ctx, []byte("myuser"), []byte("MyUser@9"), auth.PermissionAdmin, "defaultdb")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	cmdl := commandline{
 		options:        cliopt,
 		immuClient:     clientb,
@@ -563,13 +529,9 @@ defer bs.Stop()
 	usrcmd.PersistentPreRunE = nil
 
 	err = cmd.Execute()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !strings.Contains(string(msg), "User status changed successfully") {
 		t.Fatal(string(msg))
 	}
@@ -608,9 +570,7 @@ defer bs.Stop()
 	clientb, _ := client.NewImmuClient(cliopt)
 
 	token, err := clientb.Login(ctx, []byte("immudb"), []byte("immudb"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	md := metadata.Pairs("authorization", token.Token)
 	ctx = metadata.NewOutgoingContext(context.Background(), md)
@@ -619,13 +579,9 @@ defer bs.Stop()
 	err = clientb.CreateDatabase(ctx, &schema.Database{
 		Databasename: "mydb",
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	err = clientb.CreateUser(ctx, []byte("myuser"), []byte("MyUser@9"), auth.PermissionAdmin, "defaultdb")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	cmdl := commandline{
 		options:        cliopt,
 		immuClient:     clientb,
@@ -648,13 +604,9 @@ defer bs.Stop()
 
 	err = cmd.Execute()
 
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !strings.Contains(string(msg), "Permission changed successfully") {
 		t.Fatal(string(msg))
 	}

--- a/cmd/immuclient/audit/auditagent_test.go
+++ b/cmd/immuclient/audit/auditagent_test.go
@@ -180,6 +180,8 @@ defer bs.Stop()
 }
 
 func TestOptions(t *testing.T) {
+	defer viper.Reset()
+
 	viper.Set("immudb-port", "30000")
 	viper.Set("immudb-address", "127.0.0.1")
 	viper.Set("tokenfile", "tokenfile")

--- a/cmd/immuclient/audit/auditagent_test.go
+++ b/cmd/immuclient/audit/auditagent_test.go
@@ -61,9 +61,7 @@ defer bs.Stop()
 
 	logfilename := "logfile"
 	logfile, err := os.OpenFile(logfilename, os.O_APPEND, 0755)
-	if err != nil {
-		logfile = os.Stderr
-	}
+	require.NoError(t, err)
 	ad.logfile = logfile
 	ad.logger = logger.NewSimpleLogger("immuclientd", logfile)
 
@@ -72,9 +70,7 @@ defer bs.Stop()
 	}
 	ad.opts = options().WithMetrics(false).WithDialOptions(dialOptions).WithMTLs(false).WithPidPath(pidPath)
 	_, err = ad.InitAgent()
-	if err != nil {
-		t.Fatal("InitAgent", err)
-	}
+	require.NoError(t, err, "InitAgent")
 	defer func() { os.RemoveAll(pidPath); os.RemoveAll(logfilename) }()
 
 	_, err = ad.Manage([]string{"uninstall"}, &cobra.Command{})
@@ -119,9 +115,7 @@ defer bs.Stop()
 
 	logfilename := "logfile"
 	logfile, err := os.OpenFile(logfilename, os.O_APPEND, 0755)
-	if err != nil {
-		logfile = os.Stderr
-	}
+	require.NoError(t, err)
 	ad.logfile = logfile
 	ad.logger = logger.NewSimpleLogger("immuclientd", logfile)
 
@@ -130,52 +124,36 @@ defer bs.Stop()
 	}
 	ad.opts = options().WithMetrics(false).WithDialOptions(dialOptions).WithMTLs(false).WithPidPath(pidPath)
 	_, err = ad.InitAgent()
-	if err != nil {
-		t.Fatal("InitAgent", err)
-	}
+	require.NoError(t, err, "InitAgent")
 	os.RemoveAll(pidPath)
 	defer func() { os.RemoveAll(pidPath); os.RemoveAll(logfilename) }()
 
 	_, err = ad.Manage([]string{}, &cobra.Command{})
-	if err != nil {
-		t.Fatal("Manage start audit fail", err)
-	}
+	require.NoError(t, err, "Manage start audit fail")
 	os.RemoveAll(pidPath)
 
 	_, err = ad.Manage([]string{"install"}, &cobra.Command{})
-	if err != nil {
-		t.Fatal("Manage install audit fail", err)
-	}
+	require.NoError(t, err, "Manage install audit fail")
 	os.RemoveAll(pidPath)
 
 	_, err = ad.Manage([]string{"uninstall"}, &cobra.Command{})
-	if err != nil {
-		t.Fatal("Manage uninstall fail", err)
-	}
+	require.NoError(t, err, "Manage uninstall fail")
 	os.RemoveAll(pidPath)
 
 	_, err = ad.Manage([]string{"start"}, &cobra.Command{})
-	if err != nil {
-		t.Fatal("Manage start fail", err)
-	}
+	require.NoError(t, err, "Manage start fail")
 	os.RemoveAll(pidPath)
 
 	_, err = ad.Manage([]string{"restart"}, &cobra.Command{})
-	if err != nil {
-		t.Fatal("Manage restart fail", err)
-	}
+	require.NoError(t, err, "Manage restart fail")
 	os.RemoveAll(pidPath)
 
 	_, err = ad.Manage([]string{"stop"}, &cobra.Command{})
-	if err != nil {
-		t.Fatal("Manage restart", err)
-	}
+	require.NoError(t, err, "Manage restart")
 	os.RemoveAll(pidPath)
 
 	_, err = ad.Manage([]string{"status"}, &cobra.Command{})
-	if err != nil {
-		t.Fatal("Manage status", err)
-	}
+	require.NoError(t, err, "Manage status")
 
 }
 

--- a/cmd/immuclient/audit/auditor_test.go
+++ b/cmd/immuclient/audit/auditor_test.go
@@ -53,9 +53,7 @@ defer bs.Stop()
 	ad.opts = options().WithMetrics(false).WithDialOptions(dialOptions).WithMTLs(false)
 	_, err := ad.InitAgent()
 	os.RemoveAll(pidPath)
-	if err != nil {
-		t.Fatal("InitAgent", err)
-	}
+	require.NoError(t, err, "InitAgent")
 
 	os.Setenv("audit-agent-interval", "X")
 	_, err = ad.InitAgent()

--- a/cmd/immuclient/audit/auditor_test.go
+++ b/cmd/immuclient/audit/auditor_test.go
@@ -32,6 +32,8 @@ import (
 )
 
 func TestInitAgent(t *testing.T) {
+	defer viper.Reset()
+
 	srvoptions := server.Options{}.WithAuth(true).WithInMemoryStore(true).WithAdminPassword(auth.SysAdminPassword)
 	bs := servertest.NewBufconnServer(srvoptions)
 	bs.Start()

--- a/cmd/immuclient/audit/executable_test.go
+++ b/cmd/immuclient/audit/executable_test.go
@@ -44,9 +44,7 @@ defer bs.Stop()
 	ad.opts = options().WithMetrics(false).WithDialOptions(dialOptions).WithMTLs(false).WithPidPath(pidpath)
 	ad.logger = logger.NewSimpleLogger("test", os.Stdout)
 	_, err := ad.InitAgent()
-	if err != nil {
-		t.Fatal("InitAgent", err)
-	}
+	require.NoError(t, err, "InitAgent")
 	exec := newExecutable(ad)
 	go func() {
 		time.Sleep(200 * time.Millisecond)

--- a/cmd/immuclient/audit/init_test.go
+++ b/cmd/immuclient/audit/init_test.go
@@ -26,7 +26,7 @@ import (
 func TestInit(t *testing.T) {
 	args := []string{"help"}
 	err := Init(args, &cobra.Command{})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestInitWrongArg(t *testing.T) {

--- a/cmd/immuclient/cli/cli.go
+++ b/cmd/immuclient/cli/cli.go
@@ -238,7 +238,6 @@ func (cli *cli) runCommand(arrCommandStr []string) {
 		return
 	}
 	fmt.Fprintf(os.Stdout, "%v \n", result)
-	return
 }
 
 func (cli *cli) singleCommandHelp(cmdName string) (string, error) {

--- a/cmd/immuclient/cli/cli_test.go
+++ b/cmd/immuclient/cli/cli_test.go
@@ -19,7 +19,6 @@ package cli
 import (
 	"os"
 	"path"
-	"strings"
 	"testing"
 
 	"github.com/codenotary/immudb/pkg/client/tokenservice"
@@ -72,9 +71,7 @@ func TestRunCommand(t *testing.T) {
 	msg := test.CaptureStdout(func() {
 		cli.runCommand([]string{"set", "key", "value"})
 	})
-	if !strings.Contains(msg, "value") {
-		t.Fatal(msg)
-	}
+	require.Contains(t, msg, "value")
 }
 
 func TestRunCommandExtraArgs(t *testing.T) {
@@ -83,9 +80,7 @@ func TestRunCommandExtraArgs(t *testing.T) {
 	msg := test.CaptureStdout(func() {
 		cli.runCommand([]string{"set", "key", "value", "value"})
 	})
-	if !strings.Contains(msg, "Redunant argument") {
-		t.Fatal(msg)
-	}
+	require.Contains(t, msg, "Redunant argument")
 }
 func TestRunMissingArgs(t *testing.T) {
 	cli := setupTest(t)
@@ -93,9 +88,7 @@ func TestRunMissingArgs(t *testing.T) {
 	msg := test.CaptureStdout(func() {
 		cli.runCommand([]string{"set", "key"})
 	})
-	if !strings.Contains(msg, "Not enough arguments") {
-		t.Fatal(msg)
-	}
+	require.Contains(t, msg, "Not enough arguments")
 }
 
 func TestRunWrongCommand(t *testing.T) {
@@ -104,9 +97,7 @@ func TestRunWrongCommand(t *testing.T) {
 	msg := test.CaptureStdout(func() {
 		cli.runCommand([]string{"fet", "key"})
 	})
-	if !strings.Contains(msg, "ERROR: Unknown command") {
-		t.Fatal(msg)
-	}
+	require.Contains(t, msg, "ERROR: Unknown command")
 }
 
 func TestCheckCommand(t *testing.T) {
@@ -129,9 +120,7 @@ func TestCheckCommand(t *testing.T) {
 	msg = test.CaptureStdout(func() {
 		cli.checkCommand([]string{"met", "-h"}, l)
 	})
-	if !strings.Contains(msg, "Did you mean this") {
-		t.Fatal("Help is empty")
-	}
+	require.Contains(t, msg, "Did you mean this", "Help is empty")
 }
 
 func TestCheckCommandErrors(t *testing.T) {

--- a/cmd/immuclient/cli/currentstatus_test.go
+++ b/cmd/immuclient/cli/currentstatus_test.go
@@ -49,8 +49,6 @@ Connect(bs.Dialer)
 	msg, err := cli.currentRoot([]string{""})
 
 	require.NoError(t, err, "CurrentRoot fail")
-	if !strings.Contains(msg, "hash") {
-		t.Fatalf("CurrentRoot failed: %s", msg)
-	}
+	require.Contains(t, msg, "hash", "CurrentRoot failed")
 }
 */

--- a/cmd/immuclient/cli/currentstatus_test.go
+++ b/cmd/immuclient/cli/currentstatus_test.go
@@ -36,7 +36,7 @@ defer bs.Stop()
 	ts := tokenservice.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
-	}, ts)
+	}, ts, client.DefaultOptions().WithDir(t.TempDir()))
 ic.
 Connect(bs.Dialer)
 	ic.Login("immudb")

--- a/cmd/immuclient/cli/currentstatus_test.go
+++ b/cmd/immuclient/cli/currentstatus_test.go
@@ -48,9 +48,7 @@ Connect(bs.Dialer)
 	assert.NoError(t, err)
 	msg, err := cli.currentRoot([]string{""})
 
-	if err != nil {
-		t.Fatal("CurrentRoot fail", err)
-	}
+	require.NoError(t, err, "CurrentRoot fail")
 	if !strings.Contains(msg, "hash") {
 		t.Fatalf("CurrentRoot failed: %s", msg)
 	}

--- a/cmd/immuclient/cli/getcommands_test.go
+++ b/cmd/immuclient/cli/getcommands_test.go
@@ -45,9 +45,7 @@ Connect(bs.Dialer)
 
 	_, _ = cli.safeset([]string{"key", "val"})
 	msg, err := cli.getByIndex([]string{"0"})
-	if err != nil {
-		t.Fatal("GetByIndex fail", err)
-	}
+	require.NoError(t, err, "GetByIndex fail")
 	if !strings.Contains(msg, "hash") {
 		t.Fatalf("GetByIndex failed: %s", msg)
 	}
@@ -71,9 +69,7 @@ Connect(bs.Dialer)
 
 	_, _ = cli.set([]string{"key", "val"})
 	msg, err := cli.getKey([]string{"key"})
-	if err != nil {
-		t.Fatal("GetKey fail", err)
-	}
+	require.NoError(t, err, "GetKey fail")
 	if !strings.Contains(msg, "hash") {
 		t.Fatalf("GetKey failed: %s", msg)
 	}
@@ -96,9 +92,7 @@ Connect(bs.Dialer)
 
 	_, _ = cli.set([]string{"key", "val"})
 	msg, err := cli.rawSafeGetKey([]string{"key"})
-	if err != nil {
-		t.Fatal("RawSafeGetKey fail", err)
-	}
+	require.NoError(t, err, "RawSafeGetKey fail")
 	if !strings.Contains(msg, "hash") {
 		t.Fatalf("RawSafeGetKey failed: %s", msg)
 	}
@@ -121,9 +115,7 @@ Connect(bs.Dialer)
 
 	_, _ = cli.set([]string{"key", "val"})
 	msg, err := cli.safeGetKey([]string{"key"})
-	if err != nil {
-		t.Fatal("SafeGetKey fail", err)
-	}
+	require.NoError(t, err, "SafeGetKey fail")
 	if !strings.Contains(msg, "hash") {
 		t.Fatalf("SafeGetKey failed: %s", msg)
 	}
@@ -147,9 +139,7 @@ Connect(bs.Dialer)
 
 	_, _ = cli.set([]string{"key", "val"})
 	msg, err := cli.getRawBySafeIndex([]string{"0"})
-	if err != nil {
-		t.Fatal("GetRawBySafeIndex fail", err)
-	}
+	require.NoError(t, err, "GetRawBySafeIndex fail")
 	if !strings.Contains(msg, "hash") {
 		t.Fatalf("GetRawBySafeIndex failed: %s", msg)
 	}

--- a/cmd/immuclient/cli/getcommands_test.go
+++ b/cmd/immuclient/cli/getcommands_test.go
@@ -35,7 +35,7 @@ defer bs.Stop()
 	ts := tokenservice.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
-	}, ts)
+	}, ts, client.DefaultOptions().WithDir(t.TempDir()))
 ic.
 Connect(bs.Dialer)
 	ic.Login("immudb")
@@ -61,7 +61,7 @@ defer bs.Stop()
 	ts := tokenservice.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
-	}, ts)
+	}, ts, client.DefaultOptions().WithDir(t.TempDir()))
 ic.
 Connect(bs.Dialer)
 	ic.Login("immudb")
@@ -86,7 +86,7 @@ defer bs.Stop()
 	ts := tokenservice.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
-	}, ts)
+	}, ts, client.DefaultOptions().WithDir(t.TempDir()))
 ic.
 Connect(bs.Dialer)
 	ic.Login("immudb")
@@ -111,7 +111,7 @@ defer bs.Stop()
 	ts := tokenservice.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
-	}, ts)
+	}, ts, client.DefaultOptions().WithDir(t.TempDir()))
 ic.
 Connect(bs.Dialer)
 	ic.Login("immudb")
@@ -137,7 +137,7 @@ defer bs.Stop()
 	ts := tokenservice.NewTokenService().WithTokenFileName("testTokenFile").WithHds(&test.HomedirServiceMock{})
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
-	}, ts)
+	}, ts, client.DefaultOptions().WithDir(t.TempDir()))
 ic.
 Connect(bs.Dialer)
 	ic.Login("immudb")

--- a/cmd/immuclient/cli/getcommands_test.go
+++ b/cmd/immuclient/cli/getcommands_test.go
@@ -46,9 +46,7 @@ Connect(bs.Dialer)
 	_, _ = cli.safeset([]string{"key", "val"})
 	msg, err := cli.getByIndex([]string{"0"})
 	require.NoError(t, err, "GetByIndex fail")
-	if !strings.Contains(msg, "hash") {
-		t.Fatalf("GetByIndex failed: %s", msg)
-	}
+	require.Contains(t, msg, "hash", "GetByIndex failed")
 }
 
 func TestGetKey(t *testing.T) {
@@ -70,9 +68,7 @@ Connect(bs.Dialer)
 	_, _ = cli.set([]string{"key", "val"})
 	msg, err := cli.getKey([]string{"key"})
 	require.NoError(t, err, "GetKey fail")
-	if !strings.Contains(msg, "hash") {
-		t.Fatalf("GetKey failed: %s", msg)
-	}
+	require.Contains(t, msg, "hash", "GetKey failed")
 }
 func TestRawSafeGetKey(t *testing.T) {
 	options := server.DefaultOptions().WithAuth(true).WithInMemoryStore(true)
@@ -93,9 +89,7 @@ Connect(bs.Dialer)
 	_, _ = cli.set([]string{"key", "val"})
 	msg, err := cli.rawSafeGetKey([]string{"key"})
 	require.NoError(t, err, "RawSafeGetKey fail")
-	if !strings.Contains(msg, "hash") {
-		t.Fatalf("RawSafeGetKey failed: %s", msg)
-	}
+	require.Contains(t, msg, "hash", "RawSafeGetKey failed")
 }
 func TestSafeGetKey(t *testing.T) {
 	options := server.DefaultOptions().WithAuth(true).WithInMemoryStore(true)
@@ -116,9 +110,7 @@ Connect(bs.Dialer)
 	_, _ = cli.set([]string{"key", "val"})
 	msg, err := cli.safeGetKey([]string{"key"})
 	require.NoError(t, err, "SafeGetKey fail")
-	if !strings.Contains(msg, "hash") {
-		t.Fatalf("SafeGetKey failed: %s", msg)
-	}
+	require.Contains(t, msg, "hash", "SafeGetKey failed")
 }
 
 func TestGetRawBySafeIndex(t *testing.T) {
@@ -140,8 +132,6 @@ Connect(bs.Dialer)
 	_, _ = cli.set([]string{"key", "val"})
 	msg, err := cli.getRawBySafeIndex([]string{"0"})
 	require.NoError(t, err, "GetRawBySafeIndex fail")
-	if !strings.Contains(msg, "hash") {
-		t.Fatalf("GetRawBySafeIndex failed: %s", msg)
-	}
+	require.Contains(t, msg, "hash", "GetRawBySafeIndex failed")
 }
 */

--- a/cmd/immuclient/cli/login_test.go
+++ b/cmd/immuclient/cli/login_test.go
@@ -17,14 +17,11 @@ limitations under the License.
 package cli
 
 import (
-	"os"
 	"strings"
 	"testing"
 
-	"github.com/codenotary/immudb/cmd/cmdtest"
+	"github.com/codenotary/immudb/pkg/client"
 	"github.com/codenotary/immudb/pkg/client/tokenservice"
-
-	"github.com/codenotary/immudb/pkg/auth"
 
 	test "github.com/codenotary/immudb/cmd/immuclient/immuclienttest"
 	"github.com/codenotary/immudb/pkg/server"
@@ -32,20 +29,16 @@ import (
 )
 
 func TestLogin(t *testing.T) {
-	options := server.DefaultOptions().WithAuth(true).WithAdminPassword(auth.SysAdminPassword)
+	options := server.DefaultOptions().WithDir(t.TempDir())
 	bs := servertest.NewBufconnServer(options)
 
 	bs.Start()
 	defer bs.Stop()
 
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
-
-	tkf := cmdtest.RandString()
-	ts := tokenservice.NewFileTokenService().WithTokenFileName(tkf)
+	ts := tokenservice.NewInmemoryTokenService()
 	ic := test.NewClientTest(&test.PasswordReader{
 		Pass: []string{"immudb"},
-	}, ts)
+	}, ts, client.DefaultOptions().WithDir(t.TempDir()))
 	ic.Connect(bs.Dialer)
 
 	cli := new(cli)

--- a/cmd/immuclient/cli/login_test.go
+++ b/cmd/immuclient/cli/login_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cli
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/codenotary/immudb/pkg/client"
@@ -48,13 +47,9 @@ func TestLogin(t *testing.T) {
 
 	msg, err := cli.login([]string{"immudb"})
 	require.NoError(t, err)
-	if !strings.Contains(msg, "immudb user has the default password") {
-		t.Fatalf("Login failed: %s", err)
-	}
+	require.Contains(t, msg, "immudb user has the default password", "Login failed")
 
 	msg, err = cli.logout([]string{"immudb"})
 	require.NoError(t, err)
-	if !strings.Contains(msg, "Successfully logged out") {
-		t.Fatalf("Login failed: %s", err)
-	}
+	require.Contains(t, msg, "Successfully logged out", "Login failed")
 }

--- a/cmd/immuclient/cli/login_test.go
+++ b/cmd/immuclient/cli/login_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/codenotary/immudb/pkg/client"
 	"github.com/codenotary/immudb/pkg/client/tokenservice"
+	"github.com/stretchr/testify/require"
 
 	test "github.com/codenotary/immudb/cmd/immuclient/immuclienttest"
 	"github.com/codenotary/immudb/pkg/server"
@@ -46,17 +47,13 @@ func TestLogin(t *testing.T) {
 	cli.immucl.WithFileTokenService(ts)
 
 	msg, err := cli.login([]string{"immudb"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !strings.Contains(msg, "immudb user has the default password") {
 		t.Fatalf("Login failed: %s", err)
 	}
 
 	msg, err = cli.logout([]string{"immudb"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !strings.Contains(msg, "Successfully logged out") {
 		t.Fatalf("Login failed: %s", err)
 	}

--- a/cmd/immuclient/cli/misc_test.go
+++ b/cmd/immuclient/cli/misc_test.go
@@ -17,38 +17,13 @@ limitations under the License.
 package cli
 
 import (
-	"os"
 	"strings"
 	"testing"
-
-	"github.com/codenotary/immudb/cmd/cmdtest"
-	"github.com/codenotary/immudb/pkg/client/tokenservice"
-
-	test "github.com/codenotary/immudb/cmd/immuclient/immuclienttest"
-	"github.com/codenotary/immudb/pkg/server"
-	"github.com/codenotary/immudb/pkg/server/servertest"
 )
 
 func TestHealthCheck(t *testing.T) {
-	options := server.DefaultOptions().WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
+	cli := setupTest(t)
 
-	bs.Start()
-	defer bs.Stop()
-
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
-
-	tkf := cmdtest.RandString()
-	ts := tokenservice.NewFileTokenService().WithTokenFileName(tkf)
-	ic := test.NewClientTest(&test.PasswordReader{
-		Pass: []string{"immudb"},
-	}, ts)
-	ic.Connect(bs.Dialer)
-	ic.Login("immudb")
-
-	cli := new(cli)
-	cli.immucl = ic.Imc
 	msg, err := cli.healthCheck([]string{})
 	if err != nil {
 		t.Fatal("HealthCheck fail", err)
@@ -59,26 +34,8 @@ func TestHealthCheck(t *testing.T) {
 }
 
 func TestHistory(t *testing.T) {
-	options := server.DefaultOptions().WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
+	cli := setupTest(t)
 
-	bs.Start()
-	defer bs.Stop()
-
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
-
-	tkf := cmdtest.RandString()
-	ts := tokenservice.NewFileTokenService().WithTokenFileName(tkf)
-	ic := test.NewClientTest(&test.PasswordReader{
-		Pass: []string{"immudb"},
-	}, ts)
-	ic.Connect(bs.Dialer)
-	ic.Login("immudb")
-
-	cli := new(cli)
-
-	cli.immucl = ic.Imc
 	msg, err := cli.history([]string{"key"})
 	if err != nil {
 		t.Fatal("History fail", err)
@@ -100,26 +57,10 @@ func TestHistory(t *testing.T) {
 		t.Fatalf("History fail %s", msg)
 	}
 }
+
 func TestVersion(t *testing.T) {
-	options := server.DefaultOptions().WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
+	cli := setupTest(t)
 
-	bs.Start()
-	defer bs.Stop()
-
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
-
-	tkf := cmdtest.RandString()
-	ts := tokenservice.NewFileTokenService().WithTokenFileName(tkf)
-	ic := test.NewClientTest(&test.PasswordReader{
-		Pass: []string{"immudb"},
-	}, ts)
-	ic.Connect(bs.Dialer)
-	ic.Login("immudb")
-
-	cli := new(cli)
-	cli.immucl = ic.Imc
 	msg, err := cli.version([]string{"key"})
 	if err != nil {
 		t.Fatal("version fail", err)

--- a/cmd/immuclient/cli/misc_test.go
+++ b/cmd/immuclient/cli/misc_test.go
@@ -19,15 +19,15 @@ package cli
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestHealthCheck(t *testing.T) {
 	cli := setupTest(t)
 
 	msg, err := cli.healthCheck([]string{})
-	if err != nil {
-		t.Fatal("HealthCheck fail", err)
-	}
+	require.NoError(t, err, "HealthCheck fail")
 	if !strings.Contains(msg, "Health check OK") {
 		t.Fatal("HealthCheck fail")
 	}
@@ -37,22 +37,16 @@ func TestHistory(t *testing.T) {
 	cli := setupTest(t)
 
 	msg, err := cli.history([]string{"key"})
-	if err != nil {
-		t.Fatal("History fail", err)
-	}
+	require.NoError(t, err, "History fail")
 	if !strings.Contains(msg, "key not found") {
 		t.Fatalf("History fail %s", msg)
 	}
 
 	_, err = cli.set([]string{"key", "value"})
-	if err != nil {
-		t.Fatal("History fail", err)
-	}
+	require.NoError(t, err, "History fail")
 
 	msg, err = cli.history([]string{"key"})
-	if err != nil {
-		t.Fatal("History fail", err)
-	}
+	require.NoError(t, err, "History fail")
 	if !strings.Contains(msg, "value") {
 		t.Fatalf("History fail %s", msg)
 	}
@@ -62,9 +56,7 @@ func TestVersion(t *testing.T) {
 	cli := setupTest(t)
 
 	msg, err := cli.version([]string{"key"})
-	if err != nil {
-		t.Fatal("version fail", err)
-	}
+	require.NoError(t, err, "version fail")
 	if !strings.Contains(msg, "no version info available") {
 		t.Fatalf("version fail %s", msg)
 	}

--- a/cmd/immuclient/cli/misc_test.go
+++ b/cmd/immuclient/cli/misc_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cli
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -28,9 +27,7 @@ func TestHealthCheck(t *testing.T) {
 
 	msg, err := cli.healthCheck([]string{})
 	require.NoError(t, err, "HealthCheck fail")
-	if !strings.Contains(msg, "Health check OK") {
-		t.Fatal("HealthCheck fail")
-	}
+	require.Contains(t, msg, "Health check OK", "HealthCheck fail")
 }
 
 func TestHistory(t *testing.T) {
@@ -38,18 +35,14 @@ func TestHistory(t *testing.T) {
 
 	msg, err := cli.history([]string{"key"})
 	require.NoError(t, err, "History fail")
-	if !strings.Contains(msg, "key not found") {
-		t.Fatalf("History fail %s", msg)
-	}
+	require.Contains(t, msg, "key not found", "History fail")
 
 	_, err = cli.set([]string{"key", "value"})
 	require.NoError(t, err, "History fail")
 
 	msg, err = cli.history([]string{"key"})
 	require.NoError(t, err, "History fail")
-	if !strings.Contains(msg, "value") {
-		t.Fatalf("History fail %s", msg)
-	}
+	require.Contains(t, msg, "value", "History fail")
 }
 
 func TestVersion(t *testing.T) {
@@ -57,7 +50,5 @@ func TestVersion(t *testing.T) {
 
 	msg, err := cli.version([]string{"key"})
 	require.NoError(t, err, "version fail")
-	if !strings.Contains(msg, "no version info available") {
-		t.Fatalf("version fail %s", msg)
-	}
+	require.Contains(t, msg, "no version info available", "version fail")
 }

--- a/cmd/immuclient/cli/references_test.go
+++ b/cmd/immuclient/cli/references_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cli
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -30,9 +29,7 @@ func TestReference(t *testing.T) {
 
 	msg, err := cli.reference([]string{"val", "key"})
 	require.NoError(t, err, "Reference fail")
-	if !strings.Contains(msg, "value") {
-		t.Fatalf("Reference failed: %s", msg)
-	}
+	require.Contains(t, msg, "value", "Reference failed")
 }
 
 func TestSafeReference(t *testing.T) {
@@ -44,7 +41,5 @@ func TestSafeReference(t *testing.T) {
 
 	msg, err := cli.safereference([]string{"val", "key"})
 	require.NoError(t, err, "SafeReference fail")
-	if !strings.Contains(msg, "value") {
-		t.Fatalf("SafeReference failed: %s", msg)
-	}
+	require.Contains(t, msg, "value", "SafeReference failed")
 }

--- a/cmd/immuclient/cli/references_test.go
+++ b/cmd/immuclient/cli/references_test.go
@@ -17,37 +17,13 @@ limitations under the License.
 package cli
 
 import (
-	"os"
 	"strings"
 	"testing"
-
-	"github.com/codenotary/immudb/cmd/cmdtest"
-	test "github.com/codenotary/immudb/cmd/immuclient/immuclienttest"
-	"github.com/codenotary/immudb/pkg/client/tokenservice"
-	"github.com/codenotary/immudb/pkg/server"
-	"github.com/codenotary/immudb/pkg/server/servertest"
 )
 
 func TestReference(t *testing.T) {
-	options := server.DefaultOptions().WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
+	cli := setupTest(t)
 
-	bs.Start()
-	defer bs.Stop()
-
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
-
-	tkf := cmdtest.RandString()
-	ts := tokenservice.NewFileTokenService().WithTokenFileName(tkf)
-	ic := test.NewClientTest(&test.PasswordReader{
-		Pass: []string{"immudb"},
-	}, ts)
-	ic.Connect(bs.Dialer)
-	ic.Login("immudb")
-
-	cli := new(cli)
-	cli.immucl = ic.Imc
 	_, _ = cli.set([]string{"key", "val"})
 
 	msg, err := cli.reference([]string{"val", "key"})
@@ -59,27 +35,11 @@ func TestReference(t *testing.T) {
 	}
 }
 
-func _TestSafeReference(t *testing.T) {
-	options := server.DefaultOptions().WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
+func TestSafeReference(t *testing.T) {
+	t.SkipNow()
 
-	bs.Start()
-	defer bs.Stop()
+	cli := setupTest(t)
 
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
-
-	tkf := cmdtest.RandString()
-	ts := tokenservice.NewFileTokenService().WithTokenFileName(tkf)
-	ic := test.NewClientTest(&test.PasswordReader{
-		Pass: []string{"immudb"},
-	}, ts)
-	ic.
-		Connect(bs.Dialer)
-	ic.Login("immudb")
-
-	cli := new(cli)
-	cli.immucl = ic.Imc
 	_, _ = cli.set([]string{"key", "val"})
 
 	msg, err := cli.safereference([]string{"val", "key"})

--- a/cmd/immuclient/cli/references_test.go
+++ b/cmd/immuclient/cli/references_test.go
@@ -19,6 +19,8 @@ package cli
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestReference(t *testing.T) {
@@ -27,9 +29,7 @@ func TestReference(t *testing.T) {
 	_, _ = cli.set([]string{"key", "val"})
 
 	msg, err := cli.reference([]string{"val", "key"})
-	if err != nil {
-		t.Fatal("Reference fail", err)
-	}
+	require.NoError(t, err, "Reference fail")
 	if !strings.Contains(msg, "value") {
 		t.Fatalf("Reference failed: %s", msg)
 	}
@@ -43,9 +43,7 @@ func TestSafeReference(t *testing.T) {
 	_, _ = cli.set([]string{"key", "val"})
 
 	msg, err := cli.safereference([]string{"val", "key"})
-	if err != nil {
-		t.Fatal("SafeReference fail", err)
-	}
+	require.NoError(t, err, "SafeReference fail")
 	if !strings.Contains(msg, "value") {
 		t.Fatalf("SafeReference failed: %s", msg)
 	}

--- a/cmd/immuclient/cli/register_test.go
+++ b/cmd/immuclient/cli/register_test.go
@@ -22,7 +22,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func _TestInitCommands(t *testing.T) {
+func TestInitCommands(t *testing.T) {
+	t.SkipNow()
+
 	cli := new(cli)
 	cli.commands = make(map[string]*command)
 	cli.commandsList = make([]*command, 0)

--- a/cmd/immuclient/cli/scanners_test.go
+++ b/cmd/immuclient/cli/scanners_test.go
@@ -17,38 +17,13 @@ limitations under the License.
 package cli
 
 import (
-	"os"
 	"strings"
 	"testing"
-
-	"github.com/codenotary/immudb/cmd/cmdtest"
-	"github.com/codenotary/immudb/pkg/client/tokenservice"
-
-	test "github.com/codenotary/immudb/cmd/immuclient/immuclienttest"
-	"github.com/codenotary/immudb/pkg/server"
-	"github.com/codenotary/immudb/pkg/server/servertest"
 )
 
 func TestZScan(t *testing.T) {
-	options := server.DefaultOptions().WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
+	cli := setupTest(t)
 
-	bs.Start()
-	defer bs.Stop()
-
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
-
-	tkf := cmdtest.RandString()
-	ts := tokenservice.NewFileTokenService().WithTokenFileName(tkf)
-	ic := test.NewClientTest(&test.PasswordReader{
-		Pass: []string{"immudb"},
-	}, ts)
-	ic.Connect(bs.Dialer)
-	ic.Login("immudb")
-
-	cli := new(cli)
-	cli.immucl = ic.Imc
 	_, err := cli.set([]string{"key", "val"})
 	if err != nil {
 		t.Fatal("Set fail", err)
@@ -69,25 +44,8 @@ func TestZScan(t *testing.T) {
 }
 
 func TestScan(t *testing.T) {
-	options := server.DefaultOptions().WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
+	cli := setupTest(t)
 
-	bs.Start()
-	defer bs.Stop()
-
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
-
-	tkf := cmdtest.RandString()
-	ts := tokenservice.NewFileTokenService().WithTokenFileName(tkf)
-	ic := test.NewClientTest(&test.PasswordReader{
-		Pass: []string{"immudb"},
-	}, ts)
-	ic.Connect(bs.Dialer)
-	ic.Login("immudb")
-
-	cli := new(cli)
-	cli.immucl = ic.Imc
 	_, err := cli.set([]string{"key", "val"})
 	if err != nil {
 		t.Fatal("Set fail", err)
@@ -102,27 +60,11 @@ func TestScan(t *testing.T) {
 	}
 }
 
-func _TestCount(t *testing.T) {
-	options := server.DefaultOptions().WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
+func TestCount(t *testing.T) {
+	t.SkipNow()
 
-	bs.Start()
-	defer bs.Stop()
+	cli := setupTest(t)
 
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
-
-	tkf := cmdtest.RandString()
-	ts := tokenservice.NewFileTokenService().WithTokenFileName(tkf)
-	ic := test.NewClientTest(&test.PasswordReader{
-		Pass: []string{"immudb"},
-	}, ts)
-	ic.
-		Connect(bs.Dialer)
-	ic.Login("immudb")
-
-	cli := new(cli)
-	cli.immucl = ic.Imc
 	_, err := cli.set([]string{"key", "val"})
 	if err != nil {
 		t.Fatal("Set fail", err)

--- a/cmd/immuclient/cli/scanners_test.go
+++ b/cmd/immuclient/cli/scanners_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cli
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -34,9 +33,7 @@ func TestZScan(t *testing.T) {
 
 	msg, err := cli.zScan([]string{"set"})
 	require.NoError(t, err, "ZScan fail")
-	if !strings.Contains(msg, "value") {
-		t.Fatalf("ZScan failed: %s", msg)
-	}
+	require.Contains(t, msg, "value", "ZScan failed")
 }
 
 func TestScan(t *testing.T) {
@@ -47,9 +44,7 @@ func TestScan(t *testing.T) {
 
 	msg, err := cli.scan([]string{"k"})
 	require.NoError(t, err, "Scan fail")
-	if !strings.Contains(msg, "value") {
-		t.Fatalf("Scan failed: %s", msg)
-	}
+	require.Contains(t, msg, "value", "Scan failed")
 }
 
 func TestCount(t *testing.T) {
@@ -62,7 +57,5 @@ func TestCount(t *testing.T) {
 
 	msg, err := cli.count([]string{"key"})
 	require.NoError(t, err, "Count fail")
-	if !strings.Contains(msg, "1") {
-		t.Fatalf("Count failed: %s", msg)
-	}
+	require.Contains(t, msg, "1", "Count failed")
 }

--- a/cmd/immuclient/cli/scanners_test.go
+++ b/cmd/immuclient/cli/scanners_test.go
@@ -19,25 +19,21 @@ package cli
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestZScan(t *testing.T) {
 	cli := setupTest(t)
 
 	_, err := cli.set([]string{"key", "val"})
-	if err != nil {
-		t.Fatal("Set fail", err)
-	}
+	require.NoError(t, err, "Set fail")
 
 	_, err = cli.zAdd([]string{"set", "445.3", "key"})
-	if err != nil {
-		t.Fatal("ZAdd fail", err)
-	}
+	require.NoError(t, err, "ZAdd fail")
 
 	msg, err := cli.zScan([]string{"set"})
-	if err != nil {
-		t.Fatal("ZScan fail", err)
-	}
+	require.NoError(t, err, "ZScan fail")
 	if !strings.Contains(msg, "value") {
 		t.Fatalf("ZScan failed: %s", msg)
 	}
@@ -47,14 +43,10 @@ func TestScan(t *testing.T) {
 	cli := setupTest(t)
 
 	_, err := cli.set([]string{"key", "val"})
-	if err != nil {
-		t.Fatal("Set fail", err)
-	}
+	require.NoError(t, err, "Set fail")
 
 	msg, err := cli.scan([]string{"k"})
-	if err != nil {
-		t.Fatal("Scan fail", err)
-	}
+	require.NoError(t, err, "Scan fail")
 	if !strings.Contains(msg, "value") {
 		t.Fatalf("Scan failed: %s", msg)
 	}
@@ -66,14 +58,10 @@ func TestCount(t *testing.T) {
 	cli := setupTest(t)
 
 	_, err := cli.set([]string{"key", "val"})
-	if err != nil {
-		t.Fatal("Set fail", err)
-	}
+	require.NoError(t, err, "Set fail")
 
 	msg, err := cli.count([]string{"key"})
-	if err != nil {
-		t.Fatal("Count fail", err)
-	}
+	require.NoError(t, err, "Count fail")
 	if !strings.Contains(msg, "1") {
 		t.Fatalf("Count failed: %s", msg)
 	}

--- a/cmd/immuclient/cli/setcommands_test.go
+++ b/cmd/immuclient/cli/setcommands_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cli
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -28,9 +27,7 @@ func TestSet(t *testing.T) {
 
 	msg, err := cli.set([]string{"key", "val"})
 	require.NoError(t, err, "Set fail")
-	if !strings.Contains(msg, "value") {
-		t.Fatalf("Set failed: %s", msg)
-	}
+	require.Contains(t, msg, "value", "Set failed")
 }
 
 func TestSafeSet(t *testing.T) {
@@ -38,9 +35,7 @@ func TestSafeSet(t *testing.T) {
 
 	msg, err := cli.safeset([]string{"key", "val"})
 	require.NoError(t, err, "SafeSet fail")
-	if !strings.Contains(msg, "value") {
-		t.Fatalf("SafeSet failed: %s", msg)
-	}
+	require.Contains(t, msg, "value", "SafeSet failed")
 }
 
 func TestZAdd(t *testing.T) {
@@ -52,9 +47,7 @@ func TestZAdd(t *testing.T) {
 	msg, err := cli.zAdd([]string{"val", "1", "key"})
 
 	require.NoError(t, err, "ZAdd fail")
-	if !strings.Contains(msg, "hash") {
-		t.Fatalf("ZAdd failed: %s", msg)
-	}
+	require.Contains(t, msg, "hash", "ZAdd failed")
 }
 
 func TestSafeZAdd(t *testing.T) {
@@ -66,7 +59,5 @@ func TestSafeZAdd(t *testing.T) {
 	msg, err := cli.safeZAdd([]string{"val", "1", "key"})
 
 	require.NoError(t, err, "SafeZAdd fail")
-	if !strings.Contains(msg, "hash") {
-		t.Fatalf("SafeZAdd failed: %s", msg)
-	}
+	require.Contains(t, msg, "hash", "SafeZAdd failed")
 }

--- a/cmd/immuclient/cli/setcommands_test.go
+++ b/cmd/immuclient/cli/setcommands_test.go
@@ -46,7 +46,8 @@ func TestSafeSet(t *testing.T) {
 func TestZAdd(t *testing.T) {
 	cli := setupTest(t)
 
-	_, _ = cli.safeset([]string{"key", "val"})
+	_, err := cli.safeset([]string{"key", "val"})
+	require.NoError(t, err)
 
 	msg, err := cli.zAdd([]string{"val", "1", "key"})
 
@@ -59,7 +60,8 @@ func TestZAdd(t *testing.T) {
 func TestSafeZAdd(t *testing.T) {
 	cli := setupTest(t)
 
-	_, _ = cli.safeset([]string{"key", "val"})
+	_, err := cli.safeset([]string{"key", "val"})
+	require.NoError(t, err)
 
 	msg, err := cli.safeZAdd([]string{"val", "1", "key"})
 

--- a/cmd/immuclient/cli/setcommands_test.go
+++ b/cmd/immuclient/cli/setcommands_test.go
@@ -19,15 +19,15 @@ package cli
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestSet(t *testing.T) {
 	cli := setupTest(t)
 
 	msg, err := cli.set([]string{"key", "val"})
-	if err != nil {
-		t.Fatal("Set fail", err)
-	}
+	require.NoError(t, err, "Set fail")
 	if !strings.Contains(msg, "value") {
 		t.Fatalf("Set failed: %s", msg)
 	}
@@ -37,9 +37,7 @@ func TestSafeSet(t *testing.T) {
 	cli := setupTest(t)
 
 	msg, err := cli.safeset([]string{"key", "val"})
-	if err != nil {
-		t.Fatal("SafeSet fail", err)
-	}
+	require.NoError(t, err, "SafeSet fail")
 	if !strings.Contains(msg, "value") {
 		t.Fatalf("SafeSet failed: %s", msg)
 	}
@@ -52,9 +50,7 @@ func TestZAdd(t *testing.T) {
 
 	msg, err := cli.zAdd([]string{"val", "1", "key"})
 
-	if err != nil {
-		t.Fatal("ZAdd fail", err)
-	}
+	require.NoError(t, err, "ZAdd fail")
 	if !strings.Contains(msg, "hash") {
 		t.Fatalf("ZAdd failed: %s", msg)
 	}
@@ -67,9 +63,7 @@ func TestSafeZAdd(t *testing.T) {
 
 	msg, err := cli.safeZAdd([]string{"val", "1", "key"})
 
-	if err != nil {
-		t.Fatal("SafeZAdd fail", err)
-	}
+	require.NoError(t, err, "SafeZAdd fail")
 	if !strings.Contains(msg, "hash") {
 		t.Fatalf("SafeZAdd failed: %s", msg)
 	}

--- a/cmd/immuclient/cli/setcommands_test.go
+++ b/cmd/immuclient/cli/setcommands_test.go
@@ -17,38 +17,13 @@ limitations under the License.
 package cli
 
 import (
-	"os"
 	"strings"
 	"testing"
-
-	"github.com/codenotary/immudb/cmd/cmdtest"
-	"github.com/codenotary/immudb/pkg/client/tokenservice"
-
-	test "github.com/codenotary/immudb/cmd/immuclient/immuclienttest"
-	"github.com/codenotary/immudb/pkg/server"
-	"github.com/codenotary/immudb/pkg/server/servertest"
 )
 
 func TestSet(t *testing.T) {
-	options := server.DefaultOptions().WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
+	cli := setupTest(t)
 
-	bs.Start()
-	defer bs.Stop()
-
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
-
-	tkf := cmdtest.RandString()
-	ts := tokenservice.NewFileTokenService().WithTokenFileName(tkf)
-	ic := test.NewClientTest(&test.PasswordReader{
-		Pass: []string{"immudb"},
-	}, ts)
-	ic.Connect(bs.Dialer)
-	ic.Login("immudb")
-
-	cli := new(cli)
-	cli.immucl = ic.Imc
 	msg, err := cli.set([]string{"key", "val"})
 	if err != nil {
 		t.Fatal("Set fail", err)
@@ -59,25 +34,8 @@ func TestSet(t *testing.T) {
 }
 
 func TestSafeSet(t *testing.T) {
-	options := server.DefaultOptions().WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
+	cli := setupTest(t)
 
-	bs.Start()
-	defer bs.Stop()
-
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
-
-	tkf := cmdtest.RandString()
-	ts := tokenservice.NewFileTokenService().WithTokenFileName(tkf)
-	ic := test.NewClientTest(&test.PasswordReader{
-		Pass: []string{"immudb"},
-	}, ts)
-	ic.Connect(bs.Dialer)
-	ic.Login("immudb")
-
-	cli := new(cli)
-	cli.immucl = ic.Imc
 	msg, err := cli.safeset([]string{"key", "val"})
 	if err != nil {
 		t.Fatal("SafeSet fail", err)
@@ -88,25 +46,8 @@ func TestSafeSet(t *testing.T) {
 }
 
 func TestZAdd(t *testing.T) {
-	options := server.DefaultOptions().WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
+	cli := setupTest(t)
 
-	bs.Start()
-	defer bs.Stop()
-
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
-
-	tkf := cmdtest.RandString()
-	ts := tokenservice.NewFileTokenService().WithTokenFileName(tkf)
-	ic := test.NewClientTest(&test.PasswordReader{
-		Pass: []string{"immudb"},
-	}, ts)
-	ic.Connect(bs.Dialer)
-	ic.Login("immudb")
-
-	cli := new(cli)
-	cli.immucl = ic.Imc
 	_, _ = cli.safeset([]string{"key", "val"})
 
 	msg, err := cli.zAdd([]string{"val", "1", "key"})
@@ -120,26 +61,8 @@ func TestZAdd(t *testing.T) {
 }
 
 func TestSafeZAdd(t *testing.T) {
-	options := server.DefaultOptions().WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
+	cli := setupTest(t)
 
-	bs.Start()
-	defer bs.Stop()
-
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
-
-	tkf := cmdtest.RandString()
-	ts := tokenservice.NewFileTokenService().WithTokenFileName(tkf)
-	ic := test.NewClientTest(&test.PasswordReader{
-		Pass: []string{"immudb"},
-	}, ts)
-	ic.
-		Connect(bs.Dialer)
-	ic.Login("immudb")
-
-	cli := new(cli)
-	cli.immucl = ic.Imc
 	_, _ = cli.safeset([]string{"key", "val"})
 
 	msg, err := cli.safeZAdd([]string{"val", "1", "key"})

--- a/cmd/immuclient/command/commandline_test.go
+++ b/cmd/immuclient/command/commandline_test.go
@@ -47,7 +47,7 @@ func TestCommandline_ConfigChain(t *testing.T) {
 	cmd.Flags().StringVar(&c.config.CfgFn, "config", "", "config file")
 	cc := c.ConfigChain(f)
 	err := cc(cmd, []string{})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCommandline_ConfigChainErr(t *testing.T) {

--- a/cmd/immuclient/command/currentstatus_test.go
+++ b/cmd/immuclient/command/currentstatus_test.go
@@ -19,7 +19,6 @@ package immuclient
 import (
 	"bytes"
 	"io/ioutil"
-	"strings"
 	"testing"
 
 	"github.com/codenotary/immudb/pkg/client"
@@ -75,7 +74,5 @@ func TestCurrentState(t *testing.T) {
 	require.NoError(t, err)
 	rsp := string(msg)
 
-	if !strings.Contains(rsp, "txID:") {
-		t.Fatal(err)
-	}
+	require.Contains(t, rsp, "txID:")
 }

--- a/cmd/immuclient/command/currentstatus_test.go
+++ b/cmd/immuclient/command/currentstatus_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/codenotary/immudb/pkg/client"
 	"github.com/codenotary/immudb/pkg/client/tokenservice"
+	"github.com/stretchr/testify/require"
 
 	"github.com/codenotary/immudb/cmd/helper"
 
@@ -69,13 +70,9 @@ func TestCurrentState(t *testing.T) {
 
 	err := cmd.Execute()
 
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	rsp := string(msg)
 
 	if !strings.Contains(rsp, "txID:") {

--- a/cmd/immuclient/command/getcommands_test.go
+++ b/cmd/immuclient/command/getcommands_test.go
@@ -69,9 +69,7 @@ Connect(bs.Dialer)
 
 	err := cmd.Execute()
 
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	cmd.SetArgs([]string{"getByIndex", "0"})
 
@@ -81,13 +79,9 @@ Connect(bs.Dialer)
 	innercmd.PersistentPreRunE = nil
 
 	err = cmd.Execute()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !strings.Contains(string(msg), "hash") {
 		t.Fatal(err)
 	}
@@ -129,19 +123,13 @@ Connect(bs.Dialer)
 
 	err := cmd.Execute()
 
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	cmd.SetArgs([]string{"getRawBySafeIndex", "0"})
 	err = cmd.Execute()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !strings.Contains(string(msg), "hash") {
 		t.Fatal(err)
 	}
@@ -183,20 +171,14 @@ Connect(bs.Dialer)
 	cmd.SetArgs([]string{"safeset", "key", "value"})
 
 	err := cmd.Execute()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	cmd.SetArgs([]string{"get", "key"})
 
 	err = cmd.Execute()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !strings.Contains(string(msg), "hash") {
 		t.Fatal(err)
 	}
@@ -244,19 +226,13 @@ Connect(bs.Dialer)
 
 	err := cmd.Execute()
 
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	cmd.SetArgs([]string{"safeget", "key"})
 	err = cmd.Execute()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !strings.Contains(string(msg), "hash") {
 		t.Fatal(err)
 	}
@@ -298,19 +274,13 @@ Connect(bs.Dialer)
 
 	err := cmd.Execute()
 
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	cmd.SetArgs([]string{"rawsafeget", "key"})
 	err = cmd.Execute()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !strings.Contains(string(msg), "hash") {
 		t.Fatal(err)
 	}

--- a/cmd/immuclient/command/getcommands_test.go
+++ b/cmd/immuclient/command/getcommands_test.go
@@ -82,9 +82,7 @@ Connect(bs.Dialer)
 	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
 	require.NoError(t, err)
-	if !strings.Contains(string(msg), "hash") {
-		t.Fatal(err)
-	}
+	require.Contains(t, string(msg), "hash")
 }
 
 func TestGetRawBySafeIndex(t *testing.T) {
@@ -130,9 +128,7 @@ Connect(bs.Dialer)
 	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
 	require.NoError(t, err)
-	if !strings.Contains(string(msg), "hash") {
-		t.Fatal(err)
-	}
+	require.Contains(t, string(msg), "hash")
 }
 
 func TestGetKey(t *testing.T) {
@@ -179,9 +175,7 @@ Connect(bs.Dialer)
 	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
 	require.NoError(t, err)
-	if !strings.Contains(string(msg), "hash") {
-		t.Fatal(err)
-	}
+	require.Contains(t, string(msg), "hash")
 }
 
 func TestSafeGetKey(t *testing.T) {
@@ -233,9 +227,7 @@ Connect(bs.Dialer)
 	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
 	require.NoError(t, err)
-	if !strings.Contains(string(msg), "hash") {
-		t.Fatal(err)
-	}
+	require.Contains(t, string(msg), "hash")
 }
 
 func TestRawSafeGetKey(t *testing.T) {
@@ -281,8 +273,6 @@ Connect(bs.Dialer)
 	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
 	require.NoError(t, err)
-	if !strings.Contains(string(msg), "hash") {
-		t.Fatal(err)
-	}
+	require.Contains(t, string(msg), "hash")
 }
 */

--- a/cmd/immuclient/command/init_test.go
+++ b/cmd/immuclient/command/init_test.go
@@ -17,18 +17,11 @@ limitations under the License.
 package immuclient
 
 import (
-	"os"
 	"testing"
-
-	"github.com/codenotary/immudb/cmd/cmdtest"
-	"github.com/codenotary/immudb/pkg/client/tokenservice"
 
 	"github.com/codenotary/immudb/cmd/helper"
 	"github.com/stretchr/testify/require"
 
-	test "github.com/codenotary/immudb/cmd/immuclient/immuclienttest"
-	"github.com/codenotary/immudb/pkg/server"
-	"github.com/codenotary/immudb/pkg/server/servertest"
 	"github.com/spf13/cobra"
 )
 
@@ -38,22 +31,7 @@ func _TestInit(t *testing.T) {
 }
 
 func TestConnect(t *testing.T) {
-	options := server.DefaultOptions().WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
-
-	tkf := cmdtest.RandString()
-	ts := tokenservice.NewFileTokenService().WithTokenFileName(tkf)
-	ic := test.NewClientTest(&test.PasswordReader{
-		Pass: []string{"immudb"},
-	}, ts)
-	ic.Connect(bs.Dialer)
-	ic.Login("immudb")
+	ic := setupTest(t)
 
 	cmd := commandline{
 		config: helper.Config{Name: "immuclient"},

--- a/cmd/immuclient/command/misc_test.go
+++ b/cmd/immuclient/command/misc_test.go
@@ -67,13 +67,9 @@ Connect(bs.Dialer)
 
 	err := cmd.Execute()
 
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !strings.Contains(string(msg), "hash") {
 		t.Fatal(err)
 	}
@@ -113,13 +109,9 @@ Connect(bs.Dialer)
 
 	err := cmd.Execute()
 
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !strings.Contains(string(msg), "Health check OK") {
 		t.Fatal(err)
 	}
@@ -144,9 +136,7 @@ Connect(bs.Dialer)
 		immucl: ic.Imc,
 	}
 	_, err := ic.Imc.CreateDatabase([]string{"mynewdb"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	cmd, _ := cmdl.NewCmd()
 	cmdl.use(cmd)
 	b := bytes.NewBufferString("")
@@ -160,13 +150,9 @@ Connect(bs.Dialer)
 	innercmd.PersistentPreRunE = nil
 
 	err = cmd.Execute()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !strings.Contains(string(msg), "mynewdb") {
 		t.Fatal(string(msg))
 	}

--- a/cmd/immuclient/command/misc_test.go
+++ b/cmd/immuclient/command/misc_test.go
@@ -70,9 +70,7 @@ Connect(bs.Dialer)
 	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
 	require.NoError(t, err)
-	if !strings.Contains(string(msg), "hash") {
-		t.Fatal(err)
-	}
+	require.Contains(t, string(msg), "hash")
 }
 func TestStatus(t *testing.T) {
 	defer os.Remove(".root-")
@@ -112,9 +110,7 @@ Connect(bs.Dialer)
 	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
 	require.NoError(t, err)
-	if !strings.Contains(string(msg), "Health check OK") {
-		t.Fatal(err)
-	}
+	require.Contains(t, string(msg), "Health check OK")
 }
 
 func TestUseDatabase(t *testing.T) {
@@ -153,8 +149,6 @@ Connect(bs.Dialer)
 	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
 	require.NoError(t, err)
-	if !strings.Contains(string(msg), "mynewdb") {
-		t.Fatal(string(msg))
-	}
+	require.Contains(t, string(msg), "mynewdb")
 }
 */

--- a/cmd/immuclient/command/references_test.go
+++ b/cmd/immuclient/command/references_test.go
@@ -70,9 +70,7 @@ Connect(bs.Dialer)
 	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
 	require.NoError(t, err)
-	if !strings.Contains(string(msg), "hash") {
-		t.Fatal(err)
-	}
+	require.Contains(t, string(msg), "hash")
 }
 
 func TestSafeReference(t *testing.T) {
@@ -113,8 +111,6 @@ Connect(bs.Dialer)
 	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
 	require.NoError(t, err)
-	if !strings.Contains(string(msg), "hash") {
-		t.Fatal(err)
-	}
+	require.Contains(t, string(msg), "hash")
 }
 */

--- a/cmd/immuclient/command/references_test.go
+++ b/cmd/immuclient/command/references_test.go
@@ -67,13 +67,9 @@ Connect(bs.Dialer)
 
 	err := cmd.Execute()
 
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !strings.Contains(string(msg), "hash") {
 		t.Fatal(err)
 	}
@@ -114,13 +110,9 @@ Connect(bs.Dialer)
 
 	err := cmd.Execute()
 
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !strings.Contains(string(msg), "hash") {
 		t.Fatal(err)
 	}

--- a/cmd/immuclient/command/scanners_test.go
+++ b/cmd/immuclient/command/scanners_test.go
@@ -72,9 +72,7 @@ Connect(bs.Dialer)
 	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
 	require.NoError(t, err)
-	if !strings.Contains(string(msg), "hash") {
-		t.Fatal(err)
-	}
+	require.Contains(t, string(msg), "hash")
 }
 
 func TestIScan(t *testing.T) {
@@ -114,9 +112,7 @@ Connect(bs.Dialer)
 	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
 	require.NoError(t, err)
-	if !strings.Contains(string(msg), "hash") {
-		t.Fatal(err)
-	}
+	require.Contains(t, string(msg), "hash")
 }
 
 func TestScan(t *testing.T) {
@@ -157,9 +153,7 @@ Connect(bs.Dialer)
 	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
 	require.NoError(t, err)
-	if !strings.Contains(string(msg), "hash") {
-		t.Fatal(err)
-	}
+	require.Contains(t, string(msg), "hash")
 }
 
 func TestCount(t *testing.T) {
@@ -200,8 +194,6 @@ Connect(bs.Dialer)
 	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
 	require.NoError(t, err)
-	if !strings.Contains(string(msg), "1") {
-		t.Fatal(err)
-	}
+	require.Contains(t, string(msg), "1")
 }
 */

--- a/cmd/immuclient/command/scanners_test.go
+++ b/cmd/immuclient/command/scanners_test.go
@@ -69,13 +69,9 @@ Connect(bs.Dialer)
 
 	err := cmd.Execute()
 
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !strings.Contains(string(msg), "hash") {
 		t.Fatal(err)
 	}
@@ -115,13 +111,9 @@ Connect(bs.Dialer)
 
 	err := cmd.Execute()
 
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !strings.Contains(string(msg), "hash") {
 		t.Fatal(err)
 	}
@@ -162,13 +154,9 @@ Connect(bs.Dialer)
 
 	err := cmd.Execute()
 
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !strings.Contains(string(msg), "hash") {
 		t.Fatal(err)
 	}
@@ -209,13 +197,9 @@ Connect(bs.Dialer)
 
 	err := cmd.Execute()
 
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !strings.Contains(string(msg), "1") {
 		t.Fatal(err)
 	}

--- a/cmd/immuclient/command/server_info_test.go
+++ b/cmd/immuclient/command/server_info_test.go
@@ -19,33 +19,14 @@ package immuclient
 import (
 	"bytes"
 	"io/ioutil"
-	"os"
 	"strings"
 	"testing"
 
-	"github.com/codenotary/immudb/cmd/cmdtest"
 	"github.com/codenotary/immudb/cmd/helper"
-	test "github.com/codenotary/immudb/cmd/immuclient/immuclienttest"
-	"github.com/codenotary/immudb/pkg/auth"
-	"github.com/codenotary/immudb/pkg/client/tokenservice"
-	"github.com/codenotary/immudb/pkg/server"
-	"github.com/codenotary/immudb/pkg/server/servertest"
 )
 
 func TestServerInfo(t *testing.T) {
-	options := server.DefaultOptions().WithAuth(true).WithAdminPassword(auth.SysAdminPassword)
-	bs := servertest.NewBufconnServer(options)
-	bs.Start()
-	defer bs.Stop()
-	defer os.RemoveAll(options.Dir)
-
-	tkf := cmdtest.RandString()
-	ts := tokenservice.NewFileTokenService().WithTokenFileName(tkf)
-	ic := test.NewClientTest(&test.PasswordReader{
-		Pass: []string{"immudb"},
-	}, ts)
-	ic.Connect(bs.Dialer)
-	ic.Login("immudb")
+	ic := setupTest(t)
 
 	cmdl := commandline{
 		config: helper.Config{Name: "immuclient"},

--- a/cmd/immuclient/command/server_info_test.go
+++ b/cmd/immuclient/command/server_info_test.go
@@ -19,7 +19,6 @@ package immuclient
 import (
 	"bytes"
 	"io/ioutil"
-	"strings"
 	"testing"
 
 	"github.com/codenotary/immudb/cmd/helper"
@@ -51,7 +50,5 @@ func TestServerInfo(t *testing.T) {
 	require.NoError(t, err)
 
 	rsp := string(msg)
-	if !strings.Contains(rsp, "version:") {
-		t.Fatal(err)
-	}
+	require.Contains(t, rsp, "version:")
 }

--- a/cmd/immuclient/command/server_info_test.go
+++ b/cmd/immuclient/command/server_info_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/codenotary/immudb/cmd/helper"
+	"github.com/stretchr/testify/require"
 )
 
 func TestServerInfo(t *testing.T) {
@@ -44,16 +45,12 @@ func TestServerInfo(t *testing.T) {
 	innercmd.PersistentPreRunE = nil
 
 	err := cmd.Execute()
+	require.NoError(t, err)
 
-	if err != nil {
-		t.Fatal(err)
-	}
 	msg, err := ioutil.ReadAll(b)
-	if err != nil {
-		t.Fatal(err)
-	}
-	rsp := string(msg)
+	require.NoError(t, err)
 
+	rsp := string(msg)
 	if !strings.Contains(rsp, "version:") {
 		t.Fatal(err)
 	}

--- a/cmd/immuclient/command/setcommands_test.go
+++ b/cmd/immuclient/command/setcommands_test.go
@@ -65,13 +65,9 @@ Connect(bs.Dialer)
 
 	err := cmd.Execute()
 
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !strings.Contains(string(msg), "hash") {
 		t.Fatal(err)
 	}
@@ -109,13 +105,9 @@ Connect(bs.Dialer)
 
 	err := cmd.Execute()
 
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !strings.Contains(string(msg), "hash") {
 		t.Fatal(err)
 	}
@@ -153,13 +145,9 @@ Connect(bs.Dialer)
 
 	err := cmd.Execute()
 
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !strings.Contains(string(msg), "hash") {
 		t.Fatal(err)
 	}
@@ -200,9 +188,7 @@ Connect(bs.Dialer)
 
 	err := cmd.Execute()
 
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	cmd.SetArgs([]string{"zadd", "name", "1", "key"})
 
@@ -212,13 +198,9 @@ Connect(bs.Dialer)
 	innercmd.PersistentPreRunE = nil
 
 	err = cmd.Execute()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !strings.Contains(string(msg), "score") {
 		t.Fatal(err)
 	}
@@ -260,9 +242,7 @@ Connect(bs.Dialer)
 
 	err := cmd.Execute()
 
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	cmd.SetArgs([]string{"safezadd", "name", "1", "key"})
 
@@ -272,13 +252,9 @@ Connect(bs.Dialer)
 	innercmd.PersistentPreRunE = nil
 
 	err = cmd.Execute()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !strings.Contains(string(msg), "score") {
 		t.Fatal(err)
 	}

--- a/cmd/immuclient/command/setcommands_test.go
+++ b/cmd/immuclient/command/setcommands_test.go
@@ -68,9 +68,7 @@ Connect(bs.Dialer)
 	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
 	require.NoError(t, err)
-	if !strings.Contains(string(msg), "hash") {
-		t.Fatal(err)
-	}
+	require.Contains(t, string(msg), "hash")
 }
 
 func TestSet(t *testing.T) {
@@ -108,9 +106,7 @@ Connect(bs.Dialer)
 	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
 	require.NoError(t, err)
-	if !strings.Contains(string(msg), "hash") {
-		t.Fatal(err)
-	}
+	require.Contains(t, string(msg), "hash")
 }
 
 func TestSafeset(t *testing.T) {
@@ -148,9 +144,7 @@ Connect(bs.Dialer)
 	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
 	require.NoError(t, err)
-	if !strings.Contains(string(msg), "hash") {
-		t.Fatal(err)
-	}
+	require.Contains(t, string(msg), "hash")
 }
 
 func TestZAdd(t *testing.T) {
@@ -201,9 +195,7 @@ Connect(bs.Dialer)
 	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
 	require.NoError(t, err)
-	if !strings.Contains(string(msg), "score") {
-		t.Fatal(err)
-	}
+	require.Contains(t, string(msg), "score")
 }
 
 func TestSafeZAdd(t *testing.T) {
@@ -255,8 +247,6 @@ Connect(bs.Dialer)
 	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
 	require.NoError(t, err)
-	if !strings.Contains(string(msg), "score") {
-		t.Fatal(err)
-	}
+	require.Contains(t, string(msg), "score")
 }
 */

--- a/cmd/immuclient/command/tamperproofing_test.go
+++ b/cmd/immuclient/command/tamperproofing_test.go
@@ -72,9 +72,7 @@ Connect(bs.Dialer)
 	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
 	require.NoError(t, err)
-	if !strings.Contains(string(msg), "firstRoot") {
-		t.Fatal(err)
-	}
+	require.Contains(t, string(msg), "firstRoot")
 }
 func TestInclusion(t *testing.T) {
 	defer os.Remove(".root-")
@@ -115,8 +113,6 @@ Connect(bs.Dialer)
 	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
 	require.NoError(t, err)
-	if !strings.Contains(string(msg), "verified: true") {
-		t.Fatal(err)
-	}
+	require.Contains(t, string(msg), "verified: true")
 }
 */

--- a/cmd/immuclient/command/tamperproofing_test.go
+++ b/cmd/immuclient/command/tamperproofing_test.go
@@ -57,9 +57,7 @@ Connect(bs.Dialer)
 	b := bytes.NewBufferString("")
 	cmd.SetOut(b)
 	setmsg, err := cmdl.immucl.SafeSet([]string{"key", "value"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	hash := strings.Split(setmsg, "hash:		")[1]
 	hash = hash[:64]
 
@@ -71,13 +69,9 @@ Connect(bs.Dialer)
 	innercmd.PersistentPreRunE = nil
 
 	err = cmd.Execute()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !strings.Contains(string(msg), "firstRoot") {
 		t.Fatal(err)
 	}
@@ -106,9 +100,7 @@ Connect(bs.Dialer)
 	b := bytes.NewBufferString("")
 	cmd.SetOut(b)
 	setmsg, err := cmdl.immucl.SafeSet([]string{"key", "value"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	hash := strings.Split(setmsg, "hash:		")[1]
 	hash = hash[:64]
 
@@ -120,13 +112,9 @@ Connect(bs.Dialer)
 	innercmd.PersistentPreRunE = nil
 
 	err = cmd.Execute()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	msg, err := ioutil.ReadAll(b)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !strings.Contains(string(msg), "verified: true") {
 		t.Fatal(err)
 	}

--- a/cmd/immuclient/immuc/currentstatus_test.go
+++ b/cmd/immuclient/immuc/currentstatus_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/codenotary/immudb/pkg/client/tokenservice"
 	"github.com/codenotary/immudb/pkg/server"
 	"github.com/codenotary/immudb/pkg/server/servertest"
+	"github.com/stretchr/testify/require"
 )
 
 func setupTest(t *testing.T) *test.ClientTest {
@@ -50,9 +51,7 @@ func TestCurrentRoot(t *testing.T) {
 	_, _ = ic.Imc.VerifiedSet([]string{"key", "val"})
 	msg, err := ic.Imc.CurrentState([]string{""})
 
-	if err != nil {
-		t.Fatal("CurrentState fail", err)
-	}
+	require.NoError(t, err, "CurrentState fail")
 	if !strings.Contains(msg, "hash") {
 		t.Fatalf("CurrentState failed: %s", msg)
 	}

--- a/cmd/immuclient/immuc/currentstatus_test.go
+++ b/cmd/immuclient/immuc/currentstatus_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package immuc_test
 
 import (
-	"strings"
 	"testing"
 
 	test "github.com/codenotary/immudb/cmd/immuclient/immuclienttest"
@@ -53,7 +52,5 @@ func TestCurrentRoot(t *testing.T) {
 
 	msg, err := ic.Imc.CurrentState([]string{""})
 	require.NoError(t, err, "CurrentState fail")
-	if !strings.Contains(msg, "hash") {
-		t.Fatalf("CurrentState failed: %s", msg)
-	}
+	require.Contains(t, msg, "hash", "CurrentState failed")
 }

--- a/cmd/immuclient/immuc/currentstatus_test.go
+++ b/cmd/immuclient/immuc/currentstatus_test.go
@@ -48,9 +48,10 @@ func setupTest(t *testing.T) *test.ClientTest {
 func TestCurrentRoot(t *testing.T) {
 	ic := setupTest(t)
 
-	_, _ = ic.Imc.VerifiedSet([]string{"key", "val"})
-	msg, err := ic.Imc.CurrentState([]string{""})
+	_, err := ic.Imc.VerifiedSet([]string{"key", "val"})
+	require.NoError(t, err)
 
+	msg, err := ic.Imc.CurrentState([]string{""})
 	require.NoError(t, err, "CurrentState fail")
 	if !strings.Contains(msg, "hash") {
 		t.Fatalf("CurrentState failed: %s", msg)

--- a/cmd/immuclient/immuc/getcommands_test.go
+++ b/cmd/immuclient/immuc/getcommands_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package immuc_test
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -31,9 +30,7 @@ func TestGetTxByID(t *testing.T) {
 
 	msg, err := ic.Imc.GetTxByID([]string{"1"})
 	require.NoError(t, err, "GetByIndex fail")
-	if !strings.Contains(msg, "hash") {
-		t.Fatalf("GetByIndex failed: %s", msg)
-	}
+	require.Contains(t, msg, "hash", "GetByIndex failed")
 }
 func TestGet(t *testing.T) {
 	ic := setupTest(t)
@@ -43,9 +40,7 @@ func TestGet(t *testing.T) {
 
 	msg, err := ic.Imc.Get([]string{"key"})
 	require.NoError(t, err, "GetKey fail")
-	if !strings.Contains(msg, "value") {
-		t.Fatalf("GetKey failed: %s", msg)
-	}
+	require.Contains(t, msg, "value", "GetKey failed")
 }
 
 func TestVerifiedGet(t *testing.T) {
@@ -56,9 +51,7 @@ func TestVerifiedGet(t *testing.T) {
 
 	msg, err := ic.Imc.VerifiedGet([]string{"key"})
 	require.NoError(t, err, "VerifiedGet fail")
-	if !strings.Contains(msg, "value") {
-		t.Fatalf("VerifiedGet failed: %s", msg)
-	}
+	require.Contains(t, msg, "value", "VerifiedGet failed")
 }
 
 func TestGetByRevision(t *testing.T) {

--- a/cmd/immuclient/immuc/getcommands_test.go
+++ b/cmd/immuclient/immuc/getcommands_test.go
@@ -26,7 +26,8 @@ import (
 func TestGetTxByID(t *testing.T) {
 	ic := setupTest(t)
 
-	_, _ = ic.Imc.VerifiedSet([]string{"key", "val"})
+	_, err := ic.Imc.VerifiedSet([]string{"key", "val"})
+	require.NoError(t, err)
 
 	msg, err := ic.Imc.GetTxByID([]string{"1"})
 	require.NoError(t, err, "GetByIndex fail")
@@ -37,7 +38,9 @@ func TestGetTxByID(t *testing.T) {
 func TestGet(t *testing.T) {
 	ic := setupTest(t)
 
-	_, _ = ic.Imc.Set([]string{"key", "val"})
+	_, err := ic.Imc.Set([]string{"key", "val"})
+	require.NoError(t, err)
+
 	msg, err := ic.Imc.Get([]string{"key"})
 	require.NoError(t, err, "GetKey fail")
 	if !strings.Contains(msg, "value") {
@@ -48,7 +51,9 @@ func TestGet(t *testing.T) {
 func TestVerifiedGet(t *testing.T) {
 	ic := setupTest(t)
 
-	_, _ = ic.Imc.Set([]string{"key", "val"})
+	_, err := ic.Imc.Set([]string{"key", "val"})
+	require.NoError(t, err)
+
 	msg, err := ic.Imc.VerifiedGet([]string{"key"})
 	require.NoError(t, err, "VerifiedGet fail")
 	if !strings.Contains(msg, "value") {

--- a/cmd/immuclient/immuc/getcommands_test.go
+++ b/cmd/immuclient/immuc/getcommands_test.go
@@ -29,9 +29,7 @@ func TestGetTxByID(t *testing.T) {
 	_, _ = ic.Imc.VerifiedSet([]string{"key", "val"})
 
 	msg, err := ic.Imc.GetTxByID([]string{"1"})
-	if err != nil {
-		t.Fatal("GetByIndex fail", err)
-	}
+	require.NoError(t, err, "GetByIndex fail")
 	if !strings.Contains(msg, "hash") {
 		t.Fatalf("GetByIndex failed: %s", msg)
 	}
@@ -41,9 +39,7 @@ func TestGet(t *testing.T) {
 
 	_, _ = ic.Imc.Set([]string{"key", "val"})
 	msg, err := ic.Imc.Get([]string{"key"})
-	if err != nil {
-		t.Fatal("GetKey fail", err)
-	}
+	require.NoError(t, err, "GetKey fail")
 	if !strings.Contains(msg, "value") {
 		t.Fatalf("GetKey failed: %s", msg)
 	}
@@ -54,9 +50,7 @@ func TestVerifiedGet(t *testing.T) {
 
 	_, _ = ic.Imc.Set([]string{"key", "val"})
 	msg, err := ic.Imc.VerifiedGet([]string{"key"})
-	if err != nil {
-		t.Fatal("VerifiedGet fail", err)
-	}
+	require.NoError(t, err, "VerifiedGet fail")
 	if !strings.Contains(msg, "value") {
 		t.Fatalf("VerifiedGet failed: %s", msg)
 	}

--- a/cmd/immuclient/immuc/getcommands_test.go
+++ b/cmd/immuclient/immuc/getcommands_test.go
@@ -17,36 +17,14 @@ limitations under the License.
 package immuc_test
 
 import (
-	"os"
 	"strings"
 	"testing"
 
-	"github.com/codenotary/immudb/cmd/cmdtest"
-	test "github.com/codenotary/immudb/cmd/immuclient/immuclienttest"
-	"github.com/codenotary/immudb/pkg/client/tokenservice"
-	"github.com/codenotary/immudb/pkg/server"
-	"github.com/codenotary/immudb/pkg/server/servertest"
 	"github.com/stretchr/testify/require"
 )
 
 func TestGetTxByID(t *testing.T) {
-
-	options := server.DefaultOptions().WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
-
-	tkf := cmdtest.RandString()
-	ts := tokenservice.NewFileTokenService().WithTokenFileName(tkf)
-	ic := test.NewClientTest(&test.PasswordReader{
-		Pass: []string{"immudb"},
-	}, ts)
-	ic.Connect(bs.Dialer)
-	ic.Login("immudb")
+	ic := setupTest(t)
 
 	_, _ = ic.Imc.VerifiedSet([]string{"key", "val"})
 
@@ -59,23 +37,7 @@ func TestGetTxByID(t *testing.T) {
 	}
 }
 func TestGet(t *testing.T) {
-	defer os.Remove(".state")
-	options := server.DefaultOptions().WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
-
-	tkf := cmdtest.RandString()
-	ts := tokenservice.NewFileTokenService().WithTokenFileName(tkf)
-	ic := test.NewClientTest(&test.PasswordReader{
-		Pass: []string{"immudb"},
-	}, ts)
-	ic.Connect(bs.Dialer)
-	ic.Login("immudb")
+	ic := setupTest(t)
 
 	_, _ = ic.Imc.Set([]string{"key", "val"})
 	msg, err := ic.Imc.Get([]string{"key"})
@@ -88,23 +50,7 @@ func TestGet(t *testing.T) {
 }
 
 func TestVerifiedGet(t *testing.T) {
-	defer os.Remove(".state-")
-	options := server.DefaultOptions().WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
-
-	tkf := cmdtest.RandString()
-	ts := tokenservice.NewFileTokenService().WithTokenFileName(tkf)
-	ic := test.NewClientTest(&test.PasswordReader{
-		Pass: []string{"immudb"},
-	}, ts)
-	ic.Connect(bs.Dialer)
-	ic.Login("immudb")
+	ic := setupTest(t)
 
 	_, _ = ic.Imc.Set([]string{"key", "val"})
 	msg, err := ic.Imc.VerifiedGet([]string{"key"})
@@ -117,23 +63,7 @@ func TestVerifiedGet(t *testing.T) {
 }
 
 func TestGetByRevision(t *testing.T) {
-
-	options := server.DefaultOptions().WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
-
-	tkf := cmdtest.RandString()
-	ts := tokenservice.NewFileTokenService().WithTokenFileName(tkf)
-	ic := test.NewClientTest(&test.PasswordReader{
-		Pass: []string{"immudb"},
-	}, ts)
-	ic.Connect(bs.Dialer)
-	ic.Login("immudb")
+	ic := setupTest(t)
 
 	_, err := ic.Imc.Set([]string{"key", "value1"})
 	require.NoError(t, err)
@@ -172,6 +102,6 @@ func TestGetByRevision(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, msg, "value1")
 
-	msg, err = ic.Imc.Get([]string{"key@notarevision"})
+	_, err = ic.Imc.Get([]string{"key@notarevision"})
 	require.Error(t, err)
 }

--- a/cmd/immuclient/immuc/history_test.go
+++ b/cmd/immuclient/immuc/history_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package immuc_test
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -28,15 +27,11 @@ func TestHistory(t *testing.T) {
 
 	msg, err := ic.Imc.History([]string{"key"})
 	require.NoError(t, err, "History fail")
-	if !strings.Contains(msg, "key not found") {
-		t.Fatalf("History fail %s", msg)
-	}
+	require.Contains(t, msg, "key not found", "History fail")
 
 	_, err = ic.Imc.Set([]string{"key", "value"})
 	require.NoError(t, err, "History fail")
 	msg, err = ic.Imc.History([]string{"key"})
 	require.NoError(t, err, "History fail")
-	if !strings.Contains(msg, "value") {
-		t.Fatalf("History fail %s", msg)
-	}
+	require.Contains(t, msg, "value", "History fail")
 }

--- a/cmd/immuclient/immuc/history_test.go
+++ b/cmd/immuclient/immuc/history_test.go
@@ -19,27 +19,23 @@ package immuc_test
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestHistory(t *testing.T) {
 	ic := setupTest(t)
 
 	msg, err := ic.Imc.History([]string{"key"})
-	if err != nil {
-		t.Fatal("History fail", err)
-	}
+	require.NoError(t, err, "History fail")
 	if !strings.Contains(msg, "key not found") {
 		t.Fatalf("History fail %s", msg)
 	}
 
 	_, err = ic.Imc.Set([]string{"key", "value"})
-	if err != nil {
-		t.Fatal("History fail", err)
-	}
+	require.NoError(t, err, "History fail")
 	msg, err = ic.Imc.History([]string{"key"})
-	if err != nil {
-		t.Fatal("History fail", err)
-	}
+	require.NoError(t, err, "History fail")
 	if !strings.Contains(msg, "value") {
 		t.Fatalf("History fail %s", msg)
 	}

--- a/cmd/immuclient/immuc/history_test.go
+++ b/cmd/immuclient/immuc/history_test.go
@@ -17,35 +17,12 @@ limitations under the License.
 package immuc_test
 
 import (
-	"os"
 	"strings"
 	"testing"
-
-	"github.com/codenotary/immudb/cmd/cmdtest"
-	"github.com/codenotary/immudb/pkg/client/tokenservice"
-
-	test "github.com/codenotary/immudb/cmd/immuclient/immuclienttest"
-	"github.com/codenotary/immudb/pkg/server"
-	"github.com/codenotary/immudb/pkg/server/servertest"
 )
 
 func TestHistory(t *testing.T) {
-	options := server.DefaultOptions().WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
-	tkf := cmdtest.RandString()
-	ts := tokenservice.NewFileTokenService().WithTokenFileName(tkf)
-	ic := test.NewClientTest(&test.PasswordReader{
-		Pass: []string{"immudb"},
-	}, ts)
-	ic.
-		Connect(bs.Dialer)
-	ic.Login("immudb")
+	ic := setupTest(t)
 
 	msg, err := ic.Imc.History([]string{"key"})
 	if err != nil {

--- a/cmd/immuclient/immuc/init_errors_test.go
+++ b/cmd/immuclient/immuc/init_errors_test.go
@@ -24,6 +24,8 @@ import (
 )
 
 func TestInitErrors(t *testing.T) {
+	defer viper.Reset()
+
 	ic := immuc{
 		options: &Options{},
 	}

--- a/cmd/immuclient/immuc/init_test.go
+++ b/cmd/immuclient/immuc/init_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package immuc_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/codenotary/immudb/pkg/client/tokenservice"
@@ -29,20 +28,17 @@ import (
 )
 
 func TestConnect(t *testing.T) {
-	options := server.DefaultOptions().WithAuth(true)
+	options := server.DefaultOptions().WithDir(t.TempDir())
 	bs := servertest.NewBufconnServer(options)
 
 	bs.Start()
 	defer bs.Stop()
 
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
-
 	opts := OptionsFromEnv()
 	opts.GetImmudbClientOptions().
 		WithDialOptions([]grpc.DialOption{
 			grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure(),
-		})
+		}).WithDir(t.TempDir())
 	imc, err := Init(opts)
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/immuclient/immuc/init_test.go
+++ b/cmd/immuclient/immuc/init_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/codenotary/immudb/pkg/client/tokenservice"
+	"github.com/stretchr/testify/require"
 
 	. "github.com/codenotary/immudb/cmd/immuclient/immuc"
 	"github.com/codenotary/immudb/pkg/server"
@@ -40,12 +41,8 @@ func TestConnect(t *testing.T) {
 			grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure(),
 		}).WithDir(t.TempDir())
 	imc, err := Init(opts)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	err = imc.Connect([]string{""})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	imc.WithFileTokenService(tokenservice.NewInmemoryTokenService())
 }

--- a/cmd/immuclient/immuc/login_test.go
+++ b/cmd/immuclient/immuc/login_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/codenotary/immudb/pkg/client/tokenservice"
 	"github.com/codenotary/immudb/pkg/server"
 	"github.com/codenotary/immudb/pkg/server/servertest"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )
 
@@ -47,19 +48,13 @@ func TestLogin(t *testing.T) {
 		WithDir(t.TempDir())
 
 	imc, err := Init(opts)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	err = imc.Connect([]string{""})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	imc.WithFileTokenService(tokenservice.NewInmemoryTokenService())
 
 	msg, err := imc.Login([]string{"immudb"})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !strings.Contains(msg, "Successfully logged in") {
 		t.Fatal("Login error")
 	}
@@ -83,28 +78,20 @@ func TestLogout(t *testing.T) {
 		WithDir(t.TempDir())
 
 	imc, err := Init(opts)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	err = imc.Connect([]string{""})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	imc.WithFileTokenService(tokenservice.NewInmemoryTokenService())
 
 	_, err = imc.Logout([]string{""})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 }
 
 func TestUserList(t *testing.T) {
 	ic := setupTest(t)
 
 	_, err := ic.Imc.UserList([]string{""})
-	if err != nil {
-		t.Fatal("Userlist fail", err)
-	}
+	require.NoError(t, err, "Userlist fail")
 }
 
 func TestUserCreate(t *testing.T) {
@@ -129,9 +116,7 @@ func TestUserCreate(t *testing.T) {
 				ic.Connect(icMain.Dialer)
 
 				msg, err := ic.Imc.UserCreate(args)
-				if err != nil {
-					t.Fatal("TestUserCreate fail", err)
-				}
+				require.NoError(t, err, "TestUserCreate fail")
 				if !strings.Contains(msg, exp) {
 					t.Fatalf("TestUserCreate failed to create user: %s", msg)
 				}
@@ -149,9 +134,7 @@ func TestUserCreate(t *testing.T) {
 				ic.Connect(icMain.Dialer)
 
 				msg, err := ic.Imc.UserCreate(args)
-				if err != nil {
-					t.Fatal("TestUserCreate fail", err)
-				}
+				require.NoError(t, err, "TestUserCreate fail")
 				if !strings.Contains(msg, exp) {
 					t.Fatalf("TestUserCreate failed to create user: %s", msg)
 				}
@@ -169,9 +152,7 @@ func TestUserCreate(t *testing.T) {
 				ic.Connect(icMain.Dialer)
 
 				msg, err := ic.Imc.UserCreate(args)
-				if err != nil {
-					t.Fatal("TestUserCreate fail", err)
-				}
+				require.NoError(t, err, "TestUserCreate fail")
 				if !strings.Contains(msg, exp) {
 					t.Fatalf("TestUserCreate failed to create user: %s", msg)
 				}
@@ -189,9 +170,7 @@ func TestUserCreate(t *testing.T) {
 				ic.Connect(icMain.Dialer)
 
 				msg, err := ic.Imc.UserCreate(args)
-				if err != nil {
-					t.Fatal("TestUserCreate fail", err)
-				}
+				require.NoError(t, err, "TestUserCreate fail")
 				if !strings.Contains(msg, exp) {
 					t.Fatalf("TestUserCreate failed to create user: %s", msg)
 				}
@@ -249,9 +228,7 @@ func TestUserChangePassword(t *testing.T) {
 				}
 				ic.Connect(ic.Dialer)
 				msg, err := ic.Imc.ChangeUserPassword(args)
-				if err != nil {
-					t.Fatal("TestUserChangePassword fail", err)
-				}
+				require.NoError(t, err, "TestUserChangePassword fail")
 				if !strings.Contains(msg, exp) {
 					t.Fatalf("TestUserChangePassword failed to change password: %s", msg)
 				}
@@ -299,9 +276,7 @@ func TestUserSetActive(t *testing.T) {
 	ic.Connect(ic.Dialer)
 
 	_, err := ic.Imc.UserCreate([]string{"myuser", "readwrite", "defaultdb"})
-	if err != nil {
-		t.Fatal("TestUserCreate fail", err)
-	}
+	require.NoError(t, err, "TestUserCreate fail")
 	var userCreateTests = []struct {
 		name     string
 		args     []string
@@ -316,9 +291,7 @@ func TestUserSetActive(t *testing.T) {
 			"user status changed successfully",
 			func(t *testing.T, password string, args []string, exp string) {
 				msg, err := ic.Imc.SetActiveUser(args, true)
-				if err != nil {
-					t.Fatal("SetActiveUser fail", err)
-				}
+				require.NoError(t, err, "SetActiveUser fail")
 				if !strings.Contains(msg, exp) {
 					t.Fatalf("SetActiveUser failed to change status: %s", msg)
 				}
@@ -331,9 +304,7 @@ func TestUserSetActive(t *testing.T) {
 			"user status changed successfully",
 			func(t *testing.T, password string, args []string, exp string) {
 				msg, err := ic.Imc.SetActiveUser(args, false)
-				if err != nil {
-					t.Fatal("Deactivate fail", err)
-				}
+				require.NoError(t, err, "Deactivate fail")
 				if !strings.Contains(msg, exp) {
 					t.Fatalf("Deactivate failed to change status: %s", msg)
 				}
@@ -355,9 +326,7 @@ func TestSetUserPermission(t *testing.T) {
 	}
 	ic.Connect(ic.Dialer)
 	_, err := ic.Imc.UserCreate([]string{"myuser", "readwrite", "defaultdb"})
-	if err != nil {
-		t.Fatal("TestUserCreate fail", err)
-	}
+	require.NoError(t, err, "TestUserCreate fail")
 	var userCreateTests = []struct {
 		name     string
 		args     []string
@@ -372,9 +341,7 @@ func TestSetUserPermission(t *testing.T) {
 			"permission changed successfully",
 			func(t *testing.T, password string, args []string, exp string) {
 				msg, err := ic.Imc.SetUserPermission(args)
-				if err != nil {
-					t.Fatal("SetUserPermission fail", err)
-				}
+				require.NoError(t, err, "SetUserPermission fail")
 				if !strings.Contains(msg, exp) {
 					t.Fatalf("SetUserPermission failed to set user permission: %s", msg)
 				}
@@ -387,9 +354,7 @@ func TestSetUserPermission(t *testing.T) {
 			"permission changed successfully",
 			func(t *testing.T, password string, args []string, exp string) {
 				msg, err := ic.Imc.SetUserPermission(args)
-				if err != nil {
-					t.Fatal("SetUserPermission fail", err)
-				}
+				require.NoError(t, err, "SetUserPermission fail")
 				if !strings.Contains(msg, exp) {
 					t.Fatalf("SetUserPermission failed to set user permission: %s", msg)
 				}
@@ -402,9 +367,7 @@ func TestSetUserPermission(t *testing.T) {
 			"permission changed successfully",
 			func(t *testing.T, password string, args []string, exp string) {
 				msg, err := ic.Imc.SetUserPermission(args)
-				if err != nil {
-					t.Fatal("SetUserPermission fail", err)
-				}
+				require.NoError(t, err, "SetUserPermission fail")
 				if !strings.Contains(msg, exp) {
 					t.Fatalf("SetUserPermission failed to set user permission: %s", msg)
 				}
@@ -417,9 +380,7 @@ func TestSetUserPermission(t *testing.T) {
 			"permission changed successfully",
 			func(t *testing.T, password string, args []string, exp string) {
 				msg, err := ic.Imc.SetUserPermission(args)
-				if err != nil {
-					t.Fatal("SetUserPermission fail", err)
-				}
+				require.NoError(t, err, "SetUserPermission fail")
 				if !strings.Contains(msg, exp) {
 					t.Fatalf("SetUserPermission failed to set user permission: %s", msg)
 				}

--- a/cmd/immuclient/immuc/login_test.go
+++ b/cmd/immuclient/immuc/login_test.go
@@ -17,11 +17,9 @@ limitations under the License.
 package immuc_test
 
 import (
-	"strings"
 	"testing"
 
 	. "github.com/codenotary/immudb/cmd/immuclient/immuc"
-	"github.com/codenotary/immudb/cmd/immuclient/immuclienttest"
 	test "github.com/codenotary/immudb/cmd/immuclient/immuclienttest"
 	"github.com/codenotary/immudb/pkg/client/tokenservice"
 	"github.com/codenotary/immudb/pkg/server"
@@ -42,7 +40,7 @@ func TestLogin(t *testing.T) {
 		WithDialOptions([]grpc.DialOption{
 			grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure(),
 		}).
-		WithPasswordReader(&immuclienttest.PasswordReader{
+		WithPasswordReader(&test.PasswordReader{
 			Pass: []string{"immudb"},
 		}).
 		WithDir(t.TempDir())
@@ -55,9 +53,7 @@ func TestLogin(t *testing.T) {
 
 	msg, err := imc.Login([]string{"immudb"})
 	require.NoError(t, err)
-	if !strings.Contains(msg, "Successfully logged in") {
-		t.Fatal("Login error")
-	}
+	require.Contains(t, msg, "Successfully logged in", "Login error")
 }
 
 func TestLogout(t *testing.T) {
@@ -72,7 +68,7 @@ func TestLogout(t *testing.T) {
 		WithDialOptions([]grpc.DialOption{
 			grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure(),
 		}).
-		WithPasswordReader(&immuclienttest.PasswordReader{
+		WithPasswordReader(&test.PasswordReader{
 			Pass: []string{"immudb"},
 		}).
 		WithDir(t.TempDir())
@@ -117,9 +113,7 @@ func TestUserCreate(t *testing.T) {
 
 				msg, err := ic.Imc.UserCreate(args)
 				require.NoError(t, err, "TestUserCreate fail")
-				if !strings.Contains(msg, exp) {
-					t.Fatalf("TestUserCreate failed to create user: %s", msg)
-				}
+				require.Contains(t, msg, exp, "TestUserCreate failed to create user")
 			},
 		},
 		{
@@ -135,9 +129,7 @@ func TestUserCreate(t *testing.T) {
 
 				msg, err := ic.Imc.UserCreate(args)
 				require.NoError(t, err, "TestUserCreate fail")
-				if !strings.Contains(msg, exp) {
-					t.Fatalf("TestUserCreate failed to create user: %s", msg)
-				}
+				require.Contains(t, msg, exp, "TestUserCreate failed to create user")
 			},
 		},
 		{
@@ -153,9 +145,7 @@ func TestUserCreate(t *testing.T) {
 
 				msg, err := ic.Imc.UserCreate(args)
 				require.NoError(t, err, "TestUserCreate fail")
-				if !strings.Contains(msg, exp) {
-					t.Fatalf("TestUserCreate failed to create user: %s", msg)
-				}
+				require.Contains(t, msg, exp, "TestUserCreate failed to create user")
 			},
 		},
 		{
@@ -171,9 +161,7 @@ func TestUserCreate(t *testing.T) {
 
 				msg, err := ic.Imc.UserCreate(args)
 				require.NoError(t, err, "TestUserCreate fail")
-				if !strings.Contains(msg, exp) {
-					t.Fatalf("TestUserCreate failed to create user: %s", msg)
-				}
+				require.Contains(t, msg, exp, "TestUserCreate failed to create user")
 			},
 		},
 		{
@@ -188,15 +176,8 @@ func TestUserCreate(t *testing.T) {
 				ic.Connect(icMain.Dialer)
 
 				msg, err := ic.Imc.UserCreate(args)
-				if err == nil {
-					t.Fatal("TestUserCreate fail", err)
-				}
-				if !strings.Contains(err.Error(), exp) {
-					t.Fatalf("TestUserCreate failed to create user: %s", err)
-				}
-				if msg != "" {
-					t.Fatalf("TestUserCreate %s", msg)
-				}
+				require.ErrorContains(t, err, exp, "TestUserCreate fail")
+				require.Empty(t, msg)
 			},
 		},
 	}
@@ -229,9 +210,7 @@ func TestUserChangePassword(t *testing.T) {
 				ic.Connect(ic.Dialer)
 				msg, err := ic.Imc.ChangeUserPassword(args)
 				require.NoError(t, err, "TestUserChangePassword fail")
-				if !strings.Contains(msg, exp) {
-					t.Fatalf("TestUserChangePassword failed to change password: %s", msg)
-				}
+				require.Contains(t, msg, exp, "TestUserChangePassword failed to change password")
 			},
 		},
 		{
@@ -251,12 +230,7 @@ func TestUserChangePassword(t *testing.T) {
 				}
 				ic.Connect(ic.Dialer)
 				msg, err := ic.Imc.ChangeUserPassword(args)
-				if err == nil {
-					t.Fatal("TestUserChangePassword fail", err)
-				}
-				if !strings.Contains(err.Error(), exp) {
-					t.Fatalf("TestUserChangePassword failed to change password: %s", msg)
-				}
+				require.ErrorContainsf(t, err, exp, "TestUserChangePassword failed to change password: %s", msg)
 			},
 		},
 	}
@@ -292,9 +266,7 @@ func TestUserSetActive(t *testing.T) {
 			func(t *testing.T, password string, args []string, exp string) {
 				msg, err := ic.Imc.SetActiveUser(args, true)
 				require.NoError(t, err, "SetActiveUser fail")
-				if !strings.Contains(msg, exp) {
-					t.Fatalf("SetActiveUser failed to change status: %s", msg)
-				}
+				require.Contains(t, msg, exp, "SetActiveUser failed to change status")
 			},
 		},
 		{
@@ -305,9 +277,7 @@ func TestUserSetActive(t *testing.T) {
 			func(t *testing.T, password string, args []string, exp string) {
 				msg, err := ic.Imc.SetActiveUser(args, false)
 				require.NoError(t, err, "Deactivate fail")
-				if !strings.Contains(msg, exp) {
-					t.Fatalf("Deactivate failed to change status: %s", msg)
-				}
+				require.Contains(t, msg, exp, "Deactivate failed to change status")
 			},
 		},
 	}
@@ -342,9 +312,7 @@ func TestSetUserPermission(t *testing.T) {
 			func(t *testing.T, password string, args []string, exp string) {
 				msg, err := ic.Imc.SetUserPermission(args)
 				require.NoError(t, err, "SetUserPermission fail")
-				if !strings.Contains(msg, exp) {
-					t.Fatalf("SetUserPermission failed to set user permission: %s", msg)
-				}
+				require.Contains(t, msg, exp, "SetUserPermission failed to set user permission")
 			},
 		},
 		{
@@ -355,9 +323,7 @@ func TestSetUserPermission(t *testing.T) {
 			func(t *testing.T, password string, args []string, exp string) {
 				msg, err := ic.Imc.SetUserPermission(args)
 				require.NoError(t, err, "SetUserPermission fail")
-				if !strings.Contains(msg, exp) {
-					t.Fatalf("SetUserPermission failed to set user permission: %s", msg)
-				}
+				require.Contains(t, msg, exp, "SetUserPermission failed to set user permission")
 			},
 		},
 		{
@@ -368,9 +334,7 @@ func TestSetUserPermission(t *testing.T) {
 			func(t *testing.T, password string, args []string, exp string) {
 				msg, err := ic.Imc.SetUserPermission(args)
 				require.NoError(t, err, "SetUserPermission fail")
-				if !strings.Contains(msg, exp) {
-					t.Fatalf("SetUserPermission failed to set user permission: %s", msg)
-				}
+				require.Contains(t, msg, exp, "SetUserPermission failed to set user permission")
 			},
 		},
 		{
@@ -381,9 +345,7 @@ func TestSetUserPermission(t *testing.T) {
 			func(t *testing.T, password string, args []string, exp string) {
 				msg, err := ic.Imc.SetUserPermission(args)
 				require.NoError(t, err, "SetUserPermission fail")
-				if !strings.Contains(msg, exp) {
-					t.Fatalf("SetUserPermission failed to set user permission: %s", msg)
-				}
+				require.Contains(t, msg, exp, "SetUserPermission failed to set user permission")
 			},
 		},
 	}

--- a/cmd/immuclient/immuc/misc_test.go
+++ b/cmd/immuclient/immuc/misc_test.go
@@ -17,16 +17,15 @@ limitations under the License.
 package immuc_test
 
 import (
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestHealthCheck(t *testing.T) {
 	ic := setupTest(t)
 
-	if msg, err := ic.Imc.HealthCheck(nil); err != nil {
-		t.Fatal("HealthCheck fail", err)
-	} else if !strings.Contains(msg, "Health check OK") {
-		t.Fatalf("HealthCheck failed: %s", msg)
-	}
+	msg, err := ic.Imc.HealthCheck(nil)
+	require.NoError(t, err, "HealthCheck fail")
+	require.Contains(t, msg, "Health check OK")
 }

--- a/cmd/immuclient/immuc/misc_test.go
+++ b/cmd/immuclient/immuc/misc_test.go
@@ -17,34 +17,12 @@ limitations under the License.
 package immuc_test
 
 import (
-	"os"
 	"strings"
 	"testing"
-
-	"github.com/codenotary/immudb/cmd/cmdtest"
-	test "github.com/codenotary/immudb/cmd/immuclient/immuclienttest"
-	"github.com/codenotary/immudb/pkg/client/tokenservice"
-	"github.com/codenotary/immudb/pkg/server"
-	"github.com/codenotary/immudb/pkg/server/servertest"
 )
 
 func TestHealthCheck(t *testing.T) {
-	options := server.DefaultOptions().WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
-
-	tkf := cmdtest.RandString()
-	ts := tokenservice.NewFileTokenService().WithTokenFileName(tkf)
-	ic := test.NewClientTest(&test.PasswordReader{
-		Pass: []string{"immudb"},
-	}, ts)
-	ic.Connect(bs.Dialer)
-	ic.Login("immudb")
+	ic := setupTest(t)
 
 	if msg, err := ic.Imc.HealthCheck(nil); err != nil {
 		t.Fatal("HealthCheck fail", err)

--- a/cmd/immuclient/immuc/references_test.go
+++ b/cmd/immuclient/immuc/references_test.go
@@ -17,35 +17,12 @@ limitations under the License.
 package immuc_test
 
 import (
-	"os"
 	"strings"
 	"testing"
-
-	"github.com/codenotary/immudb/cmd/cmdtest"
-	"github.com/codenotary/immudb/pkg/client/tokenservice"
-
-	test "github.com/codenotary/immudb/cmd/immuclient/immuclienttest"
-	"github.com/codenotary/immudb/pkg/server"
-	"github.com/codenotary/immudb/pkg/server/servertest"
 )
 
 func TestReference(t *testing.T) {
-	options := server.DefaultOptions().WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
-
-	tkf := cmdtest.RandString()
-	ts := tokenservice.NewFileTokenService().WithTokenFileName(tkf)
-	ic := test.NewClientTest(&test.PasswordReader{
-		Pass: []string{"immudb"},
-	}, ts)
-	ic.Connect(bs.Dialer)
-	ic.Login("immudb")
+	ic := setupTest(t)
 
 	_, _ = ic.Imc.Set([]string{"key", "val"})
 
@@ -58,25 +35,10 @@ func TestReference(t *testing.T) {
 	}
 }
 
-func _TestVerifiedSetReference(t *testing.T) {
-	defer os.Remove(".state-")
-	options := server.DefaultOptions().WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
+func TestVerifiedSetReference(t *testing.T) {
+	t.SkipNow()
 
-	bs.Start()
-	defer bs.Stop()
-
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
-
-	tkf := cmdtest.RandString()
-	ts := tokenservice.NewFileTokenService().WithTokenFileName(tkf)
-	ic := test.NewClientTest(&test.PasswordReader{
-		Pass: []string{"immudb"},
-	}, ts)
-	ic.
-		Connect(bs.Dialer)
-	ic.Login("immudb")
+	ic := setupTest(t)
 
 	_, _ = ic.Imc.Set([]string{"key", "val"})
 

--- a/cmd/immuclient/immuc/references_test.go
+++ b/cmd/immuclient/immuc/references_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package immuc_test
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -30,9 +29,7 @@ func TestReference(t *testing.T) {
 
 	msg, err := ic.Imc.SetReference([]string{"val", "key"})
 	require.NoError(t, err, "Reference fail")
-	if !strings.Contains(msg, "value") {
-		t.Fatalf("Reference failed: %s", msg)
-	}
+	require.Contains(t, msg, "value", "Reference failed")
 }
 
 func TestVerifiedSetReference(t *testing.T) {
@@ -44,7 +41,5 @@ func TestVerifiedSetReference(t *testing.T) {
 
 	msg, err := ic.Imc.VerifiedSetReference([]string{"val", "key"})
 	require.NoError(t, err, "SafeReference fail")
-	if !strings.Contains(msg, "hash") {
-		t.Fatalf("SafeReference failed: %s", msg)
-	}
+	require.Contains(t, msg, "hash", "SafeReference failed")
 }

--- a/cmd/immuclient/immuc/references_test.go
+++ b/cmd/immuclient/immuc/references_test.go
@@ -19,6 +19,8 @@ package immuc_test
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestReference(t *testing.T) {
@@ -27,9 +29,7 @@ func TestReference(t *testing.T) {
 	_, _ = ic.Imc.Set([]string{"key", "val"})
 
 	msg, err := ic.Imc.SetReference([]string{"val", "key"})
-	if err != nil {
-		t.Fatal("Reference fail", err)
-	}
+	require.NoError(t, err, "Reference fail")
 	if !strings.Contains(msg, "value") {
 		t.Fatalf("Reference failed: %s", msg)
 	}
@@ -43,9 +43,7 @@ func TestVerifiedSetReference(t *testing.T) {
 	_, _ = ic.Imc.Set([]string{"key", "val"})
 
 	msg, err := ic.Imc.VerifiedSetReference([]string{"val", "key"})
-	if err != nil {
-		t.Fatal("SafeReference fail", err)
-	}
+	require.NoError(t, err, "SafeReference fail")
 	if !strings.Contains(msg, "hash") {
 		t.Fatalf("SafeReference failed: %s", msg)
 	}

--- a/cmd/immuclient/immuc/scanners_test.go
+++ b/cmd/immuclient/immuc/scanners_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package immuc_test
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -34,9 +33,7 @@ func TestZScan(t *testing.T) {
 
 	msg, err := ic.Imc.ZScan([]string{"set"})
 	require.NoError(t, err, "ZScan fail")
-	if !strings.Contains(msg, "value") {
-		t.Fatalf("ZScan failed: %s", msg)
-	}
+	require.Contains(t, msg, "value", "ZScan failed")
 }
 
 func TestIScan(t *testing.T) {
@@ -54,9 +51,7 @@ func TestScan(t *testing.T) {
 
 	msg, err := ic.Imc.Scan([]string{"k"})
 	require.NoError(t, err, "Scan fail")
-	if !strings.Contains(msg, "value") {
-		t.Fatalf("Scan failed: %s", msg)
-	}
+	require.Contains(t, msg, "value", "Scan failed")
 }
 
 func TestCount(t *testing.T) {
@@ -69,7 +64,5 @@ func TestCount(t *testing.T) {
 
 	msg, err := ic.Imc.Count([]string{"key"})
 	require.NoError(t, err, "Count fail")
-	if !strings.Contains(msg, "1") {
-		t.Fatalf("Count failed: %s", msg)
-	}
+	require.Contains(t, msg, "1", "Count failed")
 }

--- a/cmd/immuclient/immuc/scanners_test.go
+++ b/cmd/immuclient/immuc/scanners_test.go
@@ -19,25 +19,21 @@ package immuc_test
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestZScan(t *testing.T) {
 	ic := setupTest(t)
 
 	_, err := ic.Imc.Set([]string{"key", "val"})
-	if err != nil {
-		t.Fatal("Set fail", err)
-	}
+	require.NoError(t, err, "Set fail")
 
 	_, err = ic.Imc.ZAdd([]string{"set", "10.5", "key"})
-	if err != nil {
-		t.Fatal("ZAdd fail", err)
-	}
+	require.NoError(t, err, "ZAdd fail")
 
 	msg, err := ic.Imc.ZScan([]string{"set"})
-	if err != nil {
-		t.Fatal("ZScan fail", err)
-	}
+	require.NoError(t, err, "ZScan fail")
 	if !strings.Contains(msg, "value") {
 		t.Fatalf("ZScan failed: %s", msg)
 	}
@@ -47,23 +43,17 @@ func TestIScan(t *testing.T) {
 	ic := setupTest(t)
 
 	_, err := ic.Imc.VerifiedSet([]string{"key", "val"})
-	if err != nil {
-		t.Fatal("Set fail", err)
-	}
+	require.NoError(t, err, "Set fail")
 }
 
 func TestScan(t *testing.T) {
 	ic := setupTest(t)
 
 	_, err := ic.Imc.Set([]string{"key", "val"})
-	if err != nil {
-		t.Fatal("Set fail", err)
-	}
+	require.NoError(t, err, "Set fail")
 
 	msg, err := ic.Imc.Scan([]string{"k"})
-	if err != nil {
-		t.Fatal("Scan fail", err)
-	}
+	require.NoError(t, err, "Scan fail")
 	if !strings.Contains(msg, "value") {
 		t.Fatalf("Scan failed: %s", msg)
 	}
@@ -75,14 +65,10 @@ func TestCount(t *testing.T) {
 	ic := setupTest(t)
 
 	_, err := ic.Imc.Set([]string{"key", "val"})
-	if err != nil {
-		t.Fatal("Set fail", err)
-	}
+	require.NoError(t, err, "Set fail")
 
 	msg, err := ic.Imc.Count([]string{"key"})
-	if err != nil {
-		t.Fatal("Count fail", err)
-	}
+	require.NoError(t, err, "Count fail")
 	if !strings.Contains(msg, "1") {
 		t.Fatalf("Count failed: %s", msg)
 	}

--- a/cmd/immuclient/immuc/scanners_test.go
+++ b/cmd/immuclient/immuc/scanners_test.go
@@ -17,35 +17,12 @@ limitations under the License.
 package immuc_test
 
 import (
-	"os"
 	"strings"
 	"testing"
-
-	"github.com/codenotary/immudb/cmd/cmdtest"
-	"github.com/codenotary/immudb/pkg/client/tokenservice"
-
-	test "github.com/codenotary/immudb/cmd/immuclient/immuclienttest"
-	"github.com/codenotary/immudb/pkg/server"
-	"github.com/codenotary/immudb/pkg/server/servertest"
 )
 
 func TestZScan(t *testing.T) {
-	options := server.DefaultOptions().WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
-
-	tkf := cmdtest.RandString()
-	ts := tokenservice.NewFileTokenService().WithTokenFileName(tkf)
-	ic := test.NewClientTest(&test.PasswordReader{
-		Pass: []string{"immudb"},
-	}, ts)
-	ic.Connect(bs.Dialer)
-	ic.Login("immudb")
+	ic := setupTest(t)
 
 	_, err := ic.Imc.Set([]string{"key", "val"})
 	if err != nil {
@@ -67,24 +44,8 @@ func TestZScan(t *testing.T) {
 }
 
 func TestIScan(t *testing.T) {
-	defer os.Remove(".state-")
-	options := server.DefaultOptions().WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
+	ic := setupTest(t)
 
-	bs.Start()
-	defer bs.Stop()
-
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
-
-	tkf := cmdtest.RandString()
-	ts := tokenservice.NewFileTokenService().WithTokenFileName(tkf)
-	ic := test.NewClientTest(&test.PasswordReader{
-		Pass: []string{"immudb"},
-	}, ts)
-	ic.
-		Connect(bs.Dialer)
-	ic.Login("immudb")
 	_, err := ic.Imc.VerifiedSet([]string{"key", "val"})
 	if err != nil {
 		t.Fatal("Set fail", err)
@@ -92,23 +53,8 @@ func TestIScan(t *testing.T) {
 }
 
 func TestScan(t *testing.T) {
-	options := server.DefaultOptions().WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
+	ic := setupTest(t)
 
-	bs.Start()
-	defer bs.Stop()
-
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
-
-	tkf := cmdtest.RandString()
-	ts := tokenservice.NewFileTokenService().WithTokenFileName(tkf)
-	ic := test.NewClientTest(&test.PasswordReader{
-		Pass: []string{"immudb"},
-	}, ts)
-	ic.
-		Connect(bs.Dialer)
-	ic.Login("immudb")
 	_, err := ic.Imc.Set([]string{"key", "val"})
 	if err != nil {
 		t.Fatal("Set fail", err)
@@ -123,24 +69,10 @@ func TestScan(t *testing.T) {
 	}
 }
 
-func _TestCount(t *testing.T) {
-	options := server.DefaultOptions().WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
+func TestCount(t *testing.T) {
+	t.SkipNow()
 
-	bs.Start()
-	defer bs.Stop()
-
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
-
-	tkf := cmdtest.RandString()
-	ts := tokenservice.NewFileTokenService().WithTokenFileName(tkf)
-	ic := test.NewClientTest(&test.PasswordReader{
-		Pass: []string{"immudb"},
-	}, ts)
-	ic.
-		Connect(bs.Dialer)
-	ic.Login("immudb")
+	ic := setupTest(t)
 
 	_, err := ic.Imc.Set([]string{"key", "val"})
 	if err != nil {

--- a/cmd/immuclient/immuc/server_info_test.go
+++ b/cmd/immuclient/immuc/server_info_test.go
@@ -1,34 +1,12 @@
 package immuc_test
 
 import (
-	"os"
 	"strings"
 	"testing"
-
-	"github.com/codenotary/immudb/cmd/cmdtest"
-	test "github.com/codenotary/immudb/cmd/immuclient/immuclienttest"
-	"github.com/codenotary/immudb/pkg/client/tokenservice"
-	"github.com/codenotary/immudb/pkg/server"
-	"github.com/codenotary/immudb/pkg/server/servertest"
 )
 
 func TestServerInfo(t *testing.T) {
-	options := server.DefaultOptions().WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
-
-	tkf := cmdtest.RandString()
-	ts := tokenservice.NewFileTokenService().WithTokenFileName(tkf)
-	ic := test.NewClientTest(&test.PasswordReader{
-		Pass: []string{"immudb"},
-	}, ts)
-	ic.Connect(bs.Dialer)
-	ic.Login("immudb")
+	ic := setupTest(t)
 
 	if msg, err := ic.Imc.ServerInfo(nil); err != nil {
 		t.Fatal("ServerInfo fail", err)

--- a/cmd/immuclient/immuc/server_info_test.go
+++ b/cmd/immuclient/immuc/server_info_test.go
@@ -1,16 +1,15 @@
 package immuc_test
 
 import (
-	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestServerInfo(t *testing.T) {
 	ic := setupTest(t)
 
-	if msg, err := ic.Imc.ServerInfo(nil); err != nil {
-		t.Fatal("ServerInfo fail", err)
-	} else if !strings.Contains(msg, "version") {
-		t.Fatalf("ServerInfo failed: %s", msg)
-	}
+	msg, err := ic.Imc.ServerInfo(nil)
+	require.NoError(t, err, "ServerInfo fail")
+	require.Contains(t, msg, "version")
 }

--- a/cmd/immuclient/immuc/setcommands_test.go
+++ b/cmd/immuclient/immuc/setcommands_test.go
@@ -21,6 +21,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func cleanupClientFiles() {
@@ -40,9 +42,7 @@ func TestSet(t *testing.T) {
 
 	msg, err := ic.Imc.Set([]string{"key", "val"})
 
-	if err != nil {
-		t.Fatal("Set fail", err)
-	}
+	require.NoError(t, err, "Set fail")
 	if !strings.Contains(msg, "value") {
 		t.Fatalf("Set failed: %s", msg)
 	}
@@ -52,9 +52,7 @@ func TestVerifiedSet(t *testing.T) {
 
 	msg, err := ic.Imc.VerifiedSet([]string{"key", "val"})
 
-	if err != nil {
-		t.Fatal("VerifiedSet fail", err)
-	}
+	require.NoError(t, err, "VerifiedSet fail")
 	if !strings.Contains(msg, "value") {
 		t.Fatalf("VerifiedSet failed: %s", msg)
 	}
@@ -66,9 +64,7 @@ func TestZAdd(t *testing.T) {
 
 	msg, err := ic.Imc.ZAdd([]string{"val", "1", "key"})
 
-	if err != nil {
-		t.Fatal("ZAdd fail", err)
-	}
+	require.NoError(t, err, "ZAdd fail")
 	if !strings.Contains(msg, "hash") {
 		t.Fatalf("ZAdd failed: %s", msg)
 	}
@@ -80,9 +76,7 @@ func _TestVerifiedZAdd(t *testing.T) {
 
 	msg, err := ic.Imc.VerifiedZAdd([]string{"val", "1", "key"})
 
-	if err != nil {
-		t.Fatal("VerifiedZAdd fail", err)
-	}
+	require.NoError(t, err, "VerifiedZAdd fail")
 	if !strings.Contains(msg, "hash") {
 		t.Fatalf("VerifiedZAdd failed: %s", msg)
 	}
@@ -91,22 +85,16 @@ func TestCreateDatabase(t *testing.T) {
 	ic := setupTest(t)
 
 	msg, err := ic.Imc.CreateDatabase([]string{"newdb"})
-	if err != nil {
-		t.Fatal("CreateDatabase fail", err)
-	}
+	require.NoError(t, err, "CreateDatabase fail")
 	if !strings.Contains(msg, "database successfully created") {
 		t.Fatalf("CreateDatabase failed: %s", msg)
 	}
 
 	_, err = ic.Imc.DatabaseList([]string{})
-	if err != nil {
-		t.Fatal("DatabaseList fail", err)
-	}
+	require.NoError(t, err, "DatabaseList fail")
 
 	msg, err = ic.Imc.UseDatabase([]string{"newdb"})
-	if err != nil {
-		t.Fatal("UseDatabase fail", err)
-	}
+	require.NoError(t, err, "UseDatabase fail")
 	if !strings.Contains(msg, "newdb") {
 		t.Fatalf("UseDatabase failed: %s", msg)
 	}

--- a/cmd/immuclient/immuc/setcommands_test.go
+++ b/cmd/immuclient/immuc/setcommands_test.go
@@ -17,25 +17,11 @@ limitations under the License.
 package immuc_test
 
 import (
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
-
-func cleanupClientFiles() {
-	list, _ := filepath.Glob(".state-*")
-	for _, e := range list {
-		os.Remove(e)
-	}
-
-	list, _ = filepath.Glob(".identity-*")
-	for _, e := range list {
-		os.Remove(e)
-	}
-}
 
 func TestSet(t *testing.T) {
 	ic := setupTest(t)
@@ -47,6 +33,7 @@ func TestSet(t *testing.T) {
 		t.Fatalf("Set failed: %s", msg)
 	}
 }
+
 func TestVerifiedSet(t *testing.T) {
 	ic := setupTest(t)
 
@@ -57,10 +44,12 @@ func TestVerifiedSet(t *testing.T) {
 		t.Fatalf("VerifiedSet failed: %s", msg)
 	}
 }
+
 func TestZAdd(t *testing.T) {
 	ic := setupTest(t)
 
-	_, _ = ic.Imc.VerifiedSet([]string{"key", "val"})
+	_, err := ic.Imc.VerifiedSet([]string{"key", "val"})
+	require.NoError(t, err)
 
 	msg, err := ic.Imc.ZAdd([]string{"val", "1", "key"})
 
@@ -69,10 +58,12 @@ func TestZAdd(t *testing.T) {
 		t.Fatalf("ZAdd failed: %s", msg)
 	}
 }
+
 func _TestVerifiedZAdd(t *testing.T) {
 	ic := setupTest(t)
 
-	_, _ = ic.Imc.VerifiedSet([]string{"key", "val"})
+	_, err := ic.Imc.VerifiedSet([]string{"key", "val"})
+	require.NoError(t, err)
 
 	msg, err := ic.Imc.VerifiedZAdd([]string{"val", "1", "key"})
 
@@ -81,6 +72,7 @@ func _TestVerifiedZAdd(t *testing.T) {
 		t.Fatalf("VerifiedZAdd failed: %s", msg)
 	}
 }
+
 func TestCreateDatabase(t *testing.T) {
 	ic := setupTest(t)
 

--- a/cmd/immuclient/immuc/setcommands_test.go
+++ b/cmd/immuclient/immuc/setcommands_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package immuc_test
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -29,9 +28,7 @@ func TestSet(t *testing.T) {
 	msg, err := ic.Imc.Set([]string{"key", "val"})
 
 	require.NoError(t, err, "Set fail")
-	if !strings.Contains(msg, "value") {
-		t.Fatalf("Set failed: %s", msg)
-	}
+	require.Contains(t, msg, "value", "Set failed")
 }
 
 func TestVerifiedSet(t *testing.T) {
@@ -40,9 +37,7 @@ func TestVerifiedSet(t *testing.T) {
 	msg, err := ic.Imc.VerifiedSet([]string{"key", "val"})
 
 	require.NoError(t, err, "VerifiedSet fail")
-	if !strings.Contains(msg, "value") {
-		t.Fatalf("VerifiedSet failed: %s", msg)
-	}
+	require.Contains(t, msg, "value", "VerifiedSet failed")
 }
 
 func TestZAdd(t *testing.T) {
@@ -54,9 +49,7 @@ func TestZAdd(t *testing.T) {
 	msg, err := ic.Imc.ZAdd([]string{"val", "1", "key"})
 
 	require.NoError(t, err, "ZAdd fail")
-	if !strings.Contains(msg, "hash") {
-		t.Fatalf("ZAdd failed: %s", msg)
-	}
+	require.Contains(t, msg, "hash", "ZAdd failed")
 }
 
 func _TestVerifiedZAdd(t *testing.T) {
@@ -68,9 +61,7 @@ func _TestVerifiedZAdd(t *testing.T) {
 	msg, err := ic.Imc.VerifiedZAdd([]string{"val", "1", "key"})
 
 	require.NoError(t, err, "VerifiedZAdd fail")
-	if !strings.Contains(msg, "hash") {
-		t.Fatalf("VerifiedZAdd failed: %s", msg)
-	}
+	require.Contains(t, msg, "hash", "VerifiedZAdd failed")
 }
 
 func TestCreateDatabase(t *testing.T) {
@@ -78,16 +69,12 @@ func TestCreateDatabase(t *testing.T) {
 
 	msg, err := ic.Imc.CreateDatabase([]string{"newdb"})
 	require.NoError(t, err, "CreateDatabase fail")
-	if !strings.Contains(msg, "database successfully created") {
-		t.Fatalf("CreateDatabase failed: %s", msg)
-	}
+	require.Contains(t, msg, "database successfully created", "CreateDatabase failed")
 
 	_, err = ic.Imc.DatabaseList([]string{})
 	require.NoError(t, err, "DatabaseList fail")
 
 	msg, err = ic.Imc.UseDatabase([]string{"newdb"})
 	require.NoError(t, err, "UseDatabase fail")
-	if !strings.Contains(msg, "newdb") {
-		t.Fatalf("UseDatabase failed: %s", msg)
-	}
+	require.Contains(t, msg, "newdb", "UseDatabase failed")
 }

--- a/cmd/immuclient/immuc/setcommands_test.go
+++ b/cmd/immuclient/immuc/setcommands_test.go
@@ -18,35 +18,25 @@ package immuc_test
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/codenotary/immudb/cmd/cmdtest"
-	"github.com/codenotary/immudb/pkg/client/tokenservice"
-
-	test "github.com/codenotary/immudb/cmd/immuclient/immuclienttest"
-	"github.com/codenotary/immudb/pkg/server"
-	"github.com/codenotary/immudb/pkg/server/servertest"
 )
 
+func cleanupClientFiles() {
+	list, _ := filepath.Glob(".state-*")
+	for _, e := range list {
+		os.Remove(e)
+	}
+
+	list, _ = filepath.Glob(".identity-*")
+	for _, e := range list {
+		os.Remove(e)
+	}
+}
+
 func TestSet(t *testing.T) {
-	options := server.DefaultOptions().WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
-
-	tkf := cmdtest.RandString()
-	ts := tokenservice.NewFileTokenService().WithTokenFileName(tkf)
-	ic := test.NewClientTest(&test.PasswordReader{
-		Pass: []string{"immudb"},
-	}, ts)
-	ic.
-		Connect(bs.Dialer)
-	ic.Login("immudb")
+	ic := setupTest(t)
 
 	msg, err := ic.Imc.Set([]string{"key", "val"})
 
@@ -58,24 +48,7 @@ func TestSet(t *testing.T) {
 	}
 }
 func TestVerifiedSet(t *testing.T) {
-	defer os.Remove(".state-")
-	options := server.DefaultOptions().WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
-
-	tkf := cmdtest.RandString()
-	ts := tokenservice.NewFileTokenService().WithTokenFileName(tkf)
-	ic := test.NewClientTest(&test.PasswordReader{
-		Pass: []string{"immudb"},
-	}, ts)
-	ic.
-		Connect(bs.Dialer)
-	ic.Login("immudb")
+	ic := setupTest(t)
 
 	msg, err := ic.Imc.VerifiedSet([]string{"key", "val"})
 
@@ -87,24 +60,7 @@ func TestVerifiedSet(t *testing.T) {
 	}
 }
 func TestZAdd(t *testing.T) {
-	defer os.Remove(".state-")
-	options := server.DefaultOptions().WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
-
-	tkf := cmdtest.RandString()
-	ts := tokenservice.NewFileTokenService().WithTokenFileName(tkf)
-	ic := test.NewClientTest(&test.PasswordReader{
-		Pass: []string{"immudb"},
-	}, ts)
-	ic.
-		Connect(bs.Dialer)
-	ic.Login("immudb")
+	ic := setupTest(t)
 
 	_, _ = ic.Imc.VerifiedSet([]string{"key", "val"})
 
@@ -118,24 +74,7 @@ func TestZAdd(t *testing.T) {
 	}
 }
 func _TestVerifiedZAdd(t *testing.T) {
-	defer os.Remove(".state-")
-	options := server.DefaultOptions().WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
-
-	tkf := cmdtest.RandString()
-	ts := tokenservice.NewFileTokenService().WithTokenFileName(tkf)
-	ic := test.NewClientTest(&test.PasswordReader{
-		Pass: []string{"immudb"},
-	}, ts)
-	ic.
-		Connect(bs.Dialer)
-	ic.Login("immudb")
+	ic := setupTest(t)
 
 	_, _ = ic.Imc.VerifiedSet([]string{"key", "val"})
 
@@ -149,23 +88,7 @@ func _TestVerifiedZAdd(t *testing.T) {
 	}
 }
 func TestCreateDatabase(t *testing.T) {
-	options := server.DefaultOptions().WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
-
-	tkf := cmdtest.RandString()
-	ts := tokenservice.NewFileTokenService().WithTokenFileName(tkf)
-	ic := test.NewClientTest(&test.PasswordReader{
-		Pass: []string{"immudb"},
-	}, ts)
-	ic.
-		Connect(bs.Dialer)
-	ic.Login("immudb")
+	ic := setupTest(t)
 
 	msg, err := ic.Imc.CreateDatabase([]string{"newdb"})
 	if err != nil {

--- a/cmd/immudb/command/cmd_test.go
+++ b/cmd/immudb/command/cmd_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/codenotary/immudb/pkg/server"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/stretchr/testify/assert"
 )
 
 func DefaultTestOptions() (o *server.Options) {
@@ -58,13 +57,13 @@ func TestImmudbCommandFlagParser(t *testing.T) {
 	cl.setupFlags(cmd, server.DefaultOptions())
 
 	err = viper.BindPFlags(cmd.Flags())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	setupDefaults(server.DefaultOptions())
 
 	_, err = executeCommand(cmd, "--logfile="+o.Logfile)
-	assert.NoError(t, err)
-	assert.Equal(t, o.Logfile, options.Logfile)
+	require.NoError(t, err)
+	require.Equal(t, o.Logfile, options.Logfile)
 }
 
 func TestImmudbCommandFlagParserWrongTLS(t *testing.T) {
@@ -88,13 +87,13 @@ func TestImmudbCommandFlagParserWrongTLS(t *testing.T) {
 	cl.setupFlags(cmd, server.DefaultOptions())
 
 	err = viper.BindPFlags(cmd.Flags())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	setupDefaults(server.DefaultOptions())
 
 	_, err = executeCommand(cmd, "--logfile="+o.Logfile)
 
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 // Priority:
@@ -125,35 +124,35 @@ func TestImmudbCommandFlagParserPriority(t *testing.T) {
 	cl.setupFlags(cmd, server.DefaultOptions())
 
 	err = viper.BindPFlags(cmd.Flags())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	setupDefaults(server.DefaultOptions())
 
 	// 4. config file
 	_, err = executeCommand(cmd)
-	assert.NoError(t, err)
-	assert.Equal(t, "", options.Logfile)
+	require.NoError(t, err)
+	require.Equal(t, "", options.Logfile)
 	// 4-b. config file specified in command line
 	_, err = executeCommand(cmd, "--config=../../../test/immudb.toml")
-	assert.NoError(t, err)
-	assert.Equal(t, "ConfigFileThatsNameIsDeclaredOnTheCommandLine", options.Logfile)
+	require.NoError(t, err)
+	require.Equal(t, "ConfigFileThatsNameIsDeclaredOnTheCommandLine", options.Logfile)
 
 	// 3. env. variables
 	t.Setenv("IMMUDB_LOGFILE", "EnvironmentVars")
 	_, err = executeCommand(cmd)
-	assert.NoError(t, err)
-	assert.Equal(t, "EnvironmentVars", options.Logfile)
+	require.NoError(t, err)
+	require.Equal(t, "EnvironmentVars", options.Logfile)
 
 	// 2. flags
 	_, err = executeCommand(cmd, "--logfile="+o.Logfile)
-	assert.NoError(t, err)
-	assert.Equal(t, o.Logfile, options.Logfile)
+	require.NoError(t, err)
+	require.Equal(t, o.Logfile, options.Logfile)
 
 	// 1. overrides
 	viper.Set("logfile", "override")
 	_, err = executeCommand(cmd, "--logfile="+o.Logfile)
-	assert.NoError(t, err)
-	assert.Equal(t, "override", options.Logfile)
+	require.NoError(t, err)
+	require.Equal(t, "override", options.Logfile)
 }
 
 func executeCommand(root *cobra.Command, args ...string) (output string, err error) {
@@ -180,7 +179,7 @@ func TestImmudb(t *testing.T) {
 
 	immudb := cl.Immudb(&immudbcmdtest.ImmuServerMock{})
 	err := immudb(cmd, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 }
 
@@ -198,7 +197,7 @@ func TestImmudbDetached(t *testing.T) {
 
 	immudb := cl.Immudb(&immudbcmdtest.ImmuServerMock{})
 	err := immudb(cmd, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestImmudbMtls(t *testing.T) {
@@ -218,7 +217,7 @@ func TestImmudbMtls(t *testing.T) {
 
 	immudb := cl.Immudb(&immudbcmdtest.ImmuServerMock{})
 	err := immudb(cmd, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestImmudbLogFile(t *testing.T) {
@@ -235,7 +234,7 @@ func TestImmudbLogFile(t *testing.T) {
 
 	immudb := cl.Immudb(&immudbcmdtest.ImmuServerMock{})
 	err := immudb(cmd, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 type plauncherMock struct{}
@@ -257,7 +256,7 @@ func TestExecute(t *testing.T) {
 		quitCode = q
 	})
 	Execute()
-	assert.Equal(t, quitCode, 1)
+	require.Equal(t, quitCode, 1)
 }
 
 func TestImmudbCommandReplicationFlagsParser(t *testing.T) {
@@ -277,11 +276,11 @@ func TestImmudbCommandReplicationFlagsParser(t *testing.T) {
 	cl.setupFlags(cmd, server.DefaultOptions())
 
 	err = viper.BindPFlags(cmd.Flags())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	setupDefaults(server.DefaultOptions())
 
 	_, err = executeCommand(cmd, "--replication-is-replica")
-	assert.NoError(t, err)
-	assert.True(t, options.ReplicationOptions.IsReplica)
+	require.NoError(t, err)
+	require.True(t, options.ReplicationOptions.IsReplica)
 }

--- a/cmd/immudb/command/cmd_test.go
+++ b/cmd/immudb/command/cmd_test.go
@@ -68,6 +68,8 @@ func TestImmudbCommandFlagParser(t *testing.T) {
 }
 
 func TestImmudbCommandFlagParserWrongTLS(t *testing.T) {
+	defer viper.Reset()
+
 	viper.Set("mtls", true)
 	o := DefaultTestOptions()
 
@@ -93,7 +95,6 @@ func TestImmudbCommandFlagParserWrongTLS(t *testing.T) {
 	_, err = executeCommand(cmd, "--logfile="+o.Logfile)
 
 	assert.Error(t, err)
-	viper.Set("mtls", false)
 }
 
 // Priority:
@@ -102,7 +103,9 @@ func TestImmudbCommandFlagParserWrongTLS(t *testing.T) {
 // 3. env. variables
 // 4. config file
 func TestImmudbCommandFlagParserPriority(t *testing.T) {
+	defer viper.Reset()
 	defer tearDown()
+
 	o := DefaultTestOptions()
 	var options *server.Options
 	var err error
@@ -186,6 +189,8 @@ func TestImmudb(t *testing.T) {
 }
 
 func TestImmudbDetached(t *testing.T) {
+	defer viper.Reset()
+
 	var config string
 	cmd := &cobra.Command{}
 	cmd.Flags().StringVar(&config, "config", "", "test")
@@ -196,10 +201,11 @@ func TestImmudbDetached(t *testing.T) {
 	immudb := cl.Immudb(&immudbcmdtest.ImmuServerMock{})
 	err := immudb(cmd, nil)
 	assert.Nil(t, err)
-	viper.Set("detached", false)
 }
 
 func TestImmudbMtls(t *testing.T) {
+	defer viper.Reset()
+
 	var config string
 	cmd := &cobra.Command{}
 	cmd.Flags().StringVar(&config, "config", "", "test")
@@ -213,10 +219,11 @@ func TestImmudbMtls(t *testing.T) {
 	immudb := cl.Immudb(&immudbcmdtest.ImmuServerMock{})
 	err := immudb(cmd, nil)
 	assert.Nil(t, err)
-	viper.Set("mtls", false)
 }
 
 func TestImmudbLogFile(t *testing.T) {
+	defer viper.Reset()
+
 	var config string
 	cmd := &cobra.Command{}
 	cmd.Flags().StringVar(&config, "config", "", "test")

--- a/cmd/immudb/command/cmd_test.go
+++ b/cmd/immudb/command/cmd_test.go
@@ -58,7 +58,7 @@ func TestImmudbCommandFlagParser(t *testing.T) {
 	cl.setupFlags(cmd, server.DefaultOptions())
 
 	err = viper.BindPFlags(cmd.Flags())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	setupDefaults(server.DefaultOptions())
 
@@ -88,7 +88,7 @@ func TestImmudbCommandFlagParserWrongTLS(t *testing.T) {
 	cl.setupFlags(cmd, server.DefaultOptions())
 
 	err = viper.BindPFlags(cmd.Flags())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	setupDefaults(server.DefaultOptions())
 
@@ -126,7 +126,7 @@ func TestImmudbCommandFlagParserPriority(t *testing.T) {
 	cl.setupFlags(cmd, server.DefaultOptions())
 
 	err = viper.BindPFlags(cmd.Flags())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	setupDefaults(server.DefaultOptions())
 
@@ -184,7 +184,7 @@ func TestImmudb(t *testing.T) {
 
 	immudb := cl.Immudb(&immudbcmdtest.ImmuServerMock{})
 	err := immudb(cmd, nil)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 }
 
@@ -200,7 +200,7 @@ func TestImmudbDetached(t *testing.T) {
 
 	immudb := cl.Immudb(&immudbcmdtest.ImmuServerMock{})
 	err := immudb(cmd, nil)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestImmudbMtls(t *testing.T) {
@@ -218,7 +218,7 @@ func TestImmudbMtls(t *testing.T) {
 
 	immudb := cl.Immudb(&immudbcmdtest.ImmuServerMock{})
 	err := immudb(cmd, nil)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestImmudbLogFile(t *testing.T) {
@@ -234,7 +234,7 @@ func TestImmudbLogFile(t *testing.T) {
 
 	immudb := cl.Immudb(&immudbcmdtest.ImmuServerMock{})
 	err := immudb(cmd, nil)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 type plauncherMock struct{}
@@ -275,7 +275,7 @@ func TestImmudbCommandReplicationFlagsParser(t *testing.T) {
 	cl.setupFlags(cmd, server.DefaultOptions())
 
 	err = viper.BindPFlags(cmd.Flags())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	setupDefaults(server.DefaultOptions())
 

--- a/cmd/immudb/command/commandline_test.go
+++ b/cmd/immudb/command/commandline_test.go
@@ -43,7 +43,7 @@ func TestCommandline_ConfigChain(t *testing.T) {
 	cmd.Flags().StringVar(&c.config.CfgFn, "config", "", "config file")
 	cc := c.ConfigChain(f)
 	err := cc(cmd, []string{})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCommandline_ConfigChainErr(t *testing.T) {

--- a/cmd/immudb/command/root_test.go
+++ b/cmd/immudb/command/root_test.go
@@ -30,7 +30,7 @@ import (
 func TestNewCmd(t *testing.T) {
 	cl := Commandline{}
 	cmd, err := cl.NewRootCmd(server.DefaultServer())
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.IsType(t, &cobra.Command{}, cmd)
 }
 

--- a/cmd/immudb/command/service/service_test.go
+++ b/cmd/immudb/command/service/service_test.go
@@ -71,9 +71,7 @@ func TestCommandLine_ServiceImmudbUninstallRemovingData(t *testing.T) {
 	err := cmd.Execute()
 	assert.NoError(t, err)
 	out, err := ioutil.ReadAll(b)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	assert.Contains(t, string(out), "uninstall")
 }
 
@@ -90,9 +88,7 @@ func TestCommandLine_ServiceImmudbUninstallWithoutRemoveData(t *testing.T) {
 	err := cmd.Execute()
 	assert.NoError(t, err)
 	out, err := ioutil.ReadAll(b)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	assert.Contains(t, string(out), "uninstall")
 }
 

--- a/cmd/immudb/command/service/service_test.go
+++ b/cmd/immudb/command/service/service_test.go
@@ -43,7 +43,7 @@ func TestCommandLine_ServiceImmudbInstall(t *testing.T) {
 	cmd.SetOut(b)
 	cmd.SetArgs([]string{"service", "install"})
 	err := cmd.Execute()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCommandLine_ServiceImmudbUninstallAbortUnintall(t *testing.T) {
@@ -55,7 +55,7 @@ func TestCommandLine_ServiceImmudbUninstallAbortUnintall(t *testing.T) {
 	cld.Service(cmd)
 	cmd.SetArgs([]string{"service", "uninstall"})
 	err := cmd.Execute()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCommandLine_ServiceImmudbUninstallRemovingData(t *testing.T) {
@@ -69,7 +69,7 @@ func TestCommandLine_ServiceImmudbUninstallRemovingData(t *testing.T) {
 	cmd.SetOut(b)
 	cmd.SetArgs([]string{"service", "uninstall"})
 	err := cmd.Execute()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	out, err := ioutil.ReadAll(b)
 	if err != nil {
 		t.Fatal(err)
@@ -88,7 +88,7 @@ func TestCommandLine_ServiceImmudbUninstallWithoutRemoveData(t *testing.T) {
 	cmd.SetOut(b)
 	cmd.SetArgs([]string{"service", "uninstall"})
 	err := cmd.Execute()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	out, err := ioutil.ReadAll(b)
 	if err != nil {
 		t.Fatal(err)
@@ -103,7 +103,7 @@ func TestCommandLine_ServiceImmudbStop(t *testing.T) {
 	cld.Service(cmd)
 	cmd.SetArgs([]string{"service", "stop"})
 	err := cmd.Execute()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCommandLine_ServiceImmudbStart(t *testing.T) {
@@ -113,7 +113,7 @@ func TestCommandLine_ServiceImmudbStart(t *testing.T) {
 	cld.Service(cmd)
 	cmd.SetArgs([]string{"service", "start"})
 	err := cmd.Execute()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCommandLine_ServiceImmudbDelayed(t *testing.T) {
@@ -139,7 +139,7 @@ func TestCommandLine_ServiceImmudbDelayedInner(t *testing.T) {
 	os.Args = []string{"--delayed", "1"}
 	cmd.SetArgs([]string{"service", "stop", "--delayed", "1"})
 	err := cmd.Execute()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCommandLine_ServiceImmudbExtraArgs(t *testing.T) {
@@ -162,7 +162,7 @@ func TestCommandLine_ServiceImmudbRestart(t *testing.T) {
 	cld.Service(cmd)
 	cmd.SetArgs([]string{"service", "restart"})
 	err := cmd.Execute()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCommandLine_ServiceImmudbStatus(t *testing.T) {
@@ -172,7 +172,7 @@ func TestCommandLine_ServiceImmudbStatus(t *testing.T) {
 	cld.Service(cmd)
 	cmd.SetArgs([]string{"service", "status"})
 	err := cmd.Execute()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCommandline_ServiceNewDaemonError(t *testing.T) {
@@ -287,7 +287,7 @@ func TestCommandline_ServiceUninstallIsRunning(t *testing.T) {
 	cld.Service(cmd)
 	cmd.SetArgs([]string{"service", "uninstall"})
 	err := cmd.Execute()
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestCommandline_ServiceUninstallEraseDataError(t *testing.T) {
@@ -317,7 +317,7 @@ func TestCommandline_ServiceUninstallNotWanted(t *testing.T) {
 	cld.Service(cmd)
 	cmd.SetArgs([]string{"service", "uninstall"})
 	err := cmd.Execute()
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 func TestCommandline_ServiceUninstallTerminalError(t *testing.T) {
 	cmd := &cobra.Command{}

--- a/cmd/immutest/command/cmd_test.go
+++ b/cmd/immutest/command/cmd_test.go
@@ -30,6 +30,8 @@ import (
 )
 
 func TestImmutest(t *testing.T) {
+	defer viper.Reset()
+
 	viper.Set("database", "defaultdb")
 	viper.Set("user", "immudb")
 	data := map[string]string{}

--- a/cmd/immutest/immutest_test.go
+++ b/cmd/immutest/immutest_test.go
@@ -32,6 +32,8 @@ import (
 var homedirContent []byte
 
 func TestImmutest(t *testing.T) {
+	defer viper.Reset()
+
 	viper.Set("database", "defaultdb")
 	viper.Set("user", "immudb")
 	data := map[string]string{}

--- a/cmd/sservice/manpageservice_test.go
+++ b/cmd/sservice/manpageservice_test.go
@@ -19,36 +19,40 @@ package sservice
 import (
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
 
-func TestManpageService_InstallManPages(t *testing.T) {
-	rootCmd := &cobra.Command{Use: "test"}
-	versionCmd := &cobra.Command{Use: "version", Run: func(cmd *cobra.Command, args []string) {}}
-	rootCmd.AddCommand(versionCmd)
+func TestManpageService(t *testing.T) {
 
-	mps := manpageService{}
+	manDir := filepath.Join(t.TempDir(), "man_dir_test")
 
-	manDir := "./man_dir_test"
+	t.Run("install", func(t *testing.T) {
+		rootCmd := &cobra.Command{Use: "test"}
+		versionCmd := &cobra.Command{Use: "version", Run: func(cmd *cobra.Command, args []string) {}}
+		rootCmd.AddCommand(versionCmd)
 
-	require.NoError(t, mps.InstallManPages(manDir, "test", rootCmd))
-	manFiles, err := ioutil.ReadDir(manDir)
-	require.NoError(t, err)
-	require.Equal(t, 2, len(manFiles))
-}
+		mps := manpageService{}
 
-func TestManpageService_UninstallManPages(t *testing.T) {
-	mps := manpageService{}
+		require.NoError(t, mps.InstallManPages(manDir, "test", rootCmd))
+		manFiles, err := ioutil.ReadDir(manDir)
+		require.NoError(t, err)
+		require.Equal(t, 2, len(manFiles))
+	})
 
-	manDir := "./man_dir_test"
-	_, err := ioutil.ReadDir(manDir)
+	t.Run("uninstall", func(t *testing.T) {
+		mps := manpageService{}
 
-	require.NoError(t, mps.UninstallManPages(manDir, "test"))
-	manFiles, err := ioutil.ReadDir(manDir)
-	require.NoError(t, err)
-	require.Empty(t, manFiles)
-	os.RemoveAll(manDir)
+		_, err := ioutil.ReadDir(manDir)
+		require.NoError(t, err)
+
+		require.NoError(t, mps.UninstallManPages(manDir, "test"))
+		manFiles, err := ioutil.ReadDir(manDir)
+		require.NoError(t, err)
+		require.Empty(t, manFiles)
+		os.RemoveAll(manDir)
+	})
 }

--- a/cmd/sservice/sservice_unix_test.go
+++ b/cmd/sservice/sservice_unix_test.go
@@ -89,7 +89,7 @@ func TestSservice_NewDaemon(t *testing.T) {
 	mps := manpageService{}
 	ss := sservice{osMock, &servicetest.ConfigServiceMock{}, op, mps}
 	d, err := ss.NewDaemon("test", "", "")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	dc, _ := daem.New("test", "", "")
 	assert.IsType(t, d, dc)
 }
@@ -114,7 +114,7 @@ func TestSservice_InstallSetup_immudb(t *testing.T) {
 	if err != nil {
 		t.Logf("TestSservice_InstallSetup_immudb: %s", err)
 	}
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSservice_UninstallSetup_immudb(t *testing.T) {
@@ -129,7 +129,7 @@ func TestSservice_UninstallSetup_immudb(t *testing.T) {
 	mps := immudbcmdtest.ManpageServiceMock{}
 	ss := sservice{osMock, c, op, mps}
 	err := ss.UninstallSetup("immudb")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSservice_getDefaultExecPath(t *testing.T) {
@@ -148,7 +148,7 @@ func TestSservice_CopyExecInOsDefault(t *testing.T) {
 	mps := manpageService{}
 	ss := sservice{osMock, &servicetest.ConfigServiceMock{}, op, mps}
 	_, err := ss.CopyExecInOsDefault("immutest")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSservice_EraseData_immudb(t *testing.T) {
@@ -160,5 +160,5 @@ func TestSservice_EraseData_immudb(t *testing.T) {
 
 	ss := sservice{osMock, c, op, mps}
 	err := ss.EraseData("immudb")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }

--- a/cmd/sservice/sservice_windows_test.go
+++ b/cmd/sservice/sservice_windows_test.go
@@ -29,7 +29,7 @@ import (
 func TestSserviceWin_NewDaemon(t *testing.T) {
 	ss := NewSService(&Option{})
 	d, err := ss.NewDaemon("test", "", "")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	dc, _ := daem.New("test", "", "")
 	assert.IsType(t, d, dc)
 }

--- a/embedded/ahtree/ahtree_test.go
+++ b/embedded/ahtree/ahtree_test.go
@@ -979,7 +979,8 @@ func BenchmarkAppend(b *testing.B) {
 		WithSyncThld(100_000).
 		WithFileSize(1 << 29)
 
-	tree, _ := Open(b.TempDir(), opts)
+	tree, err := Open(b.TempDir(), opts)
+	require.NoError(b, err)
 
 	var bs [32]byte
 

--- a/embedded/ahtree/ahtree_test.go
+++ b/embedded/ahtree/ahtree_test.go
@@ -986,9 +986,7 @@ func BenchmarkAppend(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < 1_000_000; j++ {
 			_, _, err := tree.Append(bs[:])
-			if err != nil {
-				panic(err)
-			}
+			require.NoError(b, err)
 		}
 	}
 

--- a/embedded/appendable/remoteapp/remote_app_test.go
+++ b/embedded/appendable/remoteapp/remote_app_test.go
@@ -79,7 +79,7 @@ func TestOpenRemoteStorageAppendable(t *testing.T) {
 	require.NoError(t, err)
 
 	err = app.Close()
-	require.Equal(t, multiapp.ErrAlreadyClosed, err)
+	require.ErrorIs(t, err, multiapp.ErrAlreadyClosed)
 }
 
 func TestOpenRemoteStorageAppendableCompression(t *testing.T) {
@@ -88,7 +88,7 @@ func TestOpenRemoteStorageAppendableCompression(t *testing.T) {
 		WithCompresionLevel(appendable.BestCompression)
 
 	app, err := Open(t.TempDir(), "", memory.Open(), opts)
-	require.Equal(t, err, ErrCompressionNotSupported)
+	require.ErrorIs(t, err, ErrCompressionNotSupported)
 	require.Nil(t, app)
 }
 

--- a/embedded/sql/grouped_row_reader_test.go
+++ b/embedded/sql/grouped_row_reader_test.go
@@ -18,7 +18,6 @@ package sql
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/codenotary/immudb/embedded/store"
@@ -26,9 +25,8 @@ import (
 )
 
 func TestGroupedRowReader(t *testing.T) {
-	st, err := store.Open("sqldata_grouped_reader", store.DefaultOptions())
+	st, err := store.Open(t.TempDir(), store.DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("sqldata_grouped_reader")
 
 	engine, err := NewEngine(st, DefaultOptions().WithPrefix(sqlPrefix))
 	require.NoError(t, err)

--- a/embedded/sql/joint_row_reader_test.go
+++ b/embedded/sql/joint_row_reader_test.go
@@ -19,7 +19,6 @@ package sql
 import (
 	"context"
 	"errors"
-	"os"
 	"testing"
 
 	"github.com/codenotary/immudb/embedded/store"
@@ -27,9 +26,8 @@ import (
 )
 
 func TestJointRowReader(t *testing.T) {
-	st, err := store.Open("sqldata_joint_reader", store.DefaultOptions())
+	st, err := store.Open(t.TempDir(), store.DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("sqldata_joint_reader")
 
 	engine, err := NewEngine(st, DefaultOptions().WithPrefix(sqlPrefix))
 	require.NoError(t, err)

--- a/embedded/store/indexer_test.go
+++ b/embedded/store/indexer_test.go
@@ -30,21 +30,13 @@ import (
 )
 
 func TestNewIndexerFailure(t *testing.T) {
-	dir, err := ioutil.TempDir("", "indexertest")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	indexer, err := newIndexer(dir, nil, nil, 0)
+	indexer, err := newIndexer(t.TempDir(), nil, nil, 0)
 	require.Nil(t, indexer)
 	require.ErrorIs(t, err, tbtree.ErrIllegalArguments)
 }
 
 func TestClosedIndexerFailures(t *testing.T) {
-	d, err := ioutil.TempDir("", "indexertest")
-	require.NoError(t, err)
-	defer os.RemoveAll(d)
-
-	store, err := Open(d, DefaultOptions().WithIndexOptions(
+	store, err := Open(t.TempDir(), DefaultOptions().WithIndexOptions(
 		DefaultIndexOptions().WithCompactionThld(1),
 	))
 	require.NoError(t, err)
@@ -88,11 +80,7 @@ func TestClosedIndexerFailures(t *testing.T) {
 }
 
 func TestMaxIndexWaitees(t *testing.T) {
-	d, err := ioutil.TempDir("", "indexertest")
-	require.NoError(t, err)
-	defer os.RemoveAll(d)
-
-	store, err := Open(d, DefaultOptions().WithMaxWaitees(1).WithMaxActiveTransactions(1))
+	store, err := Open(t.TempDir(), DefaultOptions().WithMaxWaitees(1).WithMaxActiveTransactions(1))
 	require.NoError(t, err)
 
 	// Grab errors from waiters
@@ -171,10 +159,7 @@ func TestRestartIndexCornerCases(t *testing.T) {
 		},
 	} {
 		t.Run(c.name, func(t *testing.T) {
-			d, err := ioutil.TempDir("", "indexertest")
-			require.NoError(t, err)
-			defer os.RemoveAll(d)
-
+			d := t.TempDir()
 			store, err := Open(d, DefaultOptions())
 			require.NoError(t, err)
 			defer store.Close()

--- a/embedded/store/key_reader_test.go
+++ b/embedded/store/key_reader_test.go
@@ -18,20 +18,14 @@ package store
 
 import (
 	"encoding/binary"
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestImmudbStoreReader(t *testing.T) {
-	dir, err := ioutil.TempDir("", "data_store_reader")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-
 	opts := DefaultOptions().WithSynced(false).WithMaxConcurrency(4)
-	immuStore, err := Open(dir, opts)
+	immuStore, err := Open(t.TempDir(), opts)
 	require.NoError(t, err)
 
 	defer immuStore.Close()
@@ -92,12 +86,8 @@ func TestImmudbStoreReader(t *testing.T) {
 }
 
 func TestImmudbStoreReaderAsBefore(t *testing.T) {
-	dir, err := ioutil.TempDir("", "data_store_reader_as_before")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-
 	opts := DefaultOptions().WithSynced(false).WithMaxConcurrency(4)
-	immuStore, err := Open(dir, opts)
+	immuStore, err := Open(t.TempDir(), opts)
 	require.NoError(t, err)
 
 	defer immustoreClose(t, immuStore)
@@ -160,12 +150,8 @@ func TestImmudbStoreReaderAsBefore(t *testing.T) {
 }
 
 func TestImmudbStoreReaderWithOffset(t *testing.T) {
-	dir, err := ioutil.TempDir("", "data_store_reader_offset")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-
 	opts := DefaultOptions().WithSynced(false).WithMaxConcurrency(4)
-	immuStore, err := Open(dir, opts)
+	immuStore, err := Open(t.TempDir(), opts)
 	require.NoError(t, err)
 
 	defer immuStore.Close()
@@ -227,12 +213,8 @@ func TestImmudbStoreReaderWithOffset(t *testing.T) {
 }
 
 func TestImmudbStoreReaderAsBeforeWithOffset(t *testing.T) {
-	dir, err := ioutil.TempDir("", "data_store_reader_as_before_offset")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-
 	opts := DefaultOptions().WithSynced(false).WithMaxConcurrency(4)
-	immuStore, err := Open(dir, opts)
+	immuStore, err := Open(t.TempDir(), opts)
 	require.NoError(t, err)
 
 	defer immuStore.Close()

--- a/embedded/store/precommit_buffer_test.go
+++ b/embedded/store/precommit_buffer_test.go
@@ -38,10 +38,10 @@ func TestPrecommitBuffer(t *testing.T) {
 	require.ErrorIs(t, err, ErrIllegalArguments)
 
 	err = b.put(0, sha256.Sum256(nil), 0, 0)
-	require.Equal(t, err, ErrBufferIsFull)
+	require.ErrorIs(t, err, ErrBufferIsFull)
 
 	_, _, _, _, err = b.readAhead(size + 1)
-	require.Equal(t, err, ErrNotEnoughData)
+	require.ErrorIs(t, err, ErrNotEnoughData)
 
 	// reading ahead should not consume entries
 	for it := 0; it < 2; it++ {
@@ -78,7 +78,7 @@ func TestPrecommitBuffer(t *testing.T) {
 	}
 
 	_, _, _, _, err = b.readAhead(0)
-	require.Equal(t, err, ErrNotEnoughData)
+	require.ErrorIs(t, err, ErrNotEnoughData)
 
 	for i := 0; i < size; i++ {
 		err := b.put(uint64(i), sha256.Sum256([]byte{byte(i)}), int64(i*100), i*10)
@@ -86,7 +86,7 @@ func TestPrecommitBuffer(t *testing.T) {
 	}
 
 	err = b.put(0, sha256.Sum256([]byte{byte(0)}), 0, 0)
-	require.Equal(t, err, ErrBufferIsFull)
+	require.ErrorIs(t, err, ErrBufferIsFull)
 }
 
 func TestPrecommitBufferRecedeWriter(t *testing.T) {

--- a/embedded/store/tx_reader_test.go
+++ b/embedded/store/tx_reader_test.go
@@ -113,7 +113,7 @@ func TestWrapAppendableErr(t *testing.T) {
 	require.NoError(t, err)
 
 	err = immuStore.wrapAppendableErr(nil, "anAction")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	unwrappedErr := errors.New("some error")
 	err = immuStore.wrapAppendableErr(unwrappedErr, "anAction")

--- a/embedded/store/tx_reader_test.go
+++ b/embedded/store/tx_reader_test.go
@@ -19,8 +19,6 @@ package store
 import (
 	"encoding/binary"
 	"errors"
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/codenotary/immudb/embedded/appendable/multiapp"
@@ -29,12 +27,8 @@ import (
 )
 
 func TestTxReader(t *testing.T) {
-	dir, err := ioutil.TempDir("", "data_txreader")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-
 	opts := DefaultOptions().WithSynced(false).WithMaxConcurrency(1)
-	immuStore, err := Open(dir, opts)
+	immuStore, err := Open(t.TempDir(), opts)
 	require.NoError(t, err)
 
 	require.NotNil(t, immuStore)
@@ -104,12 +98,8 @@ func TestTxReader(t *testing.T) {
 }
 
 func TestWrapAppendableErr(t *testing.T) {
-	dir, err := ioutil.TempDir("", "data_txreader_wrap_error")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-
 	opts := DefaultOptions().WithSynced(false).WithMaxConcurrency(1)
-	immuStore, err := Open(dir, opts)
+	immuStore, err := Open(t.TempDir(), opts)
 	require.NoError(t, err)
 
 	err = immuStore.wrapAppendableErr(nil, "anAction")

--- a/embedded/store/verification_test.go
+++ b/embedded/store/verification_test.go
@@ -19,8 +19,6 @@ package store
 import (
 	"crypto/sha256"
 	"encoding/binary"
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -55,12 +53,8 @@ func TestVerifyDualProofEdgeCases(t *testing.T) {
 	require.False(t, VerifyDualProof(nil, 0, 0, sha256.Sum256(nil), sha256.Sum256(nil)))
 	require.False(t, VerifyDualProof(&DualProof{}, 0, 0, sha256.Sum256(nil), sha256.Sum256(nil)))
 
-	dir, err := ioutil.TempDir("", "data_dualproof_edge_cases")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-
 	opts := DefaultOptions().WithSynced(false).WithMaxLinearProofLen(0).WithMaxConcurrency(1)
-	immuStore, err := Open(dir, opts)
+	immuStore, err := Open(t.TempDir(), opts)
 	require.NoError(t, err)
 
 	defer immustoreClose(t, immuStore)

--- a/embedded/tbtree/consistency_error_test.go
+++ b/embedded/tbtree/consistency_error_test.go
@@ -3,7 +3,6 @@ package tbtree
 import (
 	"bytes"
 	"encoding/json"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -108,9 +107,8 @@ func TestConsistencyFailure(t *testing.T) {
 	}
 
 	t.Run("no flush", func(t *testing.T) {
-		tbtree, err := Open("test_tree_consistency_error_no_flush", DefaultOptions())
+		tbtree, err := Open(t.TempDir(), DefaultOptions())
 		require.NoError(t, err)
-		defer os.RemoveAll("test_tree_consistency_error_no_flush")
 		defer tbtree.Close()
 
 		for _, d := range dataset {
@@ -127,9 +125,8 @@ func TestConsistencyFailure(t *testing.T) {
 	})
 
 	t.Run("with flush", func(t *testing.T) {
-		tbtree, err := Open("test_tree_consistency_error_with_flush", DefaultOptions())
+		tbtree, err := Open(t.TempDir(), DefaultOptions())
 		require.NoError(t, err)
-		defer os.RemoveAll("test_tree_consistency_error_with_flush")
 		defer tbtree.Close()
 
 		for _, d := range dataset {

--- a/embedded/tbtree/history_reader_test.go
+++ b/embedded/tbtree/history_reader_test.go
@@ -17,16 +17,14 @@ limitations under the License.
 package tbtree
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestHistoryReaderEdgeCases(t *testing.T) {
-	tbtree, err := Open("test_tree_history_edge", DefaultOptions())
+	tbtree, err := Open(t.TempDir(), DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("test_tree_history_edge")
 
 	snapshot, err := tbtree.Snapshot()
 	require.NotNil(t, snapshot)
@@ -65,9 +63,8 @@ func TestHistoryReaderAscendingScan(t *testing.T) {
 
 	opts.WithMaxNodeSize(requiredNodeSize(opts.maxKeySize, opts.maxValueSize))
 
-	tbtree, err := Open("test_tree_history_asc", opts)
+	tbtree, err := Open(t.TempDir(), opts)
 	require.NoError(t, err)
-	defer os.RemoveAll("test_tree_history_asc")
 
 	itCount := 10
 	keyCount := 1000
@@ -119,9 +116,8 @@ func TestHistoryReaderDescendingScan(t *testing.T) {
 
 	opts.WithMaxNodeSize(requiredNodeSize(opts.maxKeySize, opts.maxValueSize))
 
-	tbtree, err := Open("test_tree_history_desc", opts)
+	tbtree, err := Open(t.TempDir(), opts)
 	require.NoError(t, err)
-	defer os.RemoveAll("test_tree_history_desc")
 
 	itCount := 10
 	keyCount := 1000

--- a/embedded/tbtree/reader_test.go
+++ b/embedded/tbtree/reader_test.go
@@ -19,16 +19,14 @@ package tbtree
 import (
 	"bytes"
 	"encoding/binary"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestReaderForEmptyTreeShouldReturnError(t *testing.T) {
-	tbtree, err := Open("test_tree_empty", DefaultOptions())
+	tbtree, err := Open(t.TempDir(), DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("test_tree_empty")
 
 	snapshot, err := tbtree.Snapshot()
 	require.NotNil(t, snapshot)
@@ -46,9 +44,8 @@ func TestReaderForEmptyTreeShouldReturnError(t *testing.T) {
 }
 
 func TestReaderWithInvalidSpec(t *testing.T) {
-	tbtree, err := Open("test_tree_rinv", DefaultOptions())
+	tbtree, err := Open(t.TempDir(), DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("test_tree_rinv")
 
 	snapshot, err := tbtree.Snapshot()
 	require.NotNil(t, snapshot)
@@ -66,9 +63,8 @@ func TestReaderAscendingScan(t *testing.T) {
 
 	opts.WithMaxNodeSize(requiredNodeSize(opts.maxKeySize, opts.maxValueSize))
 
-	tbtree, err := Open("test_tree_rasc", opts)
+	tbtree, err := Open(t.TempDir(), opts)
 	require.NoError(t, err)
-	defer os.RemoveAll("test_tree_rasc")
 
 	monotonicInsertions(t, tbtree, 1, 1000, true)
 
@@ -118,9 +114,8 @@ func TestReaderAscendingScanWithEndingKey(t *testing.T) {
 
 	opts.WithMaxNodeSize(requiredNodeSize(opts.maxKeySize, opts.maxValueSize))
 
-	tbtree, err := Open("test_tree_rasc_ending", opts)
+	tbtree, err := Open(t.TempDir(), opts)
 	require.NoError(t, err)
-	defer os.RemoveAll("test_tree_rasc_ending")
 
 	monotonicInsertions(t, tbtree, 1, 1000, true)
 
@@ -177,9 +172,8 @@ func TestReaderAscendingScanAsBefore(t *testing.T) {
 
 	opts.WithMaxNodeSize(requiredNodeSize(opts.maxKeySize, opts.maxValueSize))
 
-	tbtree, err := Open("test_tree_rasc_as_before", opts)
+	tbtree, err := Open(t.TempDir(), opts)
 	require.NoError(t, err)
-	defer os.RemoveAll("test_tree_rasc_as_before")
 
 	monotonicInsertions(t, tbtree, 1, 1000, true)
 
@@ -230,9 +224,8 @@ func TestReaderAsBefore(t *testing.T) {
 
 	opts.WithMaxNodeSize(requiredNodeSize(opts.maxKeySize, opts.maxValueSize))
 
-	tbtree, err := Open("test_tree_as_before", opts)
+	tbtree, err := Open(t.TempDir(), opts)
 	require.NoError(t, err)
-	defer os.RemoveAll("test_tree_as_before")
 
 	key := []byte{0, 0, 0, 250}
 
@@ -275,9 +268,8 @@ func TestReaderAscendingScanWithoutSeekKey(t *testing.T) {
 
 	opts.WithMaxNodeSize(requiredNodeSize(opts.maxKeySize, opts.maxValueSize))
 
-	tbtree, err := Open("test_tree_rsasc", opts)
+	tbtree, err := Open(t.TempDir(), opts)
 	require.NoError(t, err)
-	defer os.RemoveAll("test_tree_rsasc")
 
 	monotonicInsertions(t, tbtree, 1, 1000, true)
 
@@ -327,9 +319,8 @@ func TestReaderDescendingScan(t *testing.T) {
 
 	opts.WithMaxNodeSize(requiredNodeSize(opts.maxKeySize, opts.maxValueSize))
 
-	tbtree, err := Open("test_tree_rdesc", opts)
+	tbtree, err := Open(t.TempDir(), opts)
 	require.NoError(t, err)
-	defer os.RemoveAll("test_tree_rdesc")
 
 	keyCount := 1024
 	monotonicInsertions(t, tbtree, 1, keyCount, true)
@@ -377,9 +368,8 @@ func TestReaderDescendingScanAsBefore(t *testing.T) {
 
 	opts.WithMaxNodeSize(requiredNodeSize(opts.maxKeySize, opts.maxValueSize))
 
-	tbtree, err := Open("test_tree_rdesc_as_before", opts)
+	tbtree, err := Open(t.TempDir(), opts)
 	require.NoError(t, err)
-	defer os.RemoveAll("test_tree_rdesc_as_before")
 
 	keyCount := 1024
 	monotonicInsertions(t, tbtree, 1, keyCount, true)
@@ -432,9 +422,8 @@ func TestReaderDescendingWithoutSeekKeyScan(t *testing.T) {
 
 	opts.WithMaxNodeSize(requiredNodeSize(opts.maxKeySize, opts.maxValueSize))
 
-	tbtree, err := Open("test_tree_rsdesc", opts)
+	tbtree, err := Open(t.TempDir(), opts)
 	require.NoError(t, err)
-	defer os.RemoveAll("test_tree_rsdesc")
 
 	keyCount := 1024
 	monotonicInsertions(t, tbtree, 1, keyCount, true)
@@ -473,9 +462,9 @@ func TestReaderDescendingWithoutSeekKeyScan(t *testing.T) {
 }
 
 func TestFullScanAscendingOrder(t *testing.T) {
-	tbtree, err := Open("test_tree_asc", DefaultOptions())
+	dir := t.TempDir()
+	tbtree, err := Open(dir, DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("test_tree_asc")
 
 	keyCount := 10000
 	randomInsertions(t, tbtree, keyCount, false)
@@ -483,7 +472,7 @@ func TestFullScanAscendingOrder(t *testing.T) {
 	err = tbtree.Close()
 	require.NoError(t, err)
 
-	tbtree, err = Open("test_tree_asc", DefaultOptions())
+	tbtree, err = Open(dir, DefaultOptions())
 	require.NoError(t, err)
 
 	snapshot, err := tbtree.Snapshot()
@@ -518,9 +507,8 @@ func TestFullScanAscendingOrder(t *testing.T) {
 }
 
 func TestFullScanDescendingOrder(t *testing.T) {
-	tbtree, err := Open("test_tree_desc", DefaultOptions())
+	tbtree, err := Open(t.TempDir(), DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("test_tree_desc")
 
 	keyCount := 10000
 	randomInsertions(t, tbtree, keyCount, false)

--- a/embedded/tbtree/snapshot_test.go
+++ b/embedded/tbtree/snapshot_test.go
@@ -18,7 +18,6 @@ package tbtree
 
 import (
 	"bytes"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -27,11 +26,8 @@ import (
 func TestSnapshotSerialization(t *testing.T) {
 	insertionCountThld := 10_000
 
-	tbtree, err := Open("test_tree_w", DefaultOptions().
-		WithFlushThld(insertionCountThld))
-
+	tbtree, err := Open(t.TempDir(), DefaultOptions().WithFlushThld(insertionCountThld))
 	require.NoError(t, err)
-	defer os.RemoveAll("test_tree_w")
 
 	keyCount := insertionCountThld
 	monotonicInsertions(t, tbtree, 1, keyCount, true)
@@ -93,9 +89,8 @@ func TestSnapshotSerialization(t *testing.T) {
 }
 
 func TestSnapshotClosing(t *testing.T) {
-	tbtree, err := Open("test_tree_closing", DefaultOptions())
+	tbtree, err := Open(t.TempDir(), DefaultOptions())
 	require.NoError(t, err)
-	defer os.RemoveAll("test_tree_closing")
 
 	snapshot, err := tbtree.Snapshot()
 	require.NoError(t, err)
@@ -129,9 +124,8 @@ func TestSnapshotClosing(t *testing.T) {
 }
 
 func TestSnapshotLoadFromFullDump(t *testing.T) {
-	tbtree, err := Open("test_tree_r", DefaultOptions().WithCompactionThld(1).WithDelayDuringCompaction(1))
+	tbtree, err := Open(t.TempDir(), DefaultOptions().WithCompactionThld(1).WithDelayDuringCompaction(1))
 	require.NoError(t, err)
-	defer os.RemoveAll("test_tree_r")
 
 	keyCount := 1_000
 	monotonicInsertions(t, tbtree, 1, keyCount, true)
@@ -152,9 +146,8 @@ func TestSnapshotLoadFromFullDump(t *testing.T) {
 }
 
 func TestSnapshotIsolation(t *testing.T) {
-	tbtree, err := Open("test_tree_snap_isolation", DefaultOptions().WithCompactionThld(1).WithDelayDuringCompaction(1))
+	tbtree, err := Open(t.TempDir(), DefaultOptions().WithCompactionThld(1).WithDelayDuringCompaction(1))
 	require.NoError(t, err)
-	defer os.RemoveAll("test_tree_snap_isolation")
 
 	err = tbtree.Insert([]byte("key1"), []byte("value1"))
 	require.NoError(t, err)

--- a/pkg/api/schema/ops_test.go
+++ b/pkg/api/schema/ops_test.go
@@ -90,7 +90,7 @@ func TestOps_ValidateErrDuplicateZAddNotSupported(t *testing.T) {
 		},
 	}
 	err := aOps.Validate()
-	require.Equal(t, err, ErrDuplicatedZAddNotSupported)
+	require.ErrorIs(t, err, ErrDuplicatedZAddNotSupported)
 }
 
 func TestOps_ValidateErrEmptySet(t *testing.T) {
@@ -98,7 +98,7 @@ func TestOps_ValidateErrEmptySet(t *testing.T) {
 		Operations: []*Op{},
 	}
 	err := aOps.Validate()
-	require.Equal(t, err, ErrEmptySet)
+	require.ErrorIs(t, err, ErrEmptySet)
 }
 
 func TestOps_ValidateErrDuplicate(t *testing.T) {

--- a/pkg/auth/clientinterceptors_test.go
+++ b/pkg/auth/clientinterceptors_test.go
@@ -36,7 +36,7 @@ func TestClientUnaryInterceptor(t *testing.T) {
 		return nil
 	}
 	err := f(context.Background(), "", "", "", nil, invoker)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestClientStreamInterceptor(t *testing.T) {
@@ -48,5 +48,5 @@ func TestClientStreamInterceptor(t *testing.T) {
 		return nil, nil
 	}
 	_, err := f(context.Background(), nil, nil, "", streamer)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }

--- a/pkg/auth/tokenkeys_test.go
+++ b/pkg/auth/tokenkeys_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -47,6 +48,7 @@ func TestDropTokenKeys(t *testing.T) {
 	}
 	evictOldTokenKeyPairs()
 }
+
 func TestDropTokenKeysForCtx(t *testing.T) {
 	u := User{
 		Username: "copperfield",
@@ -54,21 +56,15 @@ func TestDropTokenKeysForCtx(t *testing.T) {
 	}
 	generateKeys("copperfield")
 	token, err := GenerateToken(u, 2, 60)
-	if err != nil {
-		t.Errorf("Error GenerateToken %s", err)
-	}
+	require.NoError(t, err)
 	m := make(map[string][]string)
 	m["authorization"] = []string{token}
 	ctx := metadata.NewIncomingContext(context.Background(), m)
 	js, err := GetLoggedInUser(ctx)
-	if err != nil {
-		t.Errorf("Error GetLoggedInUser %s", err)
-	}
+	require.NoError(t, err)
 	if js.Username != u.Username {
 		t.Errorf("Error GetLoggedInUser usernames do not match")
 	}
 	_, err = DropTokenKeysForCtx(ctx)
-	if err != nil {
-		t.Errorf("Error DropTokenKeysForCtx %s", err)
-	}
+	require.NoError(t, err)
 }

--- a/pkg/auth/tokens_test.go
+++ b/pkg/auth/tokens_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -41,17 +42,13 @@ func TestToken(t *testing.T) {
 		Active:   true,
 	}
 	token, err := GenerateToken(u, 2, 60)
-	if err != nil {
-		t.Errorf("Error GenerateToken %s", err)
-	}
+	require.NoError(t, err)
 	if len(token) == 0 {
 		t.Errorf("Error GenerateToken token length equal to zero")
 	}
 
 	jToken, err := verifyToken(token)
-	if err != nil {
-		t.Errorf("Error verifyToken %s", err)
-	}
+	require.NoError(t, err)
 	if jToken.Username != u.Username {
 		t.Errorf("Token username error %s", jToken.Username)
 	}
@@ -71,9 +68,7 @@ func TestVerifyFromCtx(t *testing.T) {
 		Active:   true,
 	}
 	token, err := GenerateToken(u, 2, 60)
-	if err != nil {
-		t.Errorf("Error GenerateToken %s", err)
-	}
+	require.NoError(t, err)
 	ctx := context.Background()
 	_, err = verifyTokenFromCtx(ctx)
 	if err == nil {
@@ -83,9 +78,7 @@ func TestVerifyFromCtx(t *testing.T) {
 	m["authorization"] = []string{token}
 	newCtx := metadata.NewIncomingContext(ctx, m)
 	js, err := verifyTokenFromCtx(newCtx)
-	if err != nil {
-		t.Errorf("Error verifyTokenFromCtx %s", err)
-	}
+	require.NoError(t, err)
 	if js.Username != u.Username {
 		t.Errorf("Token username error %s", js.Username)
 	}

--- a/pkg/auth/user_test.go
+++ b/pkg/auth/user_test.go
@@ -19,6 +19,8 @@ package auth
 import (
 	"bytes"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestUser(t *testing.T) {
@@ -30,16 +32,12 @@ func TestUser(t *testing.T) {
 	}
 
 	p, err := u.SetPassword(weakPassword)
-	if err != nil {
-		t.Errorf("Error setting password %s", err)
-	}
+	require.NoError(t, err)
 	if !bytes.Equal(p, weakPassword) {
 		t.Errorf("setpassword plain passwords do not match")
 	}
 	err = u.ComparePasswords(weakPassword)
-	if err != nil {
-		t.Errorf("ComparePasswords fail %s", err)
-	}
+	require.NoError(t, err)
 
 	u.GrantPermission("immudb", PermissionR)
 	perm := u.WhichPermission("immudb")

--- a/pkg/client/auditor/auditor_test.go
+++ b/pkg/client/auditor/auditor_test.go
@@ -59,7 +59,7 @@ func TestDefaultAuditor(t *testing.T) {
 		func(string, string, bool, bool, bool, *schema.ImmutableState, *schema.ImmutableState) {},
 		logger.NewSimpleLogger("test", os.Stdout),
 		nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.IsType(t, &defaultAuditor{}, da)
 }
 
@@ -364,13 +364,13 @@ func testDefaultAuditorRunOnDbWithInvalidSignature(t *testing.T, pk *ecdsa.Publi
 		func(string, string, bool, bool, bool, *schema.ImmutableState, *schema.ImmutableState) {},
 		logger.NewSimpleLogger("test", os.Stdout),
 		nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	auditorDone := make(chan struct{}, 2)
 	err = da.Run(time.Duration(10), true, context.TODO().Done(), auditorDone)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	err = da.Run(time.Duration(10), true, context.TODO().Done(), auditorDone)
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestPublishAuditNotification(t *testing.T) {

--- a/pkg/client/cache/history_file_cache_test.go
+++ b/pkg/client/cache/history_file_cache_test.go
@@ -31,9 +31,8 @@ import (
 
 func TestNewHistoryFileCache(t *testing.T) {
 	dir, err := ioutil.TempDir("", "example")
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	fc := NewHistoryFileCache(dir)
 	defer os.RemoveAll(dir)
 	require.IsType(t, &historyFileCache{}, fc)
@@ -41,9 +40,8 @@ func TestNewHistoryFileCache(t *testing.T) {
 
 func TestNewHistoryFileCacheSet(t *testing.T) {
 	dir, err := ioutil.TempDir("", "example")
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	fc := NewHistoryFileCache(dir)
 	defer os.RemoveAll(dir)
 
@@ -63,9 +61,8 @@ func TestNewHistoryFileCacheSet(t *testing.T) {
 
 func TestNewHistoryFileCacheGet(t *testing.T) {
 	dir, err := ioutil.TempDir("", "example")
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	fc := NewHistoryFileCache(dir)
 	defer os.RemoveAll(dir)
 
@@ -76,9 +73,8 @@ func TestNewHistoryFileCacheGet(t *testing.T) {
 
 func TestNewHistoryFileCacheWalk(t *testing.T) {
 	dir, err := ioutil.TempDir("", "example")
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	fc := NewHistoryFileCache(dir)
 	defer os.RemoveAll(dir)
 
@@ -104,9 +100,8 @@ func TestNewHistoryFileCacheWalk(t *testing.T) {
 
 func TestHistoryFileCache_SetError(t *testing.T) {
 	dir, err := ioutil.TempDir("", "example")
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	fc := NewHistoryFileCache(dir)
 	defer os.RemoveAll(dir)
 
@@ -116,9 +111,8 @@ func TestHistoryFileCache_SetError(t *testing.T) {
 
 func TestHistoryFileCache_GetError(t *testing.T) {
 	dir, err := ioutil.TempDir("", "example")
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	fc := NewHistoryFileCache(dir)
 	defer os.RemoveAll(dir)
 
@@ -142,9 +136,8 @@ func TestHistoryFileCache_SetMissingFolder(t *testing.T) {
 
 func TestHistoryFileCache_WalkFolderNotExistsCreated(t *testing.T) {
 	dir, err := ioutil.TempDir("", "history-cache")
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	defer os.RemoveAll(dir)
 
 	notExists := filepath.Join(dir, "not-exists")
@@ -158,9 +151,8 @@ func TestHistoryFileCache_WalkFolderNotExistsCreated(t *testing.T) {
 
 func TestHistoryFileCache_getStatesFileInfosError(t *testing.T) {
 	dir, err := ioutil.TempDir("", "history-cache")
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	defer os.RemoveAll(dir)
 
 	notExists := filepath.Join(dir, "does-not-exist")
@@ -178,9 +170,7 @@ func TestHistoryFileCache_unmarshalRootErr(t *testing.T) {
 func TestHistoryFileCache_unmarshalRootSingleLineErr(t *testing.T) {
 	dbName := "dbt"
 	tmpFile, err := ioutil.TempFile(os.TempDir(), "file-state")
-	if err != nil {
-		log.Fatal("Cannot create temporary file", err)
-	}
+	require.NoError(t, err, "Cannot create temporary file")
 	defer os.Remove(tmpFile.Name())
 	if _, err = tmpFile.Write([]byte(dbName + ":")); err != nil {
 		log.Fatal("Failed to write to temporary file", err)
@@ -193,9 +183,7 @@ func TestHistoryFileCache_unmarshalRootSingleLineErr(t *testing.T) {
 func TestHistoryFileCache_unmarshalRootUnableToDecodeErr(t *testing.T) {
 	dbName := "dbt"
 	tmpFile, err := ioutil.TempFile(os.TempDir(), "file-state")
-	if err != nil {
-		log.Fatal("Cannot create temporary file", err)
-	}
+	require.NoError(t, err, "Cannot create temporary file")
 	defer os.Remove(tmpFile.Name())
 	if _, err = tmpFile.Write([]byte(dbName + ":firstLine")); err != nil {
 		log.Fatal("Failed to write to temporary file", err)
@@ -208,9 +196,7 @@ func TestHistoryFileCache_unmarshalRootUnableToDecodeErr(t *testing.T) {
 func TestHistoryFileCache_unmarshalRootUnmarshalErr(t *testing.T) {
 	dbName := "dbt"
 	tmpFile, err := ioutil.TempFile(os.TempDir(), "file-state")
-	if err != nil {
-		log.Fatal("Cannot create temporary file", err)
-	}
+	require.NoError(t, err, "Cannot create temporary file")
 	defer os.Remove(tmpFile.Name())
 	if _, err = tmpFile.Write([]byte(dbName + ":" + base64.StdEncoding.EncodeToString([]byte("wrong-content")))); err != nil {
 		log.Fatal("Failed to write to temporary file", err)
@@ -222,9 +208,7 @@ func TestHistoryFileCache_unmarshalRootUnmarshalErr(t *testing.T) {
 
 func TestHistoryFileCache_unmarshalRootEmptyFile(t *testing.T) {
 	tmpFile, err := ioutil.TempFile(os.TempDir(), "file-state")
-	if err != nil {
-		log.Fatal("Cannot create temporary file", err)
-	}
+	require.NoError(t, err, "Cannot create temporary file")
 	defer os.Remove(tmpFile.Name())
 	text := []byte("")
 	if _, err = tmpFile.Write(text); err != nil {

--- a/pkg/client/cache/history_file_cache_test.go
+++ b/pkg/client/cache/history_file_cache_test.go
@@ -48,17 +48,17 @@ func TestNewHistoryFileCacheSet(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	err = fc.Set("uuid", "dbName", &schema.ImmutableState{TxId: 1, TxHash: []byte{1}})
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	err = fc.Set("uuid", "dbName", &schema.ImmutableState{TxId: 2, TxHash: []byte{2}})
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	root, err := fc.Get("uuid", "dbName")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.IsType(t, &schema.ImmutableState{}, root)
 
 	_, err = fc.Get("uuid1", "dbName")
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestNewHistoryFileCacheGet(t *testing.T) {
@@ -70,7 +70,7 @@ func TestNewHistoryFileCacheGet(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	root, err := fc.Get("uuid", "dbName")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.IsType(t, &schema.ImmutableState{}, root)
 }
 
@@ -85,7 +85,7 @@ func TestNewHistoryFileCacheWalk(t *testing.T) {
 	iface, err := fc.Walk("uuid", "dbName", func(root *schema.ImmutableState) interface{} {
 		return nil
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.IsType(t, []interface{}{interface{}(nil)}, iface)
 
 	err = fc.Set("uuid", "dbName", &schema.ImmutableState{
@@ -93,12 +93,12 @@ func TestNewHistoryFileCacheWalk(t *testing.T) {
 		TxHash:    []byte(`hash`),
 		Signature: nil,
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	iface, err = fc.Walk("uuid", "dbName", func(root *schema.ImmutableState) interface{} {
 		return nil
 	})
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.IsType(t, []interface{}{interface{}(nil)}, iface)
 }
 
@@ -232,6 +232,6 @@ func TestHistoryFileCache_unmarshalRootEmptyFile(t *testing.T) {
 	}
 	fc := &historyFileCache{}
 	state, err := fc.unmarshalRoot(tmpFile.Name(), "db")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Nil(t, state)
 }

--- a/pkg/client/homedir/homedir_test.go
+++ b/pkg/client/homedir/homedir_test.go
@@ -58,24 +58,32 @@ func TestReadFileFromUserHomeDir(t *testing.T) {
 	content := []byte(`t`)
 	pathToFile := "testfile"
 	user, _ := user.Current()
+
 	_, err := hds.ReadFileFromUserHomeDir(pathToFile)
-	assert.Error(t, err)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+
 	err = hds.WriteFileToUserHomeDir(content, pathToFile)
+	assert.NoError(t, err)
+	defer os.RemoveAll(filepath.Join(user.HomeDir, pathToFile))
+
 	strcontent, err := hds.ReadFileFromUserHomeDir(pathToFile)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, strcontent)
-	os.RemoveAll(filepath.Join(user.HomeDir, pathToFile))
 }
 
 func TestDeleteFileFromUserHomeDir(t *testing.T) {
 	hds := NewHomedirService()
 	content := []byte(`t`)
+
 	pathToFile := "testfile"
 	user, _ := user.Current()
 	err := hds.DeleteFileFromUserHomeDir(pathToFile)
-	assert.Error(t, err)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+
 	err = hds.WriteFileToUserHomeDir(content, pathToFile)
 	assert.NoError(t, err)
+	defer os.RemoveAll(filepath.Join(user.HomeDir, pathToFile))
+
 	err = hds.DeleteFileFromUserHomeDir(pathToFile)
 	assert.NoError(t, err)
 	assert.NoFileExists(t, filepath.Join(user.HomeDir, pathToFile))
@@ -84,17 +92,18 @@ func TestDeleteFileFromUserHomeDir(t *testing.T) {
 func TestWriteDirFileToUserHomeDir(t *testing.T) {
 	hds := NewHomedirService()
 	content := []byte(`t`)
-	pathToFile := "./testfile"
+	pathToFile := filepath.Join(t.TempDir(), "testfile")
+
 	err := hds.WriteFileToUserHomeDir(content, pathToFile)
 	assert.NoError(t, err)
 	assert.FileExists(t, pathToFile)
-	os.RemoveAll(pathToFile)
 }
 
 func TestDirFileExistsInUserHomeDir(t *testing.T) {
 	hds := NewHomedirService()
 	content := []byte(`t`)
-	pathToFile := "./testfile"
+	pathToFile := filepath.Join(t.TempDir(), "testfile")
+
 	exists, err := hds.FileExistsInUserHomeDir(pathToFile)
 	assert.NoError(t, err)
 	assert.False(t, exists)
@@ -105,13 +114,13 @@ func TestDirFileExistsInUserHomeDir(t *testing.T) {
 	exists, err = hds.FileExistsInUserHomeDir(pathToFile)
 	assert.NoError(t, err)
 	assert.True(t, exists)
-	os.RemoveAll(pathToFile)
 }
 
 func TestDirFileFileFromUserHomeDir(t *testing.T) {
 	hds := NewHomedirService()
 	content := []byte(`t`)
-	pathToFile := "./testfile"
+	pathToFile := filepath.Join(t.TempDir(), "testfile")
+
 	_, err := hds.ReadFileFromUserHomeDir(pathToFile)
 	assert.Error(t, err)
 
@@ -121,13 +130,13 @@ func TestDirFileFileFromUserHomeDir(t *testing.T) {
 	strcontent, err := hds.ReadFileFromUserHomeDir(pathToFile)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, strcontent)
-	os.RemoveAll(pathToFile)
 }
 
 func TestDeleteDirFileFromUserHomeDir(t *testing.T) {
 	hds := NewHomedirService()
 	content := []byte(`t`)
-	pathToFile := "./testfile"
+	pathToFile := filepath.Join(t.TempDir(), "testfile")
+
 	err := hds.DeleteFileFromUserHomeDir(pathToFile)
 	assert.Error(t, err)
 

--- a/pkg/client/homedir/homedir_test.go
+++ b/pkg/client/homedir/homedir_test.go
@@ -32,7 +32,7 @@ func TestWriteFileToUserHomeDir(t *testing.T) {
 	user, _ := user.Current()
 	err := hds.WriteFileToUserHomeDir(content, pathToFile)
 	assert.FileExists(t, filepath.Join(user.HomeDir, pathToFile))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	os.RemoveAll(filepath.Join(user.HomeDir, pathToFile))
 }
 
@@ -44,12 +44,12 @@ func TestFileExistsInUserHomeDir(t *testing.T) {
 	user, _ := user.Current()
 	exists, err := hds.FileExistsInUserHomeDir(filepath.Join(user.HomeDir, pathToFile))
 	assert.False(t, exists)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = hds.WriteFileToUserHomeDir(content, pathToFile)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	exists, err = hds.FileExistsInUserHomeDir(pathToFile)
 	assert.True(t, exists)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	os.RemoveAll(filepath.Join(user.HomeDir, pathToFile))
 }
 
@@ -62,8 +62,8 @@ func TestReadFileFromUserHomeDir(t *testing.T) {
 	assert.Error(t, err)
 	err = hds.WriteFileToUserHomeDir(content, pathToFile)
 	strcontent, err := hds.ReadFileFromUserHomeDir(pathToFile)
+	assert.NoError(t, err)
 	assert.NotEmpty(t, strcontent)
-	assert.Nil(t, err)
 	os.RemoveAll(filepath.Join(user.HomeDir, pathToFile))
 }
 
@@ -75,9 +75,9 @@ func TestDeleteFileFromUserHomeDir(t *testing.T) {
 	err := hds.DeleteFileFromUserHomeDir(pathToFile)
 	assert.Error(t, err)
 	err = hds.WriteFileToUserHomeDir(content, pathToFile)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	err = hds.DeleteFileFromUserHomeDir(pathToFile)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NoFileExists(t, filepath.Join(user.HomeDir, pathToFile))
 }
 
@@ -86,8 +86,8 @@ func TestWriteDirFileToUserHomeDir(t *testing.T) {
 	content := []byte(`t`)
 	pathToFile := "./testfile"
 	err := hds.WriteFileToUserHomeDir(content, pathToFile)
+	assert.NoError(t, err)
 	assert.FileExists(t, pathToFile)
-	assert.Nil(t, err)
 	os.RemoveAll(pathToFile)
 }
 
@@ -96,13 +96,15 @@ func TestDirFileExistsInUserHomeDir(t *testing.T) {
 	content := []byte(`t`)
 	pathToFile := "./testfile"
 	exists, err := hds.FileExistsInUserHomeDir(pathToFile)
+	assert.NoError(t, err)
 	assert.False(t, exists)
-	assert.Nil(t, err)
+
 	err = hds.WriteFileToUserHomeDir(content, pathToFile)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
+
 	exists, err = hds.FileExistsInUserHomeDir(pathToFile)
+	assert.NoError(t, err)
 	assert.True(t, exists)
-	assert.Nil(t, err)
 	os.RemoveAll(pathToFile)
 }
 
@@ -112,11 +114,13 @@ func TestDirFileFileFromUserHomeDir(t *testing.T) {
 	pathToFile := "./testfile"
 	_, err := hds.ReadFileFromUserHomeDir(pathToFile)
 	assert.Error(t, err)
+
 	err = hds.WriteFileToUserHomeDir(content, pathToFile)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
+
 	strcontent, err := hds.ReadFileFromUserHomeDir(pathToFile)
+	assert.NoError(t, err)
 	assert.NotEmpty(t, strcontent)
-	assert.Nil(t, err)
 	os.RemoveAll(pathToFile)
 }
 
@@ -126,9 +130,11 @@ func TestDeleteDirFileFromUserHomeDir(t *testing.T) {
 	pathToFile := "./testfile"
 	err := hds.DeleteFileFromUserHomeDir(pathToFile)
 	assert.Error(t, err)
+
 	err = hds.WriteFileToUserHomeDir(content, pathToFile)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
+
 	err = hds.DeleteFileFromUserHomeDir(pathToFile)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NoFileExists(t, pathToFile)
 }

--- a/pkg/client/state/state_service_test.go
+++ b/pkg/client/state/state_service_test.go
@@ -41,17 +41,17 @@ func TestStateService(t *testing.T) {
 	uuidProvider := NewUUIDProvider(ic)
 
 	rs, err := NewStateService(cache, logger, stateProvider, uuidProvider)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	state, err := rs.GetState(context.TODO(), "db1")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.IsType(t, &schema.ImmutableState{}, state)
 
 	err = rs.SetState(&schema.ImmutableState{}, "db1")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	state, err = rs.GetState(context.TODO(), "db1")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.IsType(t, &schema.ImmutableState{}, state)
 }
 

--- a/pkg/client/streams_integration_test.go
+++ b/pkg/client/streams_integration_test.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"strconv"
 	"strings"
@@ -76,9 +75,7 @@ func TestImmuServer_SimpleSetGetStream(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 
 	kvs, err := streamutils.GetKeyValuesFromFiles(tmpFile.Name())
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	metaTx, err := cli.StreamSet(ctx, kvs)
 	require.NoError(t, err)
@@ -95,14 +92,10 @@ func TestImmuServer_SimpleSetGetManagedStream(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 
 	kvs, err := streamutils.GetKeyValuesFromFiles(tmpFile.Name())
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	s, err := cli.streamSet(ctx)
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	kvss := stream.NewKvStreamSender(stream.NewMsgSender(s, cli.Options.StreamChunkSize))
 
@@ -118,9 +111,7 @@ func TestImmuServer_MultiSetGetManagedStream(t *testing.T) {
 	cli, ctx := externalImmudbClient(t)
 
 	s1, err := cli.streamSet(ctx)
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	kvs := stream.NewKvStreamSender(stream.NewMsgSender(s1, cli.Options.StreamChunkSize))
 
@@ -146,9 +137,7 @@ func TestImmuServer_MultiSetGetManagedStream(t *testing.T) {
 	require.IsType(t, &schema.TxHeader{}, txhdr)
 
 	s2, err := cli.streamSet(ctx)
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	kvs2 := stream.NewKvStreamSender(stream.NewMsgSender(s2, cli.Options.StreamChunkSize))
 
@@ -174,9 +163,7 @@ func TestImmuServer_MultiSetGetManagedStream(t *testing.T) {
 	require.IsType(t, &schema.TxHeader{}, txhdr)
 
 	s3, err := cli.streamSet(ctx)
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	kvs3 := stream.NewKvStreamSender(stream.NewMsgSender(s3, cli.Options.StreamChunkSize))
 

--- a/pkg/client/streams_verified_integration_test.go
+++ b/pkg/client/streams_verified_integration_test.go
@@ -37,9 +37,7 @@ func TestImmuServer_StreamVerifiedSetAndGet(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 
 	kvs, err := streamutils.GetKeyValuesFromFiles(tmpFile.Name())
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	txMeta, err := cliIF.StreamVerifiedSet(ctx, kvs)
 	require.NoError(t, err)

--- a/pkg/client/timestamp/timestamp_test.go
+++ b/pkg/client/timestamp/timestamp_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestDefault(t *testing.T) {
 	def, err := NewDefaultTimestamp()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.IsType(t, def, &timestampDefault{})
 	ts := def.Now()
 	assert.IsType(t, ts, time.Time{})

--- a/pkg/client/tokenservice/token_service_test.go
+++ b/pkg/client/tokenservice/token_service_test.go
@@ -18,6 +18,7 @@ package tokenservice
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/codenotary/immudb/pkg/client/homedir"
@@ -26,7 +27,7 @@ import (
 )
 
 func TestTokenSevice_setToken(t *testing.T) {
-	fn := "deleteme"
+	fn := filepath.Join(t.TempDir(), "token")
 	ts := file{tokenFileName: fn, hds: homedir.NewHomedirService()}
 	err := ts.SetToken("db1", "")
 	require.Equal(t, ErrEmptyTokenProvided, err)
@@ -42,7 +43,7 @@ func TestTokenSevice_setToken(t *testing.T) {
 }
 
 func TestTokenService_IsTokenPresent(t *testing.T) {
-	fn := "deleteme"
+	fn := filepath.Join(t.TempDir(), "token")
 	ts := file{tokenFileName: fn, hds: homedir.NewHomedirService()}
 	err := ts.SetToken("db1", "toooooken")
 	require.NoError(t, err)
@@ -52,7 +53,7 @@ func TestTokenService_IsTokenPresent(t *testing.T) {
 }
 
 func TestTokenService_DeleteToken(t *testing.T) {
-	fn := "deleteme"
+	fn := filepath.Join(t.TempDir(), "token")
 	ts := file{tokenFileName: fn, hds: homedir.NewHomedirService()}
 	err := ts.SetToken("db1", "toooooken")
 	require.NoError(t, err)

--- a/pkg/client/tokenservice/token_service_test.go
+++ b/pkg/client/tokenservice/token_service_test.go
@@ -31,12 +31,12 @@ func TestTokenSevice_setToken(t *testing.T) {
 	err := ts.SetToken("db1", "")
 	require.Equal(t, ErrEmptyTokenProvided, err)
 	err = ts.SetToken("db1", "toooooken")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	database, err := ts.GetDatabase()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, "db1", database)
 	token, err := ts.GetToken()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, "toooooken", token)
 	os.Remove(fn)
 }
@@ -45,9 +45,9 @@ func TestTokenService_IsTokenPresent(t *testing.T) {
 	fn := "deleteme"
 	ts := file{tokenFileName: fn, hds: homedir.NewHomedirService()}
 	err := ts.SetToken("db1", "toooooken")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	ok, err := ts.IsTokenPresent()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.True(t, ok)
 }
 
@@ -55,7 +55,7 @@ func TestTokenService_DeleteToken(t *testing.T) {
 	fn := "deleteme"
 	ts := file{tokenFileName: fn, hds: homedir.NewHomedirService()}
 	err := ts.SetToken("db1", "toooooken")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	err = ts.DeleteToken()
-	require.Nil(t, err)
+	require.NoError(t, err)
 }

--- a/pkg/database/all_ops_test.go
+++ b/pkg/database/all_ops_test.go
@@ -75,8 +75,7 @@ func execAll(db DB, req *schema.ExecAllRequest, timeout time.Duration) error {
 }
 
 func TestConcurrentCompactIndex(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	done := make(chan struct{})
 	ack := make(chan struct{})
@@ -137,8 +136,7 @@ func TestConcurrentCompactIndex(t *testing.T) {
 }
 
 func TestSetBatch(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	batchSize := 100
 
@@ -192,8 +190,7 @@ func TestSetBatch(t *testing.T) {
 }
 
 func TestSetBatchInvalidKvKey(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	_, err := db.Set(&schema.SetRequest{
 		KVs: []*schema.KeyValue{
@@ -206,8 +203,7 @@ func TestSetBatchInvalidKvKey(t *testing.T) {
 }
 
 func TestSetBatchDuplicatedKey(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	_, err := db.Set(&schema.SetRequest{
 		KVs: []*schema.KeyValue{
@@ -225,8 +221,7 @@ func TestSetBatchDuplicatedKey(t *testing.T) {
 }
 
 func TestExecAllOps(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	_, err := db.ExecAll(nil)
 	require.Equal(t, store.ErrIllegalArguments, err)
@@ -291,8 +286,7 @@ func TestExecAllOps(t *testing.T) {
 }
 
 func TestExecAllOpsZAddOnMixedAlreadyPersitedNotPersistedItems(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	idx, _ := db.Set(&schema.SetRequest{
 		KVs: []*schema.KeyValue{
@@ -351,8 +345,7 @@ func TestExecAllOpsZAddOnMixedAlreadyPersitedNotPersistedItems(t *testing.T) {
 }
 
 func TestExecAllOpsEmptyList(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	aOps := &schema.ExecAllRequest{
 		Operations: []*schema.Op{},
@@ -362,8 +355,7 @@ func TestExecAllOpsEmptyList(t *testing.T) {
 }
 
 func TestExecAllOpsInvalidKvKey(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	aOps := &schema.ExecAllRequest{
 		Operations: []*schema.Op{
@@ -448,8 +440,7 @@ func TestExecAllOpsInvalidKvKey(t *testing.T) {
 }
 
 func TestExecAllOpsZAddKeyNotFound(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	aOps := &schema.ExecAllRequest{
 		Operations: []*schema.Op{
@@ -471,8 +462,7 @@ func TestExecAllOpsZAddKeyNotFound(t *testing.T) {
 }
 
 func TestExecAllOpsNilElementFound(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	bOps := make([]*schema.Op, 1)
 	bOps[0] = &schema.Op{
@@ -490,8 +480,7 @@ func TestExecAllOpsNilElementFound(t *testing.T) {
 }
 
 func TestSetOperationNilElementFound(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	aOps := &schema.ExecAllRequest{
 		Operations: []*schema.Op{
@@ -505,8 +494,7 @@ func TestSetOperationNilElementFound(t *testing.T) {
 }
 
 func TestExecAllOpsUnexpectedType(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	aOps := &schema.ExecAllRequest{
 		Operations: []*schema.Op{
@@ -520,8 +508,7 @@ func TestExecAllOpsUnexpectedType(t *testing.T) {
 }
 
 func TestExecAllOpsDuplicatedKey(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	aOps := &schema.ExecAllRequest{
 		Operations: []*schema.Op{
@@ -557,8 +544,7 @@ func TestExecAllOpsDuplicatedKey(t *testing.T) {
 }
 
 func TestExecAllOpsDuplicatedKeyZAdd(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	aOps := &schema.ExecAllRequest{
 		Operations: []*schema.Op{
@@ -594,8 +580,7 @@ func TestExecAllOpsDuplicatedKeyZAdd(t *testing.T) {
 }
 
 func TestStore_ExecAllOpsConcurrent(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	wg := sync.WaitGroup{}
 	wg.Add(10)
@@ -663,8 +648,7 @@ func TestStore_ExecAllOpsConcurrent(t *testing.T) {
 }
 
 func TestExecAllNoWait(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	t.Run("ExecAll with NoWait should be self-contained", func(t *testing.T) {
 		aOps := &schema.ExecAllRequest{
@@ -1104,8 +1088,7 @@ func TestExecAllOpsMonotoneTsRange(t *testing.T) {
 */
 
 func TestOps_ReferenceKeyAlreadyPersisted(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	idx0, _ := db.Set(&schema.SetRequest{
 		KVs: []*schema.KeyValue{
@@ -1192,8 +1175,7 @@ func TestOps_ReferenceKeyAlreadyPersisted(t *testing.T) {
 }
 
 func TestOps_Preconditions(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	_, err := db.ExecAll(&schema.ExecAllRequest{
 		Operations: []*schema.Op{{

--- a/pkg/database/all_ops_test.go
+++ b/pkg/database/all_ops_test.go
@@ -19,7 +19,6 @@ package database
 import (
 	"errors"
 	"fmt"
-	"log"
 	"math/rand"
 	"strconv"
 	"strings"
@@ -604,9 +603,7 @@ func TestStore_ExecAllOpsConcurrent(t *testing.T) {
 
 			aOps.Operations = append(aOps.Operations, aOp)
 			float, err := strconv.ParseFloat(fmt.Sprintf("%d", j), 64)
-			if err != nil {
-				log.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			set := val
 			refKey := key

--- a/pkg/database/all_ops_test.go
+++ b/pkg/database/all_ops_test.go
@@ -94,8 +94,8 @@ func TestConcurrentCompactIndex(t *testing.T) {
 			case <-ticker.C:
 				{
 					err := compactIndex(db, cleanUpTimeout)
-					if err != nil && err != sql.ErrAlreadyClosed && err != tbtree.ErrCompactionThresholdNotReached {
-						panic(err)
+					if !errors.Is(err, sql.ErrAlreadyClosed) && !errors.Is(err, tbtree.ErrCompactionThresholdNotReached) {
+						require.NoError(t, err)
 					}
 				}
 			}
@@ -125,7 +125,6 @@ func TestConcurrentCompactIndex(t *testing.T) {
 
 		err := execAll(db, &schema.ExecAllRequest{Operations: kvs}, execAllTimeout)
 		require.NoError(t, err)
-
 	}
 
 	time.Sleep(4 * time.Second)
@@ -630,6 +629,10 @@ func TestStore_ExecAllOpsConcurrent(t *testing.T) {
 
 	wg.Wait()
 
+	if t.Failed() {
+		t.FailNow()
+	}
+
 	for i := 1; i <= 10; i++ {
 		set := strconv.FormatUint(uint64(i), 10)
 
@@ -819,6 +822,9 @@ func TestStore_ExecAllOpsConcurrentOnAlreadyPersistedKeys(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+	if t.Failed() {
+		t.FailNow()
+	}
 
 	for i := 1; i <= 10; i++ {
 		set := strconv.FormatUint(uint64(i), 10)
@@ -920,6 +926,9 @@ func TestStore_ExecAllOpsConcurrentOnMixedPersistedAndNotKeys(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+	if t.Failed() {
+		t.FailNow()
+	}
 
 	for i := 1; i <= 10; i++ {
 		set := strconv.FormatUint(uint64(i), 10)
@@ -1031,6 +1040,9 @@ func TestStore_ExecAllOpsConcurrentOnMixedPersistedAndNotOnEqualKeysAndEqualScor
 
 	}
 	wg.Wait()
+	if t.Failed() {
+		t.FailNow()
+	}
 
 	history, err := st.History(&schema.HistoryOptions{
 		Key: []byte(keyA),

--- a/pkg/database/database_test.go
+++ b/pkg/database/database_test.go
@@ -26,7 +26,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -56,30 +55,29 @@ var kvs = []*schema.KeyValue{
 	},
 }
 
-func makeDb() (*db, func()) {
-	rootPath := "data_" + strconv.FormatInt(time.Now().UnixNano(), 10)
+func makeDb(t *testing.T) *db {
+	rootPath := t.TempDir()
 
 	options := DefaultOption().WithDBRootPath(rootPath).WithCorruptionChecker(false)
 	options.storeOpts.WithIndexOptions(options.storeOpts.IndexOpts.WithCompactionThld(2))
 
-	return makeDbWith("db", options)
+	return makeDbWith(t, "db", options)
 }
 
-func makeDbWith(dbName string, opts *Options) (*db, func()) {
+func makeDbWith(t *testing.T, dbName string, opts *Options) *db {
 	d, err := NewDB(dbName, &dummyMultidbHandler{}, opts, logger.NewSimpleLogger("immudb ", os.Stderr))
 	if err != nil {
 		log.Fatalf("Error creating Db instance %s", err)
 	}
 
-	return d.(*db), func() {
-		if err := d.Close(); err != nil {
-			log.Fatal(err)
+	t.Cleanup(func() {
+		err := d.Close()
+		if !t.Failed() {
+			require.NoError(t, err)
 		}
+	})
 
-		if err := os.RemoveAll(d.GetOptions().dbRootPath); err != nil {
-			log.Fatal(err)
-		}
-	}
+	return d.(*db)
 }
 
 type dummyMultidbHandler struct {
@@ -102,19 +100,13 @@ func (h *dummyMultidbHandler) ExecPreparedStmts(ctx context.Context, stmts []sql
 }
 
 func TestDefaultDbCreation(t *testing.T) {
-	options := DefaultOption()
+	options := DefaultOption().WithDBRootPath(t.TempDir())
 	db, err := NewDB("mydb", nil, options, logger.NewSimpleLogger("immudb ", os.Stderr))
-	if err != nil {
-		t.Fatalf("Error creating Db instance %s", err)
-	}
+	require.NoError(t, err)
 
 	require.Equal(t, options, db.GetOptions())
 
-	defer func() {
-		db.Close()
-		time.Sleep(1 * time.Second)
-		os.RemoveAll(options.GetDBRootPath())
-	}()
+	defer db.Close()
 
 	n, err := db.Size()
 	require.NoError(t, err)
@@ -127,107 +119,74 @@ func TestDefaultDbCreation(t *testing.T) {
 	require.Error(t, err)
 
 	dbPath := path.Join(options.GetDBRootPath(), db.GetName())
-	if _, err = os.Stat(dbPath); os.IsNotExist(err) {
-		t.Fatalf("Db dir not created")
-	}
-
-	_, err = os.Stat(path.Join(options.GetDBRootPath()))
-	if os.IsNotExist(err) {
-		t.Fatalf("Data dir not created")
-	}
+	require.DirExists(t, dbPath)
 }
 
 func TestDbCreationInAlreadyExistentDirectories(t *testing.T) {
-	options := DefaultOption().WithDBRootPath("Paris")
-	defer os.RemoveAll(options.GetDBRootPath())
+	options := DefaultOption().WithDBRootPath(filepath.Join(t.TempDir(), "Paris"))
 
-	err := os.MkdirAll(options.GetDBRootPath(), os.ModePerm)
-	require.NoError(t, err)
-
-	err = os.MkdirAll(filepath.Join(options.GetDBRootPath(), "EdithPiaf"), os.ModePerm)
+	err := os.MkdirAll(filepath.Join(options.GetDBRootPath(), "EdithPiaf"), os.ModePerm)
 	require.NoError(t, err)
 
 	_, err = NewDB("EdithPiaf", nil, options, logger.NewSimpleLogger("immudb ", os.Stderr))
-	require.Error(t, err)
+	require.ErrorContains(t, err, "already exist")
 }
 
 func TestDbCreationInInvalidDirectory(t *testing.T) {
 	options := DefaultOption().WithDBRootPath("/?")
-	defer os.RemoveAll(options.GetDBRootPath())
 
 	_, err := NewDB("EdithPiaf", nil, options, logger.NewSimpleLogger("immudb ", os.Stderr))
 	require.Error(t, err)
 }
 
 func TestDbCreation(t *testing.T) {
-	options := DefaultOption().WithDBRootPath("Paris")
+	options := DefaultOption().WithDBRootPath(filepath.Join(t.TempDir(), "Paris"))
 	db, err := NewDB("EdithPiaf", nil, options, logger.NewSimpleLogger("immudb ", os.Stderr))
-	if err != nil {
-		t.Fatalf("Error creating Db instance %s", err)
-	}
+	require.NoError(t, err)
 
-	defer func() {
-		db.Close()
-		time.Sleep(1 * time.Second)
-		os.RemoveAll(options.GetDBRootPath())
-	}()
+	defer db.Close()
 
 	dbPath := path.Join(options.GetDBRootPath(), db.GetName())
-	if _, err = os.Stat(dbPath); os.IsNotExist(err) {
-		t.Fatalf("Db dir not created")
-	}
-
-	_, err = os.Stat(options.GetDBRootPath())
-	if os.IsNotExist(err) {
-		t.Fatalf("Data dir not created")
-	}
+	require.DirExists(t, dbPath)
 }
 
 func TestOpenWithMissingDBDirectories(t *testing.T) {
-	options := DefaultOption().WithDBRootPath("Paris")
+	options := DefaultOption().WithDBRootPath(filepath.Join(t.TempDir(), "Paris"))
 	_, err := OpenDB("EdithPiaf", nil, options, logger.NewSimpleLogger("immudb ", os.Stderr))
 	require.Error(t, err)
 }
 
 func TestOpenWithIllegalDBName(t *testing.T) {
-	options := DefaultOption().WithDBRootPath("Paris")
+	options := DefaultOption().WithDBRootPath(filepath.Join(t.TempDir(), "Paris"))
 	_, err := OpenDB("", nil, options, logger.NewSimpleLogger("immudb ", os.Stderr))
 	require.ErrorIs(t, err, ErrIllegalArguments)
 }
 
 func TestOpenDB(t *testing.T) {
-	options := DefaultOption().WithDBRootPath("Paris")
+	options := DefaultOption().WithDBRootPath(filepath.Join(t.TempDir(), "Paris"))
 	db, err := NewDB("EdithPiaf", nil, options, logger.NewSimpleLogger("immudb ", os.Stderr))
-	if err != nil {
-		t.Fatalf("Error creating Db instance %s", err)
-	}
+	require.NoError(t, err)
 
 	err = db.Close()
-	if err != nil {
-		t.Fatalf("Error closing store %s", err)
-	}
+	require.NoError(t, err)
 
 	db, err = OpenDB("EdithPiaf", nil, options, logger.NewSimpleLogger("immudb ", os.Stderr))
-	if err != nil {
-		t.Fatalf("Error opening database %s", err)
-	}
+	require.NoError(t, err)
 
-	db.Close()
-	time.Sleep(1 * time.Second)
-	os.RemoveAll(options.GetDBRootPath())
+	err = db.Close()
+	require.NoError(t, err)
 }
 
 func TestOpenV1_0_1_DB(t *testing.T) {
 	copier := fs.NewStandardCopier()
-	require.NoError(t, copier.CopyDir("../../test/data_v1.1.0", "data_v1.1.0"))
+	dir := filepath.Join(t.TempDir(), "db")
+	require.NoError(t, copier.CopyDir("../../test/data_v1.1.0", dir))
 
-	defer os.RemoveAll("data_v1.1.0")
-
-	sysOpts := DefaultOption().WithDBRootPath("./data_v1.1.0")
+	sysOpts := DefaultOption().WithDBRootPath(dir)
 	sysDB, err := OpenDB("systemdb", nil, sysOpts, logger.NewSimpleLogger("immudb ", os.Stderr))
 	require.NoError(t, err)
 
-	dbOpts := DefaultOption().WithDBRootPath("./data_v1.1.0")
+	dbOpts := DefaultOption().WithDBRootPath(dir)
 	db, err := OpenDB("defaultdb", nil, dbOpts, logger.NewSimpleLogger("immudb ", os.Stderr))
 	require.NoError(t, err)
 
@@ -239,8 +198,7 @@ func TestOpenV1_0_1_DB(t *testing.T) {
 }
 
 func TestDbSynchronousSet(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	for _, kv := range kvs {
 		_, err := db.Set(&schema.SetRequest{KVs: []*schema.KeyValue{kv}})
@@ -254,8 +212,7 @@ func TestDbSynchronousSet(t *testing.T) {
 }
 
 func TestDbSetGet(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	var trustedAlh [sha256.Size]byte
 	var trustedIndex uint64
@@ -347,8 +304,7 @@ func TestDbSetGet(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	_, err := db.Delete(nil)
 	require.ErrorIs(t, err, ErrIllegalArguments)
@@ -422,8 +378,7 @@ func TestDelete(t *testing.T) {
 }
 
 func TestCurrentState(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	for ind, val := range kvs {
 		txhdr, err := db.Set(&schema.SetRequest{KVs: []*schema.KeyValue{{Key: val.Key, Value: val.Value}}})
@@ -439,8 +394,7 @@ func TestCurrentState(t *testing.T) {
 }
 
 func TestSafeSetGet(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	state, err := db.CurrentState()
 	require.NoError(t, err)
@@ -514,8 +468,7 @@ func TestSafeSetGet(t *testing.T) {
 }
 
 func TestSetGetAll(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	kvs := []*schema.KeyValue{
 		{
@@ -555,8 +508,7 @@ func TestSetGetAll(t *testing.T) {
 }
 
 func TestTxByID(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	_, err := db.TxByID(nil)
 	require.Error(t, ErrIllegalArguments, err)
@@ -868,8 +820,7 @@ func TestTxByID(t *testing.T) {
 }
 
 func TestVerifiableTxByID(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	_, err := db.VerifiableTxByID(nil)
 	require.Error(t, ErrIllegalArguments, err)
@@ -912,8 +863,7 @@ func TestVerifiableTxByID(t *testing.T) {
 }
 
 func TestTxScan(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	db.maxResultSize = len(kvs)
 
@@ -997,8 +947,7 @@ func TestTxScan(t *testing.T) {
 }
 
 func TestHistory(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	db.maxResultSize = 2
 
@@ -1082,8 +1031,7 @@ func TestHistory(t *testing.T) {
 }
 
 func TestPreconditionedSet(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	_, err := db.Set(&schema.SetRequest{
 		KVs: []*schema.KeyValue{{
@@ -1280,8 +1228,7 @@ func TestPreconditionedSet(t *testing.T) {
 }
 
 func TestPreconditionedSetParallel(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	const parallelism = 10
 
@@ -1665,8 +1612,7 @@ func TestCheckInvalidKeyRequest(t *testing.T) {
 }
 
 func TestGetAtRevision(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	const histCount = 10
 
@@ -1788,8 +1734,7 @@ func TestGetAtRevision(t *testing.T) {
 }
 
 func TestRevisionGetConsistency(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	var keyTxId uint64
 
@@ -1870,8 +1815,7 @@ func TestRevisionGetConsistency(t *testing.T) {
 
 /*
 func TestReference(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+db := makeDb(t)
 	_, err := db.Set(kvs[0])
 	if err != nil {
 		t.Fatalf("Reference error %s", err)
@@ -1903,8 +1847,7 @@ func TestReference(t *testing.T) {
 }
 
 func TestGetReference(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+db := makeDb(t)
 	_, err := db.Set(kvs[0])
 	if err != nil {
 		t.Fatalf("Reference error %s", err)
@@ -1936,8 +1879,7 @@ func TestGetReference(t *testing.T) {
 }
 
 func TestZAdd(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+db := makeDb(t)
 	_, _ = db.Set(&schema.KeyValue{
 		Key:   []byte(`key`),
 		Value: []byte(`val`),
@@ -1971,8 +1913,7 @@ func TestZAdd(t *testing.T) {
 
 /*
 func TestScan(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+db := makeDb(t)
 
 	_, err := db.Set(kv[0])
 	if err != nil {
@@ -2039,8 +1980,7 @@ func TestScan(t *testing.T) {
 /*
 
 func TestCount(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+db := makeDb(t)
 
 	root, err := db.CurrentRoot()
 	if err != nil {
@@ -2107,8 +2047,7 @@ func TestCount(t *testing.T) {
 
 /*
 func TestSafeReference(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+db := makeDb(t)
 	root, err := db.CurrentRoot()
 	if err != nil {
 		t.Error(err)
@@ -2156,8 +2095,7 @@ func TestSafeReference(t *testing.T) {
 
 
 func TestDump(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+db := makeDb(t)
 
 	root, err := db.CurrentRoot()
 	if err != nil {
@@ -2221,8 +2159,7 @@ func (_m *mockImmuService_DumpServer) Send(kvs *pb.KVList) error {
 
 /*
 func TestDb_SetBatchAtomicOperations(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+db := makeDb(t)
 
 	aOps := &schema.Ops{
 		Operations: []*schema.Op{

--- a/pkg/database/database_test.go
+++ b/pkg/database/database_test.go
@@ -66,9 +66,7 @@ func makeDb(t *testing.T) *db {
 
 func makeDbWith(t *testing.T, dbName string, opts *Options) *db {
 	d, err := NewDB(dbName, &dummyMultidbHandler{}, opts, logger.NewSimpleLogger("immudb ", os.Stderr))
-	if err != nil {
-		log.Fatalf("Error creating Db instance %s", err)
-	}
+	require.NoError(t, err)
 
 	t.Cleanup(func() {
 		err := d.Close()
@@ -1824,9 +1822,7 @@ db := makeDb(t)
 		Reference: []byte(`tag`),
 		Key:       kvs[0].Key,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if ref.Index != 1 {
 		t.Fatalf("Reference, expected %v, got %v", 1, ref.Index)
 	}
@@ -1856,9 +1852,7 @@ db := makeDb(t)
 		Reference: []byte(`tag`),
 		Key:       kvs[0].Key,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if ref.Index != 1 {
 		t.Fatalf("Reference, expected %v, got %v", 1, ref.Index)
 	}
@@ -1890,9 +1884,7 @@ db := makeDb(t)
 		Score: &schema.Score{Score: float64(1)},
 		Set:   []byte(`mySet`),
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	if ref.Index != 1 {
 		t.Fatalf("Reference, expected %v, got %v", 1, ref.Index)
@@ -1983,9 +1975,7 @@ func TestCount(t *testing.T) {
 db := makeDb(t)
 
 	root, err := db.CurrentRoot()
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	kv := []*schema.SafeSetOptions{
 		{
@@ -2049,9 +2039,7 @@ db := makeDb(t)
 func TestSafeReference(t *testing.T) {
 db := makeDb(t)
 	root, err := db.CurrentRoot()
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	kv := []*schema.SafeSetOptions{
 		{
 			Kv: &schema.KeyValue{
@@ -2098,9 +2086,7 @@ func TestDump(t *testing.T) {
 db := makeDb(t)
 
 	root, err := db.CurrentRoot()
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 
 	kvs := []*schema.SafeSetOptions{
 		{

--- a/pkg/database/reference_test.go
+++ b/pkg/database/reference_test.go
@@ -29,8 +29,7 @@ import (
 )
 
 func TestStoreReference(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	req := &schema.SetRequest{KVs: []*schema.KeyValue{{Key: []byte(`firstKey`), Value: []byte(`firstValue`)}}}
 	txhdr, err := db.Set(req)
@@ -105,8 +104,7 @@ func TestStoreReference(t *testing.T) {
 }
 
 func TestStore_GetReferenceWithIndexResolution(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	set, err := db.Set(&schema.SetRequest{KVs: []*schema.KeyValue{{Key: []byte(`aaa`), Value: []byte(`value1`)}}})
 	require.NoError(t, err)
@@ -124,8 +122,7 @@ func TestStore_GetReferenceWithIndexResolution(t *testing.T) {
 }
 
 func TestStoreInvalidReferenceToReference(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	req := &schema.SetRequest{KVs: []*schema.KeyValue{{Key: []byte(`firstKey`), Value: []byte(`firstValue`)}}}
 	txhdr, err := db.Set(req)
@@ -141,8 +138,7 @@ func TestStoreInvalidReferenceToReference(t *testing.T) {
 }
 
 func TestStoreReferenceAsyncCommit(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	firstIndex, err := db.Set(&schema.SetRequest{KVs: []*schema.KeyValue{{Key: []byte(`firstKey`), Value: []byte(`firstValue`)}}})
 	require.NoError(t, err)
@@ -199,8 +195,7 @@ func TestStoreReferenceAsyncCommit(t *testing.T) {
 }
 
 func TestStoreMultipleReferenceOnSameKey(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	idx0, err := db.Set(&schema.SetRequest{KVs: []*schema.KeyValue{{Key: []byte(`firstKey`), Value: []byte(`firstValue`)}}})
 	require.NoError(t, err)
@@ -259,8 +254,7 @@ func TestStoreMultipleReferenceOnSameKey(t *testing.T) {
 }
 
 func TestStoreIndexReference(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	idx1, err := db.Set(&schema.SetRequest{KVs: []*schema.KeyValue{{Key: []byte(`aaa`), Value: []byte(`item1`)}}})
 	require.NoError(t, err)
@@ -286,15 +280,13 @@ func TestStoreIndexReference(t *testing.T) {
 }
 
 func TestStoreReferenceKeyNotProvided(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 	_, err := db.SetReference(&schema.ReferenceRequest{Key: []byte(`myTag1`), AtTx: 123, BoundRef: true})
 	require.Equal(t, store.ErrIllegalArguments, err)
 }
 
 func TestStore_GetOnReferenceOnSameKeyReturnsAlwaysLastValue(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	idx1, err := db.Set(&schema.SetRequest{KVs: []*schema.KeyValue{{Key: []byte(`aaa`), Value: []byte(`item1`)}}})
 	require.NoError(t, err)
@@ -320,24 +312,21 @@ func TestStore_GetOnReferenceOnSameKeyReturnsAlwaysLastValue(t *testing.T) {
 }
 
 func TestStore_ReferenceIllegalArgument(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	_, err := db.SetReference(nil)
 	require.Equal(t, err, store.ErrIllegalArguments)
 }
 
 func TestStore_ReferencedItemNotFound(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	_, err := db.SetReference(&schema.ReferenceRequest{ReferencedKey: []byte(`aaa`), Key: []byte(`notExists`)})
 	require.Equal(t, store.ErrKeyNotFound, err)
 }
 
 func TestStoreVerifiableReference(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	_, err := db.VerifiableSetReference(nil)
 	require.Equal(t, store.ErrIllegalArguments, err)
@@ -389,8 +378,7 @@ func TestStoreVerifiableReference(t *testing.T) {
 }
 
 func TestStoreReferenceWithPreconditions(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	_, err := db.Set(&schema.SetRequest{KVs: []*schema.KeyValue{{
 		Key:   []byte("key"),

--- a/pkg/database/reference_test.go
+++ b/pkg/database/reference_test.go
@@ -315,7 +315,7 @@ func TestStore_ReferenceIllegalArgument(t *testing.T) {
 	db := makeDb(t)
 
 	_, err := db.SetReference(nil)
-	require.Equal(t, err, store.ErrIllegalArguments)
+	require.ErrorIs(t, err, store.ErrIllegalArguments)
 }
 
 func TestStore_ReferencedItemNotFound(t *testing.T) {

--- a/pkg/database/replica_test.go
+++ b/pkg/database/replica_test.go
@@ -18,9 +18,7 @@ package database
 
 import (
 	"os"
-	"strconv"
 	"testing"
-	"time"
 
 	"github.com/codenotary/immudb/pkg/api/schema"
 	"github.com/codenotary/immudb/pkg/logger"
@@ -28,14 +26,12 @@ import (
 )
 
 func TestReadOnlyReplica(t *testing.T) {
-	rootPath := "data_" + strconv.FormatInt(time.Now().UnixNano(), 10)
+	rootPath := t.TempDir()
 
 	options := DefaultOption().WithDBRootPath(rootPath).AsReplica(true)
 
 	replica, err := NewDB("db", nil, options, logger.NewSimpleLogger("immudb ", os.Stderr))
 	require.NoError(t, err)
-
-	defer os.RemoveAll(options.dbRootPath)
 
 	err = replica.Close()
 	require.NoError(t, err)
@@ -95,12 +91,11 @@ func TestReadOnlyReplica(t *testing.T) {
 }
 
 func TestSwitchToReplica(t *testing.T) {
-	rootPath := "data_" + strconv.FormatInt(time.Now().UnixNano(), 10)
+	rootPath := t.TempDir()
 
 	options := DefaultOption().WithDBRootPath(rootPath).AsReplica(false)
 
-	replica, rcloser := makeDbWith("db", options)
-	defer rcloser()
+	replica := makeDbWith(t, "db", options)
 
 	_, _, err := replica.SQLExec(&schema.SQLExecRequest{Sql: "CREATE TABLE mytable(id INTEGER, title VARCHAR, PRIMARY KEY id)"}, nil)
 	require.NoError(t, err)

--- a/pkg/database/scan_test.go
+++ b/pkg/database/scan_test.go
@@ -26,8 +26,7 @@ import (
 )
 
 func TestStoreScan(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	db.maxResultSize = 3
 
@@ -95,8 +94,7 @@ func TestStoreScan(t *testing.T) {
 }
 
 func TestStoreScanPrefix(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	db.Set(&schema.SetRequest{KVs: []*schema.KeyValue{{Key: []byte(`prefix:suffix1`), Value: []byte(`item1`)}}})
 	db.Set(&schema.SetRequest{KVs: []*schema.KeyValue{{Key: []byte(`prefix:suffix2`), Value: []byte(`item2`)}}})
@@ -136,8 +134,7 @@ func TestStoreScanPrefix(t *testing.T) {
 }
 
 func TestStoreScanDesc(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	db.Set(&schema.SetRequest{KVs: []*schema.KeyValue{{Key: []byte(`key1`), Value: []byte(`item1`)}}})
 	db.Set(&schema.SetRequest{KVs: []*schema.KeyValue{{Key: []byte(`key2`), Value: []byte(`item2`)}}})
@@ -201,8 +198,7 @@ func TestStoreScanDesc(t *testing.T) {
 }
 
 func TestStoreScanEndKey(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	for i := 1; i < 100; i++ {
 		_, err := db.Set(&schema.SetRequest{KVs: []*schema.KeyValue{{

--- a/pkg/database/sorted_set_test.go
+++ b/pkg/database/sorted_set_test.go
@@ -26,8 +26,7 @@ import (
 )
 
 func TestStoreIndexExists(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	db.Set(&schema.SetRequest{KVs: []*schema.KeyValue{{Key: []byte(`myFirstElementKey`), Value: []byte(`firstValue`)}}})
 	db.Set(&schema.SetRequest{KVs: []*schema.KeyValue{{Key: []byte(`mySecondElementKey`), Value: []byte(`secondValue`)}}})
@@ -114,8 +113,7 @@ func TestStoreIndexExists(t *testing.T) {
 }
 
 func TestStoreIndexEqualKeys(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	_, err := db.ZAdd(nil)
 	require.Equal(t, store.ErrIllegalArguments, err)
@@ -192,8 +190,7 @@ func TestStoreIndexEqualKeys(t *testing.T) {
 }
 
 func TestStoreIndexEqualKeysEqualScores(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	i1, _ := db.Set(&schema.SetRequest{KVs: []*schema.KeyValue{{Key: []byte(`SignerId1`), Value: []byte(`firstValue`)}}})
 	i2, _ := db.Set(&schema.SetRequest{KVs: []*schema.KeyValue{{Key: []byte(`SignerId1`), Value: []byte(`secondValue`)}}})
@@ -263,8 +260,7 @@ func TestStoreIndexEqualKeysEqualScores(t *testing.T) {
 }
 
 func TestStoreIndexEqualKeysMismatchError(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	i1, _ := db.Set(&schema.SetRequest{KVs: []*schema.KeyValue{{Key: []byte(`SignerId1`), Value: []byte(`firstValue`)}}})
 
@@ -290,8 +286,7 @@ func TestStoreIndexEqualKeysMismatchError(t *testing.T) {
 // key: key5, score: 2
 // key: key6, score: 3/*
 func TestStore_ZScanPagination(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	setName := []byte(`set1`)
 	i1, _ := db.Set(&schema.SetRequest{KVs: []*schema.KeyValue{{Key: []byte(`key1`), Value: []byte(`val1`)}}})
@@ -409,8 +404,7 @@ func TestStore_ZScanPagination(t *testing.T) {
 // key: key5, score: 2
 // key: key6, score: 3
 func TestStore_ZScanReversePagination(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	setName := []byte(`set1`)
 	i1, _ := db.Set(&schema.SetRequest{KVs: []*schema.KeyValue{{Key: []byte(`key1`), Value: []byte(`val1`)}}})
@@ -527,8 +521,7 @@ func TestStore_ZScanReversePagination(t *testing.T) {
 }
 
 func TestStore_ZScanInvalidSet(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	opt := &schema.ZScanRequest{
 		Set: nil,
@@ -538,8 +531,7 @@ func TestStore_ZScanInvalidSet(t *testing.T) {
 }
 
 func TestStore_ZScanOnEqualKeysWithSameScoreAreReturnedOrderedByTS(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	idx0, _ := db.Set(&schema.SetRequest{KVs: []*schema.KeyValue{{Key: []byte(`key1`), Value: []byte(`val1-A`)}}})
 	db.Set(&schema.SetRequest{KVs: []*schema.KeyValue{{Key: []byte(`key2`), Value: []byte(`val2-A`)}}})
@@ -595,8 +587,7 @@ func TestStore_ZScanOnEqualKeysWithSameScoreAreReturnedOrderedByTS(t *testing.T)
 }
 
 func TestStoreZScanOnZAddIndexReference(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	i1, _ := db.Set(&schema.SetRequest{KVs: []*schema.KeyValue{{Key: []byte(`SignerId1`), Value: []byte(`firstValue`)}}})
 	i2, _ := db.Set(&schema.SetRequest{KVs: []*schema.KeyValue{{Key: []byte(`SignerId1`), Value: []byte(`secondValue`)}}})
@@ -657,8 +648,7 @@ func TestStoreZScanOnZAddIndexReference(t *testing.T) {
 }
 
 func TestStoreVerifiableZAdd(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	_, err := db.VerifiableZAdd(nil)
 	require.Equal(t, store.ErrIllegalArguments, err)

--- a/pkg/database/sql_test.go
+++ b/pkg/database/sql_test.go
@@ -26,8 +26,7 @@ import (
 )
 
 func TestSQLExecAndQuery(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	db.maxResultSize = 2
 
@@ -182,8 +181,7 @@ func TestSQLExecAndQuery(t *testing.T) {
 }
 
 func TestVerifiableSQLGet(t *testing.T) {
-	db, closer := makeDb()
-	defer closer()
+	db := makeDb(t)
 
 	_, _, err := db.SQLExec(&schema.SQLExecRequest{Sql: "CREATE DATABASE db1"}, nil)
 	require.Error(t, err)

--- a/pkg/immuos/ioutil_test.go
+++ b/pkg/immuos/ioutil_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package immuos
 
 import (
-	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -26,10 +26,9 @@ import (
 
 func TestStandardIoutil(t *testing.T) {
 	sio := NewStandardIoutil()
-	filename := "test-standard-ioutil"
+	filename := filepath.Join(t.TempDir(), "test-standard-ioutil")
 	content := strings.ReplaceAll(filename, "-", " ")
 	require.NoError(t, sio.WriteFile(filename, []byte(content), 0644))
-	defer os.Remove(filename)
 	readBytes, err := sio.ReadFile(filename)
 	require.NoError(t, err)
 	require.Equal(t, content, string(readBytes))

--- a/pkg/immuos/os_test.go
+++ b/pkg/immuos/os_test.go
@@ -34,10 +34,9 @@ func TestStandardOS(t *testing.T) {
 	os := NewStandardOS()
 
 	// Create
-	filename := "os_test_file"
+	filename := filepath.Join(t.TempDir(), "os_test_file")
 	f, err := os.Create(filename)
 	require.NoError(t, err)
-	defer stdos.Remove(filename)
 	require.NotNil(t, f)
 	createFOK := os.CreateF
 	errCreate := errors.New("Create error")
@@ -62,9 +61,8 @@ func TestStandardOS(t *testing.T) {
 	os.GetwdF = getwdFOK
 
 	// Mkdir
-	dirname := "os_test_dir"
+	dirname := filepath.Join(t.TempDir(), "os_test_dir")
 	require.NoError(t, os.Mkdir(dirname, 0755))
-	defer stdos.Remove(dirname)
 	mkdirFOK := os.MkdirF
 	errMkdir := errors.New("Mkdir error")
 	os.MkdirF = func(name string, perm stdos.FileMode) error {
@@ -74,9 +72,8 @@ func TestStandardOS(t *testing.T) {
 	os.MkdirF = mkdirFOK
 
 	// MkdirAll
-	dirname2 := "os_test_dir2"
+	dirname2 := filepath.Join(t.TempDir(), "os_test_dir2")
 	require.NoError(t, os.MkdirAll(filepath.Join(dirname2, "os_test_subdir"), 0755))
-	defer stdos.RemoveAll(dirname2)
 	mkdirAllFOK := os.MkdirAllF
 	errMkdirAll := errors.New("MkdirAll error")
 	os.MkdirAllF = func(path string, perm stdos.FileMode) error {
@@ -88,7 +85,6 @@ func TestStandardOS(t *testing.T) {
 	// Rename
 	filename2 := filename + "_renamed"
 	require.NoError(t, os.Rename(filename, filename2))
-	defer stdos.Remove(filename2)
 	renameFOK := os.RenameF
 	errRename := errors.New("Rename error")
 	os.RenameF = func(oldpath, newpath string) error {
@@ -232,10 +228,10 @@ func TestStandardOSIoutilEmbedded(t *testing.T) {
 	os := NewStandardOS()
 
 	// ReadFile ...
-	filename := "test-standard-os-ioutil-embedded-readfile"
+	filename := filepath.Join(t.TempDir(), "test-standard-os-ioutil-embedded-readfile")
 	content := strings.ReplaceAll(filename, "-", " ")
 	require.NoError(t, ioutil.WriteFile(filename, []byte(content), 0644))
-	defer os.Remove(filename)
+
 	readBytes, err := os.ReadFile(filename)
 	require.NoError(t, err)
 	require.Equal(t, content, string(readBytes))

--- a/pkg/integration/auditor_test.go
+++ b/pkg/integration/auditor_test.go
@@ -84,10 +84,10 @@ func TestDefaultAuditorRunOnEmptyDb(t *testing.T) {
 		func(string, string, bool, bool, bool, *schema.ImmutableState, *schema.ImmutableState) {},
 		logger.NewSimpleLogger("test", os.Stdout),
 		nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	auditorDone := make(chan struct{}, 2)
 	err = da.Run(time.Duration(10), true, context.TODO().Done(), auditorDone)
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 type PasswordReader struct {
@@ -171,9 +171,9 @@ func TestDefaultAuditorRunOnDb(t *testing.T) {
 
 	auditorDone := make(chan struct{}, 2)
 	err = da.Run(time.Duration(10), true, context.TODO().Done(), auditorDone)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	err = da.Run(time.Duration(10), true, context.TODO().Done(), auditorDone)
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestRepeatedAuditorRunOnDb(t *testing.T) {
@@ -345,11 +345,11 @@ func testDefaultAuditorRunOnDbWithSignature(t *testing.T, pk *ecdsa.PublicKey) {
 		func(string, string, bool, bool, bool, *schema.ImmutableState, *schema.ImmutableState) {},
 		logger.NewSimpleLogger("test", os.Stdout),
 		nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	auditorDone := make(chan struct{}, 2)
 	err = da.Run(time.Duration(10), true, context.TODO().Done(), auditorDone)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	err = da.Run(time.Duration(10), true, context.TODO().Done(), auditorDone)
-	require.Nil(t, err)
+	require.NoError(t, err)
 }

--- a/pkg/integration/client_test.go
+++ b/pkg/integration/client_test.go
@@ -684,7 +684,7 @@ func TestImmuClientDisconnect(t *testing.T) {
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
 
 	err = client.Disconnect()
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.False(t, client.IsConnected())
 
@@ -868,7 +868,7 @@ func TestWaitForHealthCheck(t *testing.T) {
 	require.NoError(t, err)
 	client.WithTokenService(tokenservice.NewInmemoryTokenService())
 	err = client.WaitForHealthCheck(context.TODO())
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestWaitForHealthCheckFail(t *testing.T) {
@@ -943,7 +943,7 @@ func TestUserManagement(t *testing.T) {
 		auth.PermissionRW,
 		testDBName,
 	)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	err = client.ChangePermission(
 		ctx,
@@ -952,7 +952,7 @@ func TestUserManagement(t *testing.T) {
 		testDBName,
 		auth.PermissionRW,
 	)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	err = client.SetActiveUser(
 		ctx,
@@ -960,7 +960,7 @@ func TestUserManagement(t *testing.T) {
 			Active:   true,
 			Username: userName,
 		})
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	err = client.ChangePassword(
 		ctx,
@@ -968,7 +968,7 @@ func TestUserManagement(t *testing.T) {
 		[]byte(userPassword),
 		[]byte(userNewPassword),
 	)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	usrList, err = client.ListUsers(ctx)
 	require.NoError(t, err)
@@ -1024,15 +1024,15 @@ func TestDatabaseManagement(t *testing.T) {
 	ctx := metadata.NewOutgoingContext(context.Background(), md)
 
 	err1 := client.CreateDatabase(ctx, &schema.DatabaseSettings{DatabaseName: "test"})
-	require.Nil(t, err1)
+	require.NoError(t, err1)
 
 	resp2, err2 := client.DatabaseList(ctx)
-	require.Nil(t, err2)
+	require.NoError(t, err2)
 	require.IsType(t, &schema.DatabaseListResponse{}, resp2)
 	require.Len(t, resp2.Databases, 2)
 
 	resp3, err3 := client.DatabaseListV2(ctx)
-	require.Nil(t, err3)
+	require.NoError(t, err3)
 	require.IsType(t, &schema.DatabaseListResponseV2{}, resp3)
 	require.Len(t, resp3.Databases, 2)
 
@@ -1072,7 +1072,7 @@ func TestImmuClient_History(t *testing.T) {
 		SinceTx: txmd.Id,
 	})
 
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Len(t, sil.Entries, 2)
 	client.Disconnect()
 }
@@ -1283,7 +1283,7 @@ func TestImmuClient_ExecAllOpsOptions(t *testing.T) {
 
 	idx, err := client.ExecAll(ctx, aOps)
 
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, idx)
 
 	client.Disconnect()
@@ -1319,7 +1319,7 @@ func TestImmuClient_Scan(t *testing.T) {
 	entries, err := client.Scan(ctx, &schema.ScanRequest{Prefix: []byte("key"), SinceTx: 3})
 
 	require.IsType(t, &schema.Entries{}, entries)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Len(t, entries.Entries, 2)
 	client.Disconnect()
 }
@@ -1357,7 +1357,7 @@ func TestImmuClient_TxScan(t *testing.T) {
 		InitialTx: 2,
 	})
 	require.IsType(t, &schema.TxList{}, txls)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Len(t, txls.Txs, 3)
 
 	txls, err = client.TxScan(ctx, &schema.TxScanRequest{
@@ -1366,7 +1366,7 @@ func TestImmuClient_TxScan(t *testing.T) {
 		Desc:      true,
 	})
 	require.IsType(t, &schema.TxList{}, txls)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Len(t, txls.Txs, 3)
 
 	txls, err = client.TxScan(ctx, &schema.TxScanRequest{
@@ -1375,7 +1375,7 @@ func TestImmuClient_TxScan(t *testing.T) {
 		Desc:      true,
 	})
 	require.IsType(t, &schema.TxList{}, txls)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Len(t, txls.Txs, 1)
 	require.Equal(t, database.TrimPrefix(txls.Txs[0].Entries[0].Key), []byte(`key1`))
 }
@@ -1414,7 +1414,7 @@ func TestImmuClient_Logout(t *testing.T) {
 	}
 	tokenServices := []tokenservice.TokenService{ts1, ts2, &ts3}
 	expectations := []func(error){
-		func(err error) { require.Nil(t, err) },
+		func(err error) { require.NoError(t, err) },
 		func(err error) {
 			require.NotNil(t, err)
 			require.Contains(t, err.Error(), "some IsTokenPresent error")
@@ -1743,7 +1743,7 @@ func TestEnforcedLogoutAfterPasswordChange(t *testing.T) {
 	)
 	// step 1: create test database
 	err = client.CreateDatabase(ctx, &schema.DatabaseSettings{DatabaseName: testDBName})
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// step 2: create test user with read write permissions to the test db
 	err = client.CreateUser(
@@ -1753,7 +1753,7 @@ func TestEnforcedLogoutAfterPasswordChange(t *testing.T) {
 		auth.PermissionRW,
 		testDBName,
 	)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// setp 3: create test client and context
 	lr, err = client.Login(context.TODO(), []byte(userName), []byte(userPassword))
@@ -1768,7 +1768,7 @@ func TestEnforcedLogoutAfterPasswordChange(t *testing.T) {
 
 	// step 4: successfully access the test db using the test client
 	_, err = client.Set(testUserContext, []byte("sampleKey"), []byte("sampleValue"))
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// step 5: using admin client change the test user password
 	err = client.ChangePassword(
@@ -1777,7 +1777,7 @@ func TestEnforcedLogoutAfterPasswordChange(t *testing.T) {
 		[]byte(userPassword),
 		[]byte(userNewPassword),
 	)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// step 6: access the test db again using the test client which should give an error
 	_, err = client.Set(testUserContext, []byte("sampleKey"), []byte("sampleValue"))
@@ -1814,7 +1814,7 @@ func TestImmuClient_CurrentStateVerifiedSignature(t *testing.T) {
 	item, err := client.CurrentState(ctx)
 
 	require.IsType(t, &schema.ImmutableState{}, item)
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestImmuClient_VerifiedGetAt(t *testing.T) {

--- a/pkg/integration/client_test.go
+++ b/pkg/integration/client_test.go
@@ -19,9 +19,8 @@ package integration
 import (
 	"context"
 	"errors"
-	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -59,6 +58,58 @@ var testData = struct {
 	refKeys: [][]byte{[]byte("refKey1"), []byte("refKey2"), []byte("refKey3")},
 	set:     []byte("set1"),
 	scores:  []float64{1.0, 2.0, 3.0},
+}
+
+func setupTestServerAndClient(t *testing.T) (*servertest.BufconnServer, ic.ImmuClient, context.Context) {
+	bs := servertest.NewBufconnServer(server.
+		DefaultOptions().
+		WithDir(t.TempDir()).
+		WithAuth(true).
+		WithSigningKey("./../../test/signer/ec1.key"),
+	)
+
+	bs.Start()
+	t.Cleanup(func() { bs.Stop() })
+
+	client, err := bs.NewAuthenticatedClient(ic.
+		DefaultOptions().
+		WithDir(t.TempDir()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { client.CloseSession(context.Background()) })
+	return bs, client, context.Background()
+}
+
+func setupTestServerAndClientWithToken(t *testing.T) (*servertest.BufconnServer, ic.ImmuClient, context.Context) {
+	bs := servertest.NewBufconnServer(server.
+		DefaultOptions().
+		WithDir(t.TempDir()).
+		WithAuth(true).
+		WithSigningKey("./../../test/signer/ec1.key"),
+	)
+
+	bs.Start()
+	t.Cleanup(func() { bs.Stop() })
+
+	client, err := ic.NewImmuClient(ic.
+		DefaultOptions().
+		WithDir(t.TempDir()).
+		WithDialOptions([]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).
+		WithServerSigningPubKey("./../../test/signer/ec1.pub"),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { client.Disconnect() })
+
+	client.WithTokenService(tokenservice.NewInmemoryTokenService())
+	require.NoError(t, err)
+
+	resp, err := client.Login(context.TODO(), []byte(`immudb`), []byte(`immudb`))
+	require.NoError(t, err)
+
+	md := metadata.Pairs("authorization", resp.Token)
+	ctx := metadata.NewOutgoingContext(context.Background(), md)
+
+	return bs, client, ctx
 }
 
 func testSafeSetAndSafeGet(ctx context.Context, t *testing.T, key []byte, value []byte, client ic.ImmuClient) {
@@ -283,31 +334,7 @@ func testImmuClient_VerifiedTxByID(ctx context.Context, t *testing.T, set []byte
 }
 
 func TestImmuClient(t *testing.T) {
-	dir, err := ioutil.TempDir("", "integration_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	defer os.Remove(".state-")
-
-	options := server.DefaultOptions().
-		WithDir(dir).
-		WithAuth(true).
-		WithSigningKey("./../../test/signer/ec1.key")
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	opts := ic.DefaultOptions().WithDialOptions([]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()})
-	client, err := ic.NewImmuClient(opts.WithServerSigningPubKey("./../../test/signer/ec1.pub"))
-	client.WithTokenService(tokenservice.NewInmemoryTokenService())
-	require.NoError(t, err)
-
-	resp, err := client.Login(context.TODO(), []byte(`immudb`), []byte(`immudb`))
-	require.NoError(t, err)
-
-	md := metadata.Pairs("authorization", resp.Token)
-	ctx := metadata.NewOutgoingContext(context.Background(), md)
+	_, client, ctx := setupTestServerAndClient(t)
 
 	testSafeSetAndSafeGet(ctx, t, testData.keys[0], testData.values[0], client)
 	testSafeSetAndSafeGet(ctx, t, testData.keys[1], testData.values[1], client)
@@ -332,33 +359,9 @@ func TestImmuClient(t *testing.T) {
 }
 
 func TestImmuClientTampering(t *testing.T) {
-	dir, err := ioutil.TempDir("", "integration_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	bs, client, ctx := setupTestServerAndClient(t)
 
-	defer os.Remove(".state-")
-
-	options := server.DefaultOptions().
-		WithDir(dir).
-		WithAuth(true).
-		WithSigningKey("./../../test/signer/ec1.key")
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	opts := ic.DefaultOptions().WithDialOptions([]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()})
-	client, err := ic.NewImmuClient(opts.WithServerSigningPubKey("./../../test/signer/ec1.pub"))
-	require.NoError(t, err)
-
-	client.WithTokenService(tokenservice.NewInmemoryTokenService())
-	resp, err := client.Login(context.TODO(), []byte(`immudb`), []byte(`immudb`))
-	require.NoError(t, err)
-
-	md := metadata.Pairs("authorization", resp.Token)
-	ctx := metadata.NewOutgoingContext(context.Background(), md)
-
-	_, err = client.Set(ctx, []byte{0}, []byte{0})
+	_, err := client.Set(ctx, []byte{0}, []byte{0})
 	require.NoError(t, err)
 
 	bs.Server.PostSetFn = func(ctx context.Context,
@@ -486,29 +489,9 @@ func TestImmuClientTampering(t *testing.T) {
 }
 
 func TestReplica(t *testing.T) {
-	dir, err := ioutil.TempDir("", "integration_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	_, client, ctx := setupTestServerAndClient(t)
 
-	defer os.Remove(".state-")
-
-	options := server.DefaultOptions().
-		WithDir(dir).
-		WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions([]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}))
-	require.NoError(t, err)
-	client.WithTokenService(tokenservice.NewInmemoryTokenService())
-	lr, err := client.Login(context.TODO(), []byte(`immudb`), []byte(`immudb`))
-	require.NoError(t, err)
-	md := metadata.Pairs("authorization", lr.Token)
-	ctx := metadata.NewOutgoingContext(context.Background(), md)
-
-	err = client.CreateDatabase(ctx, &schema.DatabaseSettings{
+	err := client.CreateDatabase(ctx, &schema.DatabaseSettings{
 		DatabaseName:   "db1",
 		Replica:        true,
 		MasterDatabase: "defaultdb",
@@ -527,7 +510,7 @@ func TestReplica(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	md = metadata.Pairs("authorization", resp.Token)
+	md := metadata.Pairs("authorization", resp.Token)
 	ctx = metadata.NewOutgoingContext(context.Background(), md)
 
 	_, err = client.VerifiedSet(ctx, []byte(`db1-key1`), []byte(`db1-value1`))
@@ -535,35 +518,9 @@ func TestReplica(t *testing.T) {
 }
 
 func TestDatabasesSwitching(t *testing.T) {
-	dir, err := ioutil.TempDir("", "integration_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	_, client, ctx := setupTestServerAndClient(t)
 
-	defer os.Remove(".state-")
-
-	options := server.DefaultOptions().
-		WithDir(dir).
-		WithAuth(true)
-
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	client, err := ic.NewImmuClient(
-		ic.DefaultOptions().
-			WithDialOptions([]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}))
-	require.NoError(t, err)
-
-	client.WithTokenService(tokenservice.NewInmemoryTokenService())
-
-	lr, err := client.Login(context.TODO(), []byte(`immudb`), []byte(`immudb`))
-	require.NoError(t, err)
-
-	md := metadata.Pairs("authorization", lr.Token)
-	ctx := metadata.NewOutgoingContext(context.Background(), md)
-
-	err = client.CreateDatabase(ctx, &schema.DatabaseSettings{
+	err := client.CreateDatabase(ctx, &schema.DatabaseSettings{
 		DatabaseName: "db1",
 	})
 	require.NoError(t, err)
@@ -574,7 +531,7 @@ func TestDatabasesSwitching(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, resp.Token)
 
-	md = metadata.Pairs("authorization", resp.Token)
+	md := metadata.Pairs("authorization", resp.Token)
 	ctx = metadata.NewOutgoingContext(context.Background(), md)
 
 	_, err = client.VerifiedSet(ctx, []byte(`db1-my`), []byte(`item`))
@@ -603,29 +560,9 @@ func TestDatabasesSwitching(t *testing.T) {
 }
 
 func TestDatabasesSwitchingWithInMemoryToken(t *testing.T) {
-	dir, err := ioutil.TempDir("", "integration_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	_, client, _ := setupTestServerAndClient(t)
 
-	defer os.Remove(".state-")
-
-	options := server.DefaultOptions().
-		WithDir(dir).
-		WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	client, err := ic.NewImmuClient(
-		ic.DefaultOptions().
-			WithDialOptions([]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}))
-	require.NoError(t, err)
-	client.WithTokenService(tokenservice.NewInmemoryTokenService())
-	_, err = client.Login(context.TODO(), []byte(`immudb`), []byte(`immudb`))
-	require.NoError(t, err)
-
-	err = client.CreateDatabase(context.TODO(), &schema.DatabaseSettings{
+	err := client.CreateDatabase(context.TODO(), &schema.DatabaseSettings{
 		DatabaseName: "db1",
 	})
 	require.NoError(t, err)
@@ -659,43 +596,30 @@ func TestDatabasesSwitchingWithInMemoryToken(t *testing.T) {
 }
 
 func TestImmuClientDisconnect(t *testing.T) {
-	dir, err := ioutil.TempDir("", "integration_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	_, client, ctx := setupTestServerAndClientWithToken(t)
 
-	defer os.Remove(".state-")
-
-	options := server.DefaultOptions().
-		WithDir(dir).
-		WithAuth(true).
-		WithSigningKey("./../../test/signer/ec1.key")
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	opts := ic.DefaultOptions().WithDialOptions([]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()})
-	client, err := ic.NewImmuClient(opts.WithServerSigningPubKey("./../../test/signer/ec1.pub"))
-	require.NoError(t, err)
-	client.WithTokenService(tokenservice.NewInmemoryTokenService())
-	lr, err := client.Login(context.TODO(), []byte(`immudb`), []byte(`immudb`))
-	require.NoError(t, err)
-	md := metadata.Pairs("authorization", lr.Token)
-	ctx := metadata.NewOutgoingContext(context.Background(), md)
-
-	err = client.Disconnect()
+	err := client.Disconnect()
 	require.NoError(t, err)
 
 	require.False(t, client.IsConnected())
 
-	require.True(t, errors.Is(client.CreateUser(ctx, []byte("user"), []byte("passwd"), 1, "db"), ic.ErrNotConnected))
-	require.True(t, errors.Is(client.ChangePassword(ctx, []byte("user"), []byte("oldPasswd"), []byte("newPasswd")), ic.ErrNotConnected))
-	require.True(t, errors.Is(client.UpdateAuthConfig(ctx, auth.KindPassword), ic.ErrNotConnected))
-	require.True(t, errors.Is(client.UpdateMTLSConfig(ctx, false), ic.ErrNotConnected))
-	require.True(t, errors.Is(client.CompactIndex(ctx, &emptypb.Empty{}), ic.ErrNotConnected))
+	err = client.CreateUser(ctx, []byte("user"), []byte("passwd"), 1, "db")
+	require.ErrorIs(t, err, ic.ErrNotConnected)
+
+	err = client.ChangePassword(ctx, []byte("user"), []byte("oldPasswd"), []byte("newPasswd"))
+	require.ErrorIs(t, err, ic.ErrNotConnected)
+
+	err = client.UpdateAuthConfig(ctx, auth.KindPassword)
+	require.ErrorIs(t, err, ic.ErrNotConnected)
+
+	err = client.UpdateMTLSConfig(ctx, false)
+	require.ErrorIs(t, err, ic.ErrNotConnected)
+
+	err = client.CompactIndex(ctx, &emptypb.Empty{})
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
 	_, err = client.FlushIndex(ctx, 100, true)
-	require.True(t, errors.Is(err, ic.ErrNotConnected))
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
 	_, err = client.Login(context.TODO(), []byte("user"), []byte("passwd"))
 	require.True(t, errors.Is(err.(immuErrors.ImmuError), ic.ErrNotConnected))
@@ -703,171 +627,143 @@ func TestImmuClientDisconnect(t *testing.T) {
 	require.True(t, errors.Is(client.Logout(context.TODO()), ic.ErrNotConnected))
 
 	_, err = client.Get(context.TODO(), []byte("key"))
-	require.True(t, errors.Is(err, ic.ErrNotConnected))
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
 	_, err = client.CurrentState(context.TODO())
-	require.True(t, errors.Is(err, ic.ErrNotConnected))
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
 	_, err = client.VerifiedGet(context.TODO(), []byte("key"))
-	require.True(t, errors.Is(err, ic.ErrNotConnected))
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
 	_, err = client.GetAll(context.TODO(), [][]byte{[]byte(`aaa`), []byte(`bbb`)})
-	require.True(t, errors.Is(err, ic.ErrNotConnected))
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
 	_, err = client.Scan(context.TODO(), &schema.ScanRequest{
 		Prefix: []byte("key"),
 	})
-	require.True(t, errors.Is(err, ic.ErrNotConnected))
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
 	_, err = client.ZScan(context.TODO(), &schema.ZScanRequest{Set: []byte("key")})
-	require.True(t, errors.Is(err, ic.ErrNotConnected))
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
 	_, err = client.Count(context.TODO(), []byte("key"))
-	require.True(t, errors.Is(err, ic.ErrNotConnected))
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
 	_, err = client.CountAll(context.TODO())
-	require.True(t, errors.Is(err, ic.ErrNotConnected))
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
 	_, err = client.Set(context.TODO(), []byte("key"), []byte("value"))
-	require.True(t, errors.Is(err, ic.ErrNotConnected))
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
 	_, err = client.VerifiedSet(context.TODO(), []byte("key"), []byte("value"))
-	require.True(t, errors.Is(err, ic.ErrNotConnected))
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
 	_, err = client.Set(context.TODO(), nil, nil)
-	require.True(t, errors.Is(err, ic.ErrNotConnected))
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
 	_, err = client.Delete(context.TODO(), nil)
-	require.True(t, errors.Is(err, ic.ErrNotConnected))
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
 	_, err = client.ExecAll(context.TODO(), nil)
-	require.True(t, errors.Is(err, ic.ErrNotConnected))
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
 	_, err = client.TxByID(context.TODO(), 1)
-	require.True(t, errors.Is(err, ic.ErrNotConnected))
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
 	_, err = client.VerifiedTxByID(context.TODO(), 1)
-	require.True(t, errors.Is(err, ic.ErrNotConnected))
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
 	_, err = client.TxByIDWithSpec(context.TODO(), nil)
-	require.True(t, errors.Is(err, ic.ErrNotConnected))
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
 	_, err = client.TxScan(context.TODO(), nil)
-	require.True(t, errors.Is(err, ic.ErrNotConnected))
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
 	_, err = client.History(context.TODO(), &schema.HistoryRequest{
 		Key: []byte("key"),
 	})
-	require.True(t, errors.Is(err, ic.ErrNotConnected))
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
 	_, err = client.SetReference(context.TODO(), []byte("ref"), []byte("key"))
-	require.True(t, errors.Is(err, ic.ErrNotConnected))
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
 	_, err = client.VerifiedSetReference(context.TODO(), []byte("ref"), []byte("key"))
-	require.True(t, errors.Is(err, ic.ErrNotConnected))
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
 	_, err = client.ZAdd(context.TODO(), []byte("set"), 1, []byte("key"))
-	require.True(t, errors.Is(err, ic.ErrNotConnected))
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
 	_, err = client.VerifiedZAdd(context.TODO(), []byte("set"), 1, []byte("key"))
-	require.True(t, errors.Is(err, ic.ErrNotConnected))
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
 	//_, err = client.Dump(context.TODO(), nil)
 	//require.Equal(t, ic.ErrNotConnected, err)
 
 	_, err = client.GetSince(context.TODO(), []byte("key"), 0)
-	require.True(t, errors.Is(err, ic.ErrNotConnected))
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
 	_, err = client.GetAt(context.TODO(), []byte("key"), 0)
-	require.True(t, errors.Is(err, ic.ErrNotConnected))
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
 	_, err = client.ServerInfo(context.TODO(), nil)
-	require.True(t, errors.Is(err, ic.ErrNotConnected))
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
-	require.True(t, errors.Is(client.HealthCheck(context.TODO()), ic.ErrNotConnected))
+	err = client.HealthCheck(context.TODO())
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
-	require.True(t, errors.Is(client.CreateDatabase(context.TODO(), nil), ic.ErrNotConnected))
+	err = client.CreateDatabase(context.TODO(), nil)
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
 	_, err = client.UseDatabase(context.TODO(), nil)
-	require.True(t, errors.Is(err, ic.ErrNotConnected))
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
 	err = client.ChangePermission(context.TODO(), schema.PermissionAction_REVOKE, "userName", "testDBName", auth.PermissionRW)
-	require.True(t, errors.Is(err, ic.ErrNotConnected))
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
-	require.True(t, errors.Is(client.SetActiveUser(context.TODO(), nil), ic.ErrNotConnected))
+	err = client.SetActiveUser(context.TODO(), nil)
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
 	_, err = client.ListUsers(context.TODO())
-	require.True(t, errors.Is(err, ic.ErrNotConnected))
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
 	_, err = client.DatabaseList(context.TODO())
-	require.True(t, errors.Is(err, ic.ErrNotConnected))
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
 	_, err = client.DatabaseListV2(context.TODO())
-	require.True(t, errors.Is(err, ic.ErrNotConnected))
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
 	_, err = client.UpdateDatabaseV2(context.TODO(), "defaultdb", nil)
-	require.True(t, errors.Is(err, ic.ErrNotConnected))
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
-	_, err = client.CurrentRoot(context.TODO())
-	require.True(t, errors.Is(err, ic.ErrNotConnected))
+	_, err = client.CurrentState(context.TODO())
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
-	_, err = client.SafeSet(context.TODO(), nil, nil)
-	require.True(t, errors.Is(err, ic.ErrNotConnected))
+	_, err = client.VerifiedSet(context.TODO(), nil, nil)
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
-	_, err = client.SafeGet(context.TODO(), nil)
-	require.True(t, errors.Is(err, ic.ErrNotConnected))
+	_, err = client.VerifiedGet(context.TODO(), nil)
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
-	_, err = client.SafeZAdd(context.TODO(), nil, 0, nil)
-	require.True(t, errors.Is(err, ic.ErrNotConnected))
+	_, err = client.VerifiedZAdd(context.TODO(), nil, 0, nil)
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 
-	_, err = client.SafeReference(context.TODO(), nil, nil)
-	require.True(t, errors.Is(err, ic.ErrNotConnected))
+	_, err = client.VerifiedSetReference(context.TODO(), nil, nil)
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 }
 
 func TestImmuClientDisconnectNotConn(t *testing.T) {
-	dir, err := ioutil.TempDir("", "integration_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	defer os.Remove(".state-")
-
-	options := server.DefaultOptions().
-		WithDir(dir).
-		WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions([]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}))
-	require.NoError(t, err)
-	client.WithTokenService(tokenservice.NewInmemoryTokenService())
+	_, client, _ := setupTestServerAndClientWithToken(t)
 
 	client.Disconnect()
-	err = client.Disconnect()
+	err := client.Disconnect()
 	require.Error(t, err)
-	require.Errorf(t, err, "not connected")
+	require.ErrorContains(t, err, "not connected")
 }
 
 func TestWaitForHealthCheck(t *testing.T) {
-	dir, err := ioutil.TempDir("", "integration_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	_, client, _ := setupTestServerAndClient(t)
 
-	defer os.Remove(".state-")
-
-	options := server.DefaultOptions().
-		WithDir(dir).
-		WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions([]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}))
-	require.NoError(t, err)
-	client.WithTokenService(tokenservice.NewInmemoryTokenService())
-	err = client.WaitForHealthCheck(context.TODO())
+	err := client.WaitForHealthCheck(context.TODO())
 	require.NoError(t, err)
 }
 
@@ -903,29 +799,7 @@ func TestUserManagement(t *testing.T) {
 		testUser        *schema.User
 	)
 
-	dir, err := ioutil.TempDir("", "integration_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	defer os.Remove(".state-")
-
-	options := server.DefaultOptions().
-		WithDir(dir).
-		WithAuth(true).
-		WithConfig("../../configs/immudb.toml")
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions([]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}))
-	require.NoError(t, err)
-	lr, err := client.Login(context.TODO(), []byte(`immudb`), []byte(`immudb`))
-	client.WithTokenService(tokenservice.NewInmemoryTokenService())
-
-	require.NoError(t, err)
-	md := metadata.Pairs("authorization", lr.Token)
-	ctx := metadata.NewOutgoingContext(context.Background(), md)
+	_, client, ctx := setupTestServerAndClient(t)
 
 	err = client.CreateDatabase(ctx, testDB)
 	require.NoError(t, err)
@@ -995,33 +869,10 @@ func TestUserManagement(t *testing.T) {
 	require.Len(t, testUser.Permissions, 0)
 	require.Equal(t, "immudb", testUser.Createdby)
 	require.True(t, testUser.Active)
-
-	client.Disconnect()
 }
 
 func TestDatabaseManagement(t *testing.T) {
-	dir, err := ioutil.TempDir("", "integration_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	defer os.Remove(".state-")
-
-	options := server.DefaultOptions().
-		WithDir(dir).
-		WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions([]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}))
-	require.NoError(t, err)
-	client.WithTokenService(tokenservice.NewInmemoryTokenService())
-
-	lr, err := client.Login(context.TODO(), []byte(`immudb`), []byte(`immudb`))
-	require.NoError(t, err)
-	md := metadata.Pairs("authorization", lr.Token)
-	ctx := metadata.NewOutgoingContext(context.Background(), md)
+	_, client, ctx := setupTestServerAndClient(t)
 
 	err1 := client.CreateDatabase(ctx, &schema.DatabaseSettings{DatabaseName: "test"})
 	require.NoError(t, err1)
@@ -1035,33 +886,10 @@ func TestDatabaseManagement(t *testing.T) {
 	require.NoError(t, err3)
 	require.IsType(t, &schema.DatabaseListResponseV2{}, resp3)
 	require.Len(t, resp3.Databases, 2)
-
-	client.Disconnect()
 }
 
 func TestImmuClient_History(t *testing.T) {
-	dir, err := ioutil.TempDir("", "integration_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	defer os.Remove(".state-")
-
-	options := server.DefaultOptions().
-		WithDir(dir).
-		WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions([]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}))
-	require.NoError(t, err)
-	client.WithTokenService(tokenservice.NewInmemoryTokenService())
-
-	lr, err := client.Login(context.TODO(), []byte(`immudb`), []byte(`immudb`))
-	require.NoError(t, err)
-	md := metadata.Pairs("authorization", lr.Token)
-	ctx := metadata.NewOutgoingContext(context.Background(), md)
+	_, client, ctx := setupTestServerAndClient(t)
 
 	_, _ = client.VerifiedSet(ctx, []byte(`key1`), []byte(`val1`))
 	txmd, err := client.VerifiedSet(ctx, []byte(`key1`), []byte(`val2`))
@@ -1074,33 +902,12 @@ func TestImmuClient_History(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Len(t, sil.Entries, 2)
-	client.Disconnect()
 }
 
 func TestImmuClient_SetAll(t *testing.T) {
-	dir, err := ioutil.TempDir("", "integration_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	_, client, ctx := setupTestServerAndClient(t)
 
-	defer os.Remove(".state-")
-
-	options := server.DefaultOptions().
-		WithDir(dir).
-		WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions([]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}))
-	require.NoError(t, err)
-	client.WithTokenService(tokenservice.NewInmemoryTokenService())
-	lr, err := client.Login(context.TODO(), []byte(`immudb`), []byte(`immudb`))
-	require.NoError(t, err)
-	md := metadata.Pairs("authorization", lr.Token)
-	ctx := metadata.NewOutgoingContext(context.Background(), md)
-
-	_, err = client.SetAll(ctx, nil)
+	_, err := client.SetAll(ctx, nil)
 	require.Error(t, err)
 
 	setRequest := &schema.SetRequest{KVs: []*schema.KeyValue{}}
@@ -1129,38 +936,17 @@ func TestImmuClient_SetAll(t *testing.T) {
 		}
 	}
 
-	err = client.Disconnect()
+	err = client.CloseSession(ctx)
 	require.NoError(t, err)
 
 	_, err = client.SetAll(ctx, setRequest)
-	require.True(t, errors.Is(err, ic.ErrNotConnected))
+	require.ErrorIs(t, err, ic.ErrNotConnected)
 }
 
 func TestImmuClient_GetAll(t *testing.T) {
-	dir, err := ioutil.TempDir("", "integration_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	_, client, ctx := setupTestServerAndClient(t)
 
-	defer os.Remove(".state-")
-
-	options := server.DefaultOptions().
-		WithDir(dir).
-		WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions([]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}))
-	require.NoError(t, err)
-	client.WithTokenService(tokenservice.NewInmemoryTokenService())
-
-	lr, err := client.Login(context.TODO(), []byte(`immudb`), []byte(`immudb`))
-	require.NoError(t, err)
-	md := metadata.Pairs("authorization", lr.Token)
-	ctx := metadata.NewOutgoingContext(context.Background(), md)
-
-	_, err = client.VerifiedSet(ctx, []byte(`aaa`), []byte(`val`))
+	_, err := client.VerifiedSet(ctx, []byte(`aaa`), []byte(`val`))
 	require.NoError(t, err)
 
 	entries, err := client.GetAll(ctx, [][]byte{[]byte(`aaa`), []byte(`bbb`)})
@@ -1179,36 +965,12 @@ func TestImmuClient_GetAll(t *testing.T) {
 	entries, err = client.GetAll(ctx, [][]byte{[]byte(`aaa`), []byte(`bbb`)})
 	require.NoError(t, err)
 	require.Len(t, entries.Entries, 2)
-
-	client.Disconnect()
 }
 
 func TestImmuClient_Delete(t *testing.T) {
-	dir, err := ioutil.TempDir("", "integration_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	_, client, ctx := setupTestServerAndClient(t)
 
-	defer os.Remove(".state-")
-
-	options := server.DefaultOptions().
-		WithDir(dir).
-		WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions([]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}))
-	client.WithTokenService(tokenservice.NewInmemoryTokenService())
-	require.NoError(t, err)
-
-	lr, err := client.Login(context.TODO(), []byte(`immudb`), []byte(`immudb`))
-	require.NoError(t, err)
-
-	md := metadata.Pairs("authorization", lr.Token)
-	ctx := metadata.NewOutgoingContext(context.Background(), md)
-
-	_, err = client.Delete(ctx, nil)
+	_, err := client.Delete(ctx, nil)
 	require.Error(t, err)
 
 	deleteRequest := &schema.DeleteKeysRequest{}
@@ -1240,33 +1002,10 @@ func TestImmuClient_Delete(t *testing.T) {
 	_, err = client.Delete(ctx, deleteRequest)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "key not found")
-
-	err = client.Disconnect()
-	require.NoError(t, err)
 }
 
 func TestImmuClient_ExecAllOpsOptions(t *testing.T) {
-	dir, err := ioutil.TempDir("", "integration_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	defer os.Remove(".state-")
-
-	options := server.DefaultOptions().
-		WithDir(dir).
-		WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions([]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}))
-	require.NoError(t, err)
-	client.WithTokenService(tokenservice.NewInmemoryTokenService())
-	lr, err := client.Login(context.TODO(), []byte(`immudb`), []byte(`immudb`))
-	require.NoError(t, err)
-	md := metadata.Pairs("authorization", lr.Token)
-	ctx := metadata.NewOutgoingContext(context.Background(), md)
+	_, client, ctx := setupTestServerAndClient(t)
 
 	aOps := &schema.ExecAllRequest{
 		Operations: []*schema.Op{
@@ -1285,73 +1024,33 @@ func TestImmuClient_ExecAllOpsOptions(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, idx)
-
-	client.Disconnect()
 }
 
 func TestImmuClient_Scan(t *testing.T) {
-	dir, err := ioutil.TempDir("", "integration_test")
+	_, client, ctx := setupTestServerAndClient(t)
+
+	_, err := client.VerifiedSet(ctx, []byte(`key1`), []byte(`val1`))
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	defer os.Remove(".state-")
-
-	options := server.DefaultOptions().
-		WithDir(dir).
-		WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions([]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}))
+	_, err = client.VerifiedSet(ctx, []byte(`key1`), []byte(`val11`))
 	require.NoError(t, err)
-	client.WithTokenService(tokenservice.NewInmemoryTokenService())
-	lr, err := client.Login(context.TODO(), []byte(`immudb`), []byte(`immudb`))
+	_, err = client.VerifiedSet(ctx, []byte(`key3`), []byte(`val3`))
 	require.NoError(t, err)
-	md := metadata.Pairs("authorization", lr.Token)
-	ctx := metadata.NewOutgoingContext(context.Background(), md)
-
-	_, _ = client.VerifiedSet(ctx, []byte(`key1`), []byte(`val1`))
-	_, _ = client.VerifiedSet(ctx, []byte(`key1`), []byte(`val11`))
-	_, _ = client.VerifiedSet(ctx, []byte(`key3`), []byte(`val3`))
 
 	entries, err := client.Scan(ctx, &schema.ScanRequest{Prefix: []byte("key"), SinceTx: 3})
-
-	require.IsType(t, &schema.Entries{}, entries)
 	require.NoError(t, err)
+	require.IsType(t, &schema.Entries{}, entries)
 	require.Len(t, entries.Entries, 2)
-	client.Disconnect()
 }
 
 func TestImmuClient_TxScan(t *testing.T) {
-	dir, err := ioutil.TempDir("", "integration_test")
+	_, client, ctx := setupTestServerAndClient(t)
+
+	_, err := client.Set(ctx, []byte(`key1`), []byte(`val1`))
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	defer os.Remove(".state-")
-
-	options := server.DefaultOptions().
-		WithDir(dir).
-		WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions([]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}))
+	_, err = client.Set(ctx, []byte(`key1`), []byte(`val11`))
 	require.NoError(t, err)
-	defer client.Disconnect()
-
-	client.WithTokenService(tokenservice.NewInmemoryTokenService())
-	lr, err := client.Login(context.TODO(), []byte(`immudb`), []byte(`immudb`))
+	_, err = client.Set(ctx, []byte(`key3`), []byte(`val3`))
 	require.NoError(t, err)
-	md := metadata.Pairs("authorization", lr.Token)
-	ctx := metadata.NewOutgoingContext(context.Background(), md)
-
-	_, _ = client.Set(ctx, []byte(`key1`), []byte(`val1`))
-	_, _ = client.Set(ctx, []byte(`key1`), []byte(`val11`))
-	_, _ = client.Set(ctx, []byte(`key3`), []byte(`val3`))
 
 	txls, err := client.TxScan(ctx, &schema.TxScanRequest{
 		InitialTx: 2,
@@ -1381,16 +1080,11 @@ func TestImmuClient_TxScan(t *testing.T) {
 }
 
 func TestImmuClient_Logout(t *testing.T) {
-	dir, err := ioutil.TempDir("", "integration_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	defer os.Remove(".state-")
-
-	options := server.DefaultOptions().
-		WithDir(dir).
-		WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
+	bs := servertest.NewBufconnServer(server.
+		DefaultOptions().
+		WithDir(t.TempDir()).
+		WithAuth(true),
+	)
 
 	bs.Start()
 	defer bs.Stop()
@@ -1414,7 +1108,9 @@ func TestImmuClient_Logout(t *testing.T) {
 	}
 	tokenServices := []tokenservice.TokenService{ts1, ts2, &ts3}
 	expectations := []func(error){
-		func(err error) { require.NoError(t, err) },
+		func(err error) {
+			require.NoError(t, err)
+		},
 		func(err error) {
 			require.NotNil(t, err)
 			require.Contains(t, err.Error(), "some IsTokenPresent error")
@@ -1426,9 +1122,11 @@ func TestImmuClient_Logout(t *testing.T) {
 	}
 
 	for i, expect := range expectations {
-		clientOpts := ic.DefaultOptions().
-			WithDialOptions([]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()})
-		client, err := ic.NewImmuClient(clientOpts)
+		client, err := ic.NewImmuClient(ic.
+			DefaultOptions().
+			WithDialOptions([]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).
+			WithDir(t.TempDir()),
+		)
 		if err != nil {
 			expect(err)
 			continue
@@ -1445,33 +1143,16 @@ func TestImmuClient_Logout(t *testing.T) {
 
 		err = client.Logout(ctx)
 		expect(err)
-		client.Disconnect()
+		err = client.Disconnect()
+		require.NoError(t, err)
 	}
 }
 
 func TestImmuClient_GetServiceClient(t *testing.T) {
-	dir, err := ioutil.TempDir("", "integration_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	defer os.Remove(".state-")
-
-	options := server.DefaultOptions().
-		WithDir(dir).
-		WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions([]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}))
-	require.NoError(t, err)
-
-	client.WithTokenService(tokenservice.NewInmemoryTokenService())
+	_, client, _ := setupTestServerAndClient(t)
 
 	cli := client.GetServiceClient()
 	require.Implements(t, (*schema.ImmuServiceClient)(nil), cli)
-	client.Disconnect()
 }
 
 func TestImmuClient_GetOptions(t *testing.T) {
@@ -1481,28 +1162,7 @@ func TestImmuClient_GetOptions(t *testing.T) {
 }
 
 func TestImmuClient_ServerInfo(t *testing.T) {
-	dir, err := ioutil.TempDir("", "integration_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	defer os.Remove(".state-")
-
-	options := server.DefaultOptions().
-		WithDir(dir).
-		WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions([]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}))
-	require.NoError(t, err)
-	defer client.Disconnect()
-	client.WithTokenService(tokenservice.NewInmemoryTokenService())
-	lr, err := client.Login(context.TODO(), []byte(`immudb`), []byte(`immudb`))
-	require.NoError(t, err)
-	md := metadata.Pairs("authorization", lr.Token)
-	ctx := metadata.NewOutgoingContext(context.Background(), md)
+	_, client, ctx := setupTestServerAndClient(t)
 
 	resp, err := client.ServerInfo(ctx, &schema.ServerInfoRequest{})
 	require.NoError(t, err)
@@ -1511,29 +1171,9 @@ func TestImmuClient_ServerInfo(t *testing.T) {
 }
 
 func TestImmuClient_CurrentRoot(t *testing.T) {
-	dir, err := ioutil.TempDir("", "integration_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	_, client, ctx := setupTestServerAndClient(t)
 
-	defer os.Remove(".state-")
-
-	options := server.DefaultOptions().
-		WithDir(dir).
-		WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions([]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}))
-	require.NoError(t, err)
-	client.WithTokenService(tokenservice.NewInmemoryTokenService())
-	lr, err := client.Login(context.TODO(), []byte(`immudb`), []byte(`immudb`))
-	require.NoError(t, err)
-	md := metadata.Pairs("authorization", lr.Token)
-	ctx := metadata.NewOutgoingContext(context.Background(), md)
-
-	_, err = client.VerifiedSet(ctx, []byte(`key1`), []byte(`val1`))
+	_, err := client.VerifiedSet(ctx, []byte(`key1`), []byte(`val1`))
 	require.NoError(t, err)
 
 	r, err := client.CurrentState(ctx)
@@ -1544,61 +1184,19 @@ func TestImmuClient_CurrentRoot(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, healthRes)
 	require.Equal(t, uint32(0x0), healthRes.PendingRequests)
-
-	client.Disconnect()
 }
 
 func TestImmuClient_Count(t *testing.T) {
-	dir, err := ioutil.TempDir("", "integration_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	_, client, ctx := setupTestServerAndClient(t)
 
-	defer os.Remove(".state-")
-
-	options := server.DefaultOptions().
-		WithDir(dir).
-		WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions([]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}))
-	require.NoError(t, err)
-	client.WithTokenService(tokenservice.NewInmemoryTokenService())
-	lr, err := client.Login(context.TODO(), []byte(`immudb`), []byte(`immudb`))
-	require.NoError(t, err)
-	md := metadata.Pairs("authorization", lr.Token)
-	ctx := metadata.NewOutgoingContext(context.Background(), md)
-
-	_, err = client.Count(ctx, []byte(`key1`))
+	_, err := client.Count(ctx, []byte(`key1`))
 	require.Error(t, err)
 }
 
 func TestImmuClient_CountAll(t *testing.T) {
-	dir, err := ioutil.TempDir("", "integration_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	_, client, ctx := setupTestServerAndClient(t)
 
-	defer os.Remove(".state-")
-
-	options := server.DefaultOptions().
-		WithDir(dir).
-		WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions([]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}))
-	require.NoError(t, err)
-	client.WithTokenService(tokenservice.NewInmemoryTokenService())
-	lr, err := client.Login(context.TODO(), []byte(`immudb`), []byte(`immudb`))
-	require.NoError(t, err)
-	md := metadata.Pairs("authorization", lr.Token)
-	ctx := metadata.NewOutgoingContext(context.Background(), md)
-	_, err = client.CountAll(ctx)
-
+	_, err := client.CountAll(ctx)
 	require.Error(t, err)
 }
 
@@ -1710,28 +1308,8 @@ func TestImmuClient_GetReference(t *testing.T) {
 
 */
 
-func TestEnforcedLogoutAfterPasswordChange(t *testing.T) {
-	dir, err := ioutil.TempDir("", "integration_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	defer os.Remove(".state-")
-
-	options := server.DefaultOptions().
-		WithDir(dir).
-		WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions([]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}))
-	require.NoError(t, err)
-	client.WithTokenService(tokenservice.NewInmemoryTokenService())
-	lr, err := client.Login(context.TODO(), []byte(`immudb`), []byte(`immudb`))
-	require.NoError(t, err)
-	md := metadata.Pairs("authorization", lr.Token)
-	ctx := metadata.NewOutgoingContext(context.Background(), md)
+func TestEnforcedLogoutAfterPasswordChangeWithToken(t *testing.T) {
+	_, client, ctx := setupTestServerAndClientWithToken(t)
 
 	var (
 		userName        = "test"
@@ -1742,7 +1320,7 @@ func TestEnforcedLogoutAfterPasswordChange(t *testing.T) {
 		testUserContext = context.TODO()
 	)
 	// step 1: create test database
-	err = client.CreateDatabase(ctx, &schema.DatabaseSettings{DatabaseName: testDBName})
+	err := client.CreateDatabase(ctx, &schema.DatabaseSettings{DatabaseName: testDBName})
 	require.NoError(t, err)
 
 	// step 2: create test user with read write permissions to the test db
@@ -1755,11 +1333,11 @@ func TestEnforcedLogoutAfterPasswordChange(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	// setp 3: create test client and context
-	lr, err = client.Login(context.TODO(), []byte(userName), []byte(userPassword))
+	// step 3: create test client and context
+	lr, err := client.Login(context.TODO(), []byte(userName), []byte(userPassword))
 	require.NoError(t, err)
 
-	md = metadata.Pairs("authorization", lr.Token)
+	md := metadata.Pairs("authorization", lr.Token)
 	testUserContext = metadata.NewOutgoingContext(context.Background(), md)
 
 	dbResp, err := client.UseDatabase(testUserContext, testDB)
@@ -1781,68 +1359,68 @@ func TestEnforcedLogoutAfterPasswordChange(t *testing.T) {
 
 	// step 6: access the test db again using the test client which should give an error
 	_, err = client.Set(testUserContext, []byte("sampleKey"), []byte("sampleValue"))
-	require.NotNil(t, err)
+	require.Error(t, err)
+}
 
-	client.Disconnect()
+func TestEnforcedLogoutAfterPasswordChangeWithSessions(t *testing.T) {
+	t.SkipNow()
+	bs, client, ctx := setupTestServerAndClient(t)
+
+	var (
+		userName        = "test"
+		userPassword    = "1Password!*"
+		userNewPassword = "2Password!*"
+		testDBName      = "test"
+		testUserContext = context.TODO()
+	)
+	// step 1: create test database
+	err := client.CreateDatabase(ctx, &schema.DatabaseSettings{DatabaseName: testDBName})
+	require.NoError(t, err)
+
+	// step 2: create test user with read write permissions to the test db
+	err = client.CreateUser(
+		ctx,
+		[]byte(userName),
+		[]byte(userPassword),
+		auth.PermissionRW,
+		testDBName,
+	)
+	require.NoError(t, err)
+
+	// step 3: create test client and context
+	testClient := bs.NewClient(ic.DefaultOptions().WithDir(t.TempDir()))
+
+	err = testClient.OpenSession(context.Background(), []byte(userName), []byte(userPassword), testDBName)
+	require.NoError(t, err)
+
+	// step 4: successfully access the test db using the test client
+	_, err = testClient.Set(testUserContext, []byte("sampleKey"), []byte("sampleValue"))
+	require.NoError(t, err)
+
+	// step 5: using admin client change the test user password
+	err = client.ChangePassword(
+		ctx,
+		[]byte(userName),
+		[]byte(userPassword),
+		[]byte(userNewPassword),
+	)
+	require.NoError(t, err)
+
+	// step 6: access the test db again using the test client which should give an error
+	_, err = testClient.Set(testUserContext, []byte("sampleKey"), []byte("sampleValue"))
+	require.Error(t, err)
 }
 
 func TestImmuClient_CurrentStateVerifiedSignature(t *testing.T) {
-	dir, err := ioutil.TempDir("", "integration_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	_, client, ctx := setupTestServerAndClient(t)
 
-	defer os.Remove(".state-")
-
-	options := server.DefaultOptions().
-		WithDir(dir).
-		WithAuth(true).
-		WithSigningKey("./../../test/signer/ec1.key")
-	bs := servertest.NewBufconnServer(options)
-
-	err = bs.Start()
-	require.NoError(t, err)
-	defer bs.Stop()
-
-	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions([]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).
-		WithServerSigningPubKey("./../../test/signer/ec1.pub"))
-	require.NoError(t, err)
-	client.WithTokenService(tokenservice.NewInmemoryTokenService())
-	lr, err := client.Login(context.TODO(), []byte(`immudb`), []byte(`immudb`))
-	require.NoError(t, err)
-	md := metadata.Pairs("authorization", lr.Token)
-	ctx := metadata.NewOutgoingContext(context.Background(), md)
 	item, err := client.CurrentState(ctx)
-
 	require.IsType(t, &schema.ImmutableState{}, item)
 	require.NoError(t, err)
 }
 
 func TestImmuClient_VerifiedGetAt(t *testing.T) {
-	dir, err := ioutil.TempDir("", "integration_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	defer os.Remove(".state-")
-
-	options := server.DefaultOptions().
-		WithDir(dir).
-		WithAuth(true).
-		WithSigningKey("./../../test/signer/ec1.key")
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	opts := ic.DefaultOptions().WithDialOptions([]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()})
-	client, err := ic.NewImmuClient(opts.WithServerSigningPubKey("./../../test/signer/ec1.pub"))
-	require.NoError(t, err)
-
-	client.WithTokenService(tokenservice.NewInmemoryTokenService())
-	lr, err := client.Login(context.TODO(), []byte(`immudb`), []byte(`immudb`))
-	require.NoError(t, err)
-
-	md := metadata.Pairs("authorization", lr.Token)
-	ctx := metadata.NewOutgoingContext(context.Background(), md)
+	bs, client, ctx := setupTestServerAndClient(t)
 
 	txHdr0, err := client.Set(ctx, []byte(`key0`), []byte(`val0`))
 	require.NoError(t, err)
@@ -1880,34 +1458,12 @@ func TestImmuClient_VerifiedGetAt(t *testing.T) {
 
 	_, err = client.VerifiedSet(ctx, []byte(`key1`), []byte(`val3`))
 	require.Equal(t, store.ErrCorruptedData, err)
-
-	client.Disconnect()
 }
 
 func TestImmuClient_VerifiedGetSince(t *testing.T) {
-	dir, err := ioutil.TempDir("", "integration_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	_, client, ctx := setupTestServerAndClient(t)
 
-	defer os.Remove(".state-")
-
-	options := server.DefaultOptions().
-		WithDir(dir).
-		WithAuth(true)
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions([]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}))
-	require.NoError(t, err)
-	client.WithTokenService(tokenservice.NewInmemoryTokenService())
-	lr, err := client.Login(context.TODO(), []byte(`immudb`), []byte(`immudb`))
-	require.NoError(t, err)
-	md := metadata.Pairs("authorization", lr.Token)
-	ctx := metadata.NewOutgoingContext(context.Background(), md)
-
-	_, err = client.VerifiedSet(ctx, []byte(`key1`), []byte(`val1`))
+	_, err := client.VerifiedSet(ctx, []byte(`key1`), []byte(`val1`))
 	require.NoError(t, err)
 	txMeta2, err := client.VerifiedSet(ctx, []byte(`key1`), []byte(`val2`))
 	require.NoError(t, err)
@@ -1920,32 +1476,9 @@ func TestImmuClient_VerifiedGetSince(t *testing.T) {
 }
 
 func TestImmuClient_BackupAndRestoreUX(t *testing.T) {
-	stateFileDir := path.Join(os.TempDir(), "testStates")
-	dir := path.Join(os.TempDir(), "data")
-	dirAtTx3 := path.Join(os.TempDir(), "dataTx3")
+	bs, client, ctx := setupTestServerAndClient(t)
 
-	defer os.RemoveAll(dir)
-	defer os.RemoveAll(dirAtTx3)
-	defer os.RemoveAll(stateFileDir)
-
-	os.RemoveAll(dir)
-	os.RemoveAll(dirAtTx3)
-
-	options := server.DefaultOptions().WithAuth(true).WithDir(dir)
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-
-	cliOpts := ic.DefaultOptions().WithDialOptions([]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithDir(stateFileDir)
-	cliOpts.CurrentDatabase = ic.DefaultDB
-	client, err := ic.NewImmuClient(cliOpts)
-	require.NoError(t, err)
-	lr, err := client.Login(context.TODO(), []byte(`immudb`), []byte(`immudb`))
-	require.NoError(t, err)
-	md := metadata.Pairs("authorization", lr.Token)
-	ctx := metadata.NewOutgoingContext(context.Background(), md)
-
-	_, err = client.VerifiedSet(ctx, []byte(`key1`), []byte(`val1`))
+	_, err := client.VerifiedSet(ctx, []byte(`key1`), []byte(`val1`))
 	require.NoError(t, err)
 
 	_, err = client.VerifiedSet(ctx, []byte(`key2`), []byte(`val2`))
@@ -1960,41 +1493,54 @@ func TestImmuClient_BackupAndRestoreUX(t *testing.T) {
 	bs.Stop()
 
 	copier := fs.NewStandardCopier()
-	err = copier.CopyDir(dir, dirAtTx3)
+	dirAtTx3 := filepath.Join(t.TempDir(), "data")
+	err = copier.CopyDir(bs.Options.Dir, dirAtTx3)
 	require.NoError(t, err)
 
-	bs = servertest.NewBufconnServer(options)
+	bs = servertest.NewBufconnServer(bs.Options)
 	err = bs.Start()
 	require.NoError(t, err)
 
-	cliOpts = ic.DefaultOptions().WithDialOptions([]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithDir(stateFileDir)
+	stateFileDir := t.TempDir()
+	cliOpts := ic.
+		DefaultOptions().
+		WithDialOptions([]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).
+		WithDir(stateFileDir)
 	cliOpts.CurrentDatabase = ic.DefaultDB
 	client, err = ic.NewImmuClient(cliOpts)
 	require.NoError(t, err)
 
-	lr, err = client.Login(context.TODO(), []byte(`immudb`), []byte(`immudb`))
+	lr, err := client.Login(context.TODO(), []byte(`immudb`), []byte(`immudb`))
 	require.NoError(t, err)
 
-	md = metadata.Pairs("authorization", lr.Token)
+	md := metadata.Pairs("authorization", lr.Token)
 	ctx = metadata.NewOutgoingContext(context.Background(), md)
 
 	_, err = client.VerifiedSet(ctx, []byte(`key1`), []byte(`val1`))
+	require.NoError(t, err)
 	_, err = client.VerifiedSet(ctx, []byte(`key2`), []byte(`val2`))
+	require.NoError(t, err)
 	_, err = client.VerifiedSet(ctx, []byte(`key3`), []byte(`val3`))
 	require.NoError(t, err)
 	_, err = client.VerifiedGet(ctx, []byte(`key3`))
-	client.Disconnect()
-	bs.Stop()
-
-	os.RemoveAll(dir)
-	err = copier.CopyDir(dirAtTx3, dir)
+	require.NoError(t, err)
+	err = client.Disconnect()
 	require.NoError(t, err)
 
-	bs = servertest.NewBufconnServer(options)
+	bs.Stop()
+
+	os.RemoveAll(bs.Options.Dir)
+	err = copier.CopyDir(dirAtTx3, bs.Options.Dir)
+	require.NoError(t, err)
+
+	bs = servertest.NewBufconnServer(bs.Options)
 	err = bs.Start()
 	require.NoError(t, err)
 
-	cliOpts = ic.DefaultOptions().WithDialOptions([]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).WithDir(stateFileDir)
+	cliOpts = ic.
+		DefaultOptions().
+		WithDialOptions([]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()}).
+		WithDir(stateFileDir)
 	cliOpts.CurrentDatabase = ic.DefaultDB
 	client, err = ic.NewImmuClient(cliOpts)
 	require.NoError(t, err)

--- a/pkg/integration/database_runtime_test.go
+++ b/pkg/integration/database_runtime_test.go
@@ -17,47 +17,30 @@ limitations under the License.
 package integration
 
 import (
-	"context"
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/codenotary/immudb/pkg/api/schema"
-	immudb "github.com/codenotary/immudb/pkg/client"
-	"github.com/codenotary/immudb/pkg/server"
-	"github.com/codenotary/immudb/pkg/server/servertest"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
 )
 
 func TestDatabaseLoadingUnloading(t *testing.T) {
-	dir, err := ioutil.TempDir("", "integration_test")
+	_, client, ctx := setupTestServerAndClient(t)
+
+	err := client.CloseSession(ctx)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	defer os.Remove(".state-")
-
-	options := server.DefaultOptions().WithDir(dir)
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	clientOpts := immudb.DefaultOptions().WithDialOptions([]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()})
-	client := immudb.NewClient().WithOptions(clientOpts)
 
 	t.Run("attempt load/unload/delete a database without an active session should fail", func(t *testing.T) {
-		_, err := client.LoadDatabase(context.Background(), &schema.LoadDatabaseRequest{Database: "db1"})
+		_, err := client.LoadDatabase(ctx, &schema.LoadDatabaseRequest{Database: "db1"})
 		require.Contains(t, err.Error(), "not connected")
 
-		_, err = client.UnloadDatabase(context.Background(), &schema.UnloadDatabaseRequest{Database: "db1"})
+		_, err = client.UnloadDatabase(ctx, &schema.UnloadDatabaseRequest{Database: "db1"})
 		require.Contains(t, err.Error(), "not connected")
 
-		_, err = client.DeleteDatabase(context.Background(), &schema.DeleteDatabaseRequest{Database: "db1"})
+		_, err = client.DeleteDatabase(ctx, &schema.DeleteDatabaseRequest{Database: "db1"})
 		require.Contains(t, err.Error(), "not connected")
 	})
 
-	err = client.OpenSession(context.TODO(), []byte(`immudb`), []byte(`immudb`), "defaultdb")
+	err = client.OpenSession(ctx, []byte(`immudb`), []byte(`immudb`), "defaultdb")
 	require.NoError(t, err)
 
 	dbSettings := &schema.DatabaseSettings{
@@ -69,47 +52,47 @@ func TestDatabaseLoadingUnloading(t *testing.T) {
 		MaxTxEntries:      100,
 		ExcludeCommitTime: false,
 	}
-	err = client.CreateDatabase(context.Background(), dbSettings)
+	err = client.CreateDatabase(ctx, dbSettings)
 	require.NoError(t, err)
 
-	_, err = client.UseDatabase(context.Background(), &schema.Database{DatabaseName: "db1"})
+	_, err = client.UseDatabase(ctx, &schema.Database{DatabaseName: "db1"})
 	require.NoError(t, err)
 
 	t.Run("attempt to load unexistent database should fail", func(t *testing.T) {
-		_, err := client.LoadDatabase(context.Background(), &schema.LoadDatabaseRequest{Database: "db2"})
+		_, err := client.LoadDatabase(ctx, &schema.LoadDatabaseRequest{Database: "db2"})
 		require.Contains(t, err.Error(), "database does not exist")
 	})
 
 	t.Run("attempt to load an already open database should fail", func(t *testing.T) {
-		_, err := client.LoadDatabase(context.Background(), &schema.LoadDatabaseRequest{Database: "db1"})
+		_, err := client.LoadDatabase(ctx, &schema.LoadDatabaseRequest{Database: "db1"})
 		require.Contains(t, err.Error(), "database already loaded")
 	})
 
 	t.Run("attempt to unload unexistent database should fail", func(t *testing.T) {
-		_, err := client.UnloadDatabase(context.Background(), &schema.UnloadDatabaseRequest{Database: "db2"})
+		_, err := client.UnloadDatabase(ctx, &schema.UnloadDatabaseRequest{Database: "db2"})
 		require.Contains(t, err.Error(), "database does not exist")
 	})
 
 	t.Run("attempt to unload a loaded database should succeed", func(t *testing.T) {
-		_, err := client.UnloadDatabase(context.Background(), &schema.UnloadDatabaseRequest{Database: "db1"})
+		_, err := client.UnloadDatabase(ctx, &schema.UnloadDatabaseRequest{Database: "db1"})
 		require.NoError(t, err)
 	})
 
 	t.Run("attempt to unload an already unloaded database should fail", func(t *testing.T) {
-		_, err := client.UnloadDatabase(context.Background(), &schema.UnloadDatabaseRequest{Database: "db1"})
+		_, err := client.UnloadDatabase(ctx, &schema.UnloadDatabaseRequest{Database: "db1"})
 		require.Contains(t, err.Error(), "already closed")
 	})
 
 	t.Run("attempt to delete unexistent database should fail", func(t *testing.T) {
-		_, err := client.DeleteDatabase(context.Background(), &schema.DeleteDatabaseRequest{Database: "db2"})
+		_, err := client.DeleteDatabase(ctx, &schema.DeleteDatabaseRequest{Database: "db2"})
 		require.Contains(t, err.Error(), "database does not exist")
 	})
 
 	t.Run("attempt to delete a closed database should succeed", func(t *testing.T) {
-		_, err := client.DeleteDatabase(context.Background(), &schema.DeleteDatabaseRequest{Database: "db1"})
+		_, err := client.DeleteDatabase(ctx, &schema.DeleteDatabaseRequest{Database: "db1"})
 		require.NoError(t, err)
 	})
 
-	err = client.CloseSession(context.Background())
+	err = client.CloseSession(ctx)
 	require.NoError(t, err)
 }

--- a/pkg/integration/follower_replication_test.go
+++ b/pkg/integration/follower_replication_test.go
@@ -34,9 +34,7 @@ import (
 
 func TestReplication(t *testing.T) {
 	//init master server
-	masterDir, err := ioutil.TempDir("", "master-data")
-	require.NoError(t, err)
-	defer os.RemoveAll(masterDir)
+	masterDir := t.TempDir()
 
 	masterServerOpts := server.DefaultOptions().
 		WithMetricsServer(false).
@@ -47,13 +45,11 @@ func TestReplication(t *testing.T) {
 
 	masterServer := server.DefaultServer().WithOptions(masterServerOpts).(*server.ImmuServer)
 
-	err = masterServer.Initialize()
+	err := masterServer.Initialize()
 	require.NoError(t, err)
 
 	//init follower server
-	followerDir, err := ioutil.TempDir("", "follower-data")
-	require.NoError(t, err)
-	defer os.RemoveAll(followerDir)
+	followerDir := t.TempDir()
 
 	followerServerOpts := server.DefaultOptions().
 		WithMetricsServer(false).

--- a/pkg/integration/replication/docker.go
+++ b/pkg/integration/replication/docker.go
@@ -25,7 +25,7 @@ type dockerTestServerProvider struct {
 
 func (p *dockerTestServerProvider) AddServer(t *testing.T) TestServer {
 	pool, err := dockertest.NewPool("")
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ret := &dockerTestServer{
 		pool: pool,
@@ -117,7 +117,7 @@ func (s *dockerTestServer) Start(t *testing.T) {
 	})
 
 	port, err := strconv.Atoi(container.GetPort("3322/tcp"))
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	s.srv = container
 	s.port = port

--- a/pkg/integration/replication/docker_test.go
+++ b/pkg/integration/replication/docker_test.go
@@ -13,7 +13,7 @@ package replication
 
 // func TestImmudb(t *testing.T) {
 // 	resource, err := pool.Run("codenotary/immudb", "latest", []string{})
-// 	require.Nil(t, err)
+// 	require.NoError(t, err)
 
 // 	assert.NotEmpty(t, resource.GetPort("3322/tcp"))
 // 	assert.NotEmpty(t, resource.GetBoundIP("3322/tcp"))

--- a/pkg/integration/replication/suite.go
+++ b/pkg/integration/replication/suite.go
@@ -55,6 +55,8 @@ type baseReplicationTestSuite struct {
 	followers        []TestServer
 	followersDBName  []string
 	followersRunning []bool
+
+	clientStateDir string
 }
 
 func (suite *baseReplicationTestSuite) GetFollowersCount() int {
@@ -230,6 +232,7 @@ func (suite *baseReplicationTestSuite) internalClientFor(srv TestServer, dbName 
 
 	opts := client.
 		DefaultOptions().
+		WithDir(suite.clientStateDir).
 		WithAddress(host).
 		WithPort(port)
 
@@ -330,6 +333,8 @@ func (suite *baseReplicationTestSuite) ValidateClusterSetup() {
 func (suite *baseReplicationTestSuite) SetupTest() {
 	suite.mu.Lock()
 	defer suite.mu.Unlock()
+
+	suite.clientStateDir = suite.T().TempDir()
 
 	if suite.srvProvider == nil {
 		suite.srvProvider = &inProcessTestServerProvider{}

--- a/pkg/integration/stream/stream_test.go
+++ b/pkg/integration/stream/stream_test.go
@@ -876,11 +876,11 @@ func TestImmuClient_StreamWithSignature(t *testing.T) {
 			Size:    len([]byte(`val`)),
 		},
 	}})
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	_, err = client.StreamVerifiedGet(ctx, &schema.VerifiableGetRequest{KeyRequest: &schema.KeyRequest{Key: []byte(`key`)}})
 
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestImmuClient_StreamWithSignatureErrors(t *testing.T) {

--- a/pkg/integration/stream/streams_verified_test.go
+++ b/pkg/integration/stream/streams_verified_test.go
@@ -21,49 +21,17 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 
 	"github.com/codenotary/immudb/pkg/api/schema"
-	ic "github.com/codenotary/immudb/pkg/client"
-	"github.com/codenotary/immudb/pkg/server"
-	"github.com/codenotary/immudb/pkg/server/servertest"
 	"github.com/codenotary/immudb/pkg/stream/streamtest"
 	"github.com/codenotary/immudb/pkg/streamutils"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/metadata"
 )
 
 func TestImmuClient_StreamVerifiedSetAndGet(t *testing.T) {
-	dir, err := ioutil.TempDir("", "integration_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	defer os.Remove(".state-")
-
-	options := server.DefaultOptions().
-		WithDir(dir).
-		WithAuth(true)
-
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	client, err := ic.NewImmuClient(ic.DefaultOptions().WithDialOptions(
-		[]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()},
-	))
-	require.NoError(t, err)
-
-	lr, err := client.Login(context.TODO(), []byte(`immudb`), []byte(`immudb`))
-	require.NoError(t, err)
-
-	defer client.Disconnect()
-
-	md := metadata.Pairs("authorization", lr.Token)
-	ctx := metadata.NewOutgoingContext(context.Background(), md)
+	_, client := setupTest(t)
 
 	nbFiles := 3
 	fileNames := make([]string, 0, nbFiles)
@@ -92,15 +60,17 @@ func TestImmuClient_StreamVerifiedSetAndGet(t *testing.T) {
 	fileNames1 := fileNames[:len(fileNames)-1]
 	lastFileName := fileNames[len(fileNames)-1]
 	kvs1, err := streamutils.GetKeyValuesFromFiles(fileNames1...)
+	require.NoError(t, err)
 	lastKv, err := streamutils.GetKeyValuesFromFiles(lastFileName)
+	require.NoError(t, err)
 
 	// set and get all but the last one
-	hdr, err := client.StreamVerifiedSet(ctx, kvs1)
+	hdr, err := client.StreamVerifiedSet(context.Background(), kvs1)
 	require.NoError(t, err)
 	require.NotNil(t, hdr)
 
 	for i, fileName := range fileNames1 {
-		entry, err := client.StreamVerifiedGet(ctx, &schema.VerifiableGetRequest{
+		entry, err := client.StreamVerifiedGet(context.Background(), &schema.VerifiableGetRequest{
 			KeyRequest: &schema.KeyRequest{Key: []byte(fileName)},
 		})
 		require.NoError(t, err)
@@ -109,11 +79,11 @@ func TestImmuClient_StreamVerifiedSetAndGet(t *testing.T) {
 	}
 
 	// set and get the last one
-	hdr, err = client.StreamVerifiedSet(ctx, lastKv)
+	hdr, err = client.StreamVerifiedSet(context.Background(), lastKv)
 	require.NoError(t, err)
 	require.NotNil(t, hdr)
 
-	entry, err := client.StreamVerifiedGet(ctx, &schema.VerifiableGetRequest{
+	entry, err := client.StreamVerifiedGet(context.Background(), &schema.VerifiableGetRequest{
 		KeyRequest: &schema.KeyRequest{Key: []byte(lastFileName)},
 	})
 	require.NoError(t, err)

--- a/pkg/integration/tx/tx_entries_test.go
+++ b/pkg/integration/tx/tx_entries_test.go
@@ -19,39 +19,14 @@ package integration
 import (
 	"context"
 	"crypto/sha256"
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/codenotary/immudb/pkg/api/schema"
-	ic "github.com/codenotary/immudb/pkg/client"
-	"github.com/codenotary/immudb/pkg/server"
-	"github.com/codenotary/immudb/pkg/server/servertest"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
 )
 
 func Test_GetTransactionEntries(t *testing.T) {
-	dir, err := ioutil.TempDir("", "integration_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	defer os.Remove(".state-")
-
-	options := server.DefaultOptions().WithDir(dir)
-
-	bs := servertest.NewBufconnServer(options)
-
-	bs.Start()
-	defer bs.Stop()
-
-	cliOpts := ic.DefaultOptions().
-		WithDialOptions([]grpc.DialOption{grpc.WithContextDialer(bs.Dialer), grpc.WithInsecure()})
-
-	client := ic.NewClient().WithOptions(cliOpts)
-
-	err = client.OpenSession(context.TODO(), []byte(`immudb`), []byte(`immudb`), "defaultdb")
-	require.NoError(t, err)
+	_, client := setupTest(t)
 
 	hdr, err := client.ExecAll(context.Background(), &schema.ExecAllRequest{
 		Operations: []*schema.Op{

--- a/pkg/logger/file_test.go
+++ b/pkg/logger/file_test.go
@@ -17,9 +17,7 @@ limitations under the License.
 package logger
 
 import (
-	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -27,12 +25,13 @@ import (
 )
 
 func TestFileLogger(t *testing.T) {
-	os.Setenv("LOG_LEVEL", "error")
-	defer os.Unsetenv("LOG_LEVEL")
-	name := "test-file-logger"
+	t.Setenv("LOG_LEVEL", "error")
+
+	name := t.TempDir()
+
 	outputFile := filepath.Join(name, "test-file-logger.log")
-	fl, _, err := NewFileLogger(fmt.Sprintf("%s ", name), outputFile)
-	defer os.RemoveAll(name)
+	fl, _, err := NewFileLogger(name, outputFile)
+
 	require.NoError(t, err)
 	fl.Debugf("some debug %d", 1)
 	fl.Infof("some info %d", 1)
@@ -49,7 +48,7 @@ func TestFileLogger(t *testing.T) {
 	require.NoError(t, fl.Close())
 
 	outputFile3 := filepath.Join(name, "test-file-logger-with-level.log")
-	fl3, err := NewFileLoggerWithLevel(fmt.Sprintf("%s ", name), outputFile3, LogWarn)
+	fl3, err := NewFileLoggerWithLevel(name, outputFile3, LogWarn)
 	require.NoError(t, err)
 	fl3.Debugf("some debug %d", 3)
 	fl3.Infof("some info %d", 3)

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -18,6 +18,7 @@ package logger
 
 import (
 	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 )
@@ -86,7 +87,7 @@ func TestNewLoggerWithFile(t *testing.T) {
 				opts: &Options{
 					Name:      "foo",
 					LogFormat: "json",
-					LogFile:   "log_json.log",
+					LogFile:   filepath.Join(t.TempDir(), "log_json.log"),
 				},
 			},
 			wantLoggerType: &JsonLogger{},
@@ -98,7 +99,7 @@ func TestNewLoggerWithFile(t *testing.T) {
 				opts: &Options{
 					Name:      "foo",
 					LogFormat: LogFormatText,
-					LogFile:   "log_text.log",
+					LogFile:   filepath.Join(t.TempDir(), "log_text.log"),
 				},
 			},
 			wantLoggerType: &FileLogger{},

--- a/pkg/server/corruption_checker_test.go
+++ b/pkg/server/corruption_checker_test.go
@@ -99,9 +99,8 @@ func TestCorruptionCheckerOnTamperInsertionOrderIndexDb(t *testing.T) {
 	dbList := NewDatabaseList()
 	options := database.DefaultOption().WithDbName("test").WithDbRootPath("test")
 	db, err := database.NewDb(options, logger.NewSimpleLogger("immudb ", os.Stderr))
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	k := []byte(strconv.FormatUint(1, 10))
 	v := []byte(strconv.FormatUint(2, 10))
 	kv := &schema.KeyValue{
@@ -115,19 +114,16 @@ func TestCorruptionCheckerOnTamperInsertionOrderIndexDb(t *testing.T) {
 	// Tampering
 	opts := badger.DefaultOptions("test/test").WithLogger(nil)
 	dbb, err := badger.OpenManaged(opts)
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	txn := dbb.NewTransactionAt(math.MaxUint64, true)
 	defer txn.Discard()
 	item, err := txn.Get(k)
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	value, err := item.ValueCopy(nil)
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	ts := binary.BigEndian.Uint64(value[:8])
 	v1 := append(value[:8], []byte(strconv.FormatUint(3, 10))...)
 	if err := txn.Set(k, v1); err != nil {
@@ -165,9 +161,8 @@ func TestCorruptionCheckerOnTamperDbInconsistentState(t *testing.T) {
 	dbList := NewDatabaseList()
 	options := database.DefaultOption().WithDbName("test").WithDbRootPath("test")
 	db, err := database.NewDb(options, logger.NewSimpleLogger("immudb ", os.Stderr))
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	k := []byte(strconv.FormatUint(1, 10))
 	v := []byte(strconv.FormatUint(2, 10))
 	kv := &schema.KeyValue{
@@ -181,16 +176,14 @@ func TestCorruptionCheckerOnTamperDbInconsistentState(t *testing.T) {
 	// Tampering
 	opts := badger.DefaultOptions("test/test").WithLogger(nil)
 	dbb, err := badger.OpenManaged(opts)
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	txn := dbb.NewTransactionAt(math.MaxUint64, true)
 	defer txn.Discard()
 
 	item, err := txn.Get(treeKey(0, 0))
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	ts := item.Version()
 	v1 := []byte(strconv.FormatUint(3, 10))
 	if err := txn.Set(item.Key(), v1); err != nil {
@@ -228,9 +221,8 @@ func TestCorruptionCheckerOnTamperDb(t *testing.T) {
 	dbList := NewDatabaseList()
 	options := database.DefaultOption().WithDbName("test").WithDbRootPath("test")
 	db, err := database.NewDb(options, logger.NewSimpleLogger("immudb ", os.Stderr))
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	k := []byte(strconv.FormatUint(1, 10))
 	v := []byte(strconv.FormatUint(2, 10))
 	kv := &schema.KeyValue{
@@ -253,16 +245,14 @@ func TestCorruptionCheckerOnTamperDb(t *testing.T) {
 	// Tampering
 	opts := badger.DefaultOptions("test/test").WithLogger(nil)
 	dbb, err := badger.OpenManaged(opts)
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	txn := dbb.NewTransactionAt(math.MaxUint64, true)
 	defer txn.Discard()
 
 	item, err := txn.Get(treeKey(0, 0))
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	ts := item.Version()
 	v1 = []byte(`QWERTYUIOPASDFGHJKLZXCBVBN123456fake root`)
 	if err := txn.Set(item.Key(), v1); err != nil {

--- a/pkg/server/corruption_checker_test.go
+++ b/pkg/server/corruption_checker_test.go
@@ -62,7 +62,7 @@ func TestEmptyDBCorruptionChecker(t *testing.T) {
 		val := dbList.GetByIndex(int64(i))
 		val.Close()
 	}
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCorruptionChecker(t *testing.T) {
@@ -90,7 +90,7 @@ func TestCorruptionChecker(t *testing.T) {
 		val := dbList.GetByIndex(int64(i))
 		val.Close()
 	}
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestCorruptionCheckerOnTamperInsertionOrderIndexDb(t *testing.T) {
@@ -354,7 +354,7 @@ func TestCorruptionChecker_ExitImmediatly(t *testing.T) {
 		val := dbList.GetByIndex(int64(i))
 		val.Close()
 	}
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func treeKey(layer uint8, index uint64) []byte {

--- a/pkg/server/metrics_funcs_test.go
+++ b/pkg/server/metrics_funcs_test.go
@@ -121,14 +121,12 @@ func TestMetricFuncServerUptimeCounter(t *testing.T) {
 }
 
 func TestMetricFuncComputeDBSizes(t *testing.T) {
-	dataDir := "TestDBSizesData"
+	dataDir := filepath.Join(t.TempDir(), "TestDBSizesData")
 	defaultDBName := "TestDBSizesDefaultDB"
 
 	//--> create the data dir with subdir for each db
 	var fullPermissions os.FileMode = 0777
 	require.NoError(t, os.MkdirAll(dataDir, fullPermissions))
-	defer os.RemoveAll(dataDir)
-
 	require.NoError(t, os.MkdirAll(filepath.Join(dataDir, defaultDBName), fullPermissions))
 	require.NoError(t, os.MkdirAll(filepath.Join(dataDir, SystemDBName), fullPermissions))
 	require.NoError(t, os.MkdirAll(filepath.Join(dataDir, SystemDBName, "some-dir"), fullPermissions))

--- a/pkg/server/remote_storage_test.go
+++ b/pkg/server/remote_storage_test.go
@@ -266,8 +266,7 @@ func TestInitializeRemoteStorageDownloadIdentifierErrorOnGet(t *testing.T) {
 }
 
 func TestInitializeRemoteStorageDownloadIdentifierErrorOnStore(t *testing.T) {
-	require.NoError(t, os.MkdirAll("data_uuiderr/immudb.identifier", 0777))
-	defer os.RemoveAll("data_uuiderr")
+	require.NoError(t, os.MkdirAll(filepath.Join(t.TempDir(), "data_uuiderr", "immudb.identifier"), 0777))
 
 	s := DefaultServer()
 	m := memory.Open()

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1180,7 +1180,7 @@ func TestServerUpdateConfigItem(t *testing.T) {
 		return errWriteFile
 	}
 	err = s.updateConfigItem("key3", "key3 = value3", func(string) bool { return false })
-	require.Equal(t, err, errWriteFile)
+	require.ErrorIs(t, err, errWriteFile)
 }
 
 func TestServerPID(t *testing.T) {

--- a/pkg/server/sever_current_state_test.go
+++ b/pkg/server/sever_current_state_test.go
@@ -19,7 +19,6 @@ package server
 import (
 	"context"
 	"io/ioutil"
-	"log"
 	"os"
 	"testing"
 
@@ -48,14 +47,10 @@ func TestServerCurrentStateSigned(t *testing.T) {
 	s = s.WithOptions(s.Options.WithAuth(false).WithSigningKey("foo")).WithStateSigner(stSig).(*ImmuServer)
 
 	err = s.loadSystemDatabase(dbRootpath, nil, s.Options.AdminPassword)
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	err = s.loadDefaultDatabase(dbRootpath, nil)
-	if err != nil {
-		log.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	ctx := context.Background()
 

--- a/pkg/server/user_test.go
+++ b/pkg/server/user_test.go
@@ -49,9 +49,7 @@ func TestServerLogin(t *testing.T) {
 		Password: []byte(auth.SysAdminPassword),
 	}
 	resp, err := s.Login(context.Background(), r)
-	if err != nil {
-		t.Fatalf("Login error %v", err)
-	}
+	require.NoError(t, err)
 	if len(resp.Token) == 0 {
 		t.Fatalf("login token is empty")
 	}
@@ -85,16 +83,12 @@ func TestServerLogout(t *testing.T) {
 	}
 	ctx := context.Background()
 	l, err := s.Login(ctx, r)
-	if err != nil {
-		t.Fatalf("Login error %v", err)
-	}
+	require.NoError(t, err)
 	m := make(map[string]string)
 	m["Authorization"] = "Bearer " + string(l.Token)
 	ctx = metadata.NewIncomingContext(ctx, metadata.New(m))
 	_, err = s.Logout(ctx, &emptypb.Empty{})
-	if err != nil {
-		t.Fatalf("Logout error %v", err)
-	}
+	require.NoError(t, err)
 }
 
 func TestServerLoginLogoutWithAuthDisabled(t *testing.T) {
@@ -136,9 +130,7 @@ func TestServerListUsersAdmin(t *testing.T) {
 	}
 	ctx := context.Background()
 	lr, err := s.Login(ctx, r)
-	if err != nil {
-		t.Fatalf("Login error %v", err)
-	}
+	require.NoError(t, err)
 
 	md := metadata.Pairs("authorization", lr.Token)
 	ctx = metadata.NewIncomingContext(context.Background(), md)
@@ -147,9 +139,7 @@ func TestServerListUsersAdmin(t *testing.T) {
 		DatabaseName: testDatabase,
 	}
 	_, err = s.CreateDatabaseWith(ctx, newdb)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	err = s.CloseDatabases()
 	require.NoError(t, err)
@@ -177,47 +167,33 @@ func TestServerListUsersAdmin(t *testing.T) {
 		Permission: auth.PermissionAdmin,
 	}
 	_, err = s.CreateUser(ctx, newUser)
-	if err != nil {
-		t.Fatalf("CreateUser error %v", err)
-	}
+	require.NoError(t, err)
 	s.multidbmode = true
 	lr, err = s.Login(ctx, &schema.LoginRequest{User: testUsername, Password: testPassword})
-	if err != nil {
-		t.Fatalf("Login error %v", err)
-	}
+	require.NoError(t, err)
 	md = metadata.Pairs("authorization", lr.Token)
 	ctx = metadata.NewIncomingContext(context.Background(), md)
 	ur, err := s.UseDatabase(ctx, &schema.Database{
 		DatabaseName: testDatabase,
 	})
-	if err != nil {
-		t.Fatalf("UseDatabase error %v", err)
-	}
+	require.NoError(t, err)
 	md = metadata.Pairs("authorization", ur.Token)
 	ctx = metadata.NewIncomingContext(context.Background(), md)
 
 	users, err := s.ListUsers(ctx, &emptypb.Empty{})
-	if err != nil {
-		t.Fatalf("ListUsers error %v", err)
-	}
+	require.NoError(t, err)
 	if len(users.Users) < 1 {
 		t.Fatalf("List users, expected >1 got %v", len(users.Users))
 	}
 
 	lr, err = s.Login(ctx, &schema.LoginRequest{User: []byte(auth.SysAdminUsername), Password: []byte(auth.SysAdminPassword)})
-	if err != nil {
-		t.Fatalf("Login error %v", err)
-	}
+	require.NoError(t, err)
 	md = metadata.Pairs("authorization", lr.Token)
 	ctx = metadata.NewIncomingContext(context.Background(), md)
 
-	if err != nil {
-		t.Fatalf("login error %v", err)
-	}
+	require.NoError(t, err)
 	users, err = s.ListUsers(ctx, &emptypb.Empty{})
-	if err != nil {
-		t.Fatalf("ListUsers error %v", err)
-	}
+	require.NoError(t, err)
 	if len(users.Users) < 1 {
 		t.Fatalf("List users, expected >1 got %v", len(users.Users))
 	}
@@ -230,31 +206,23 @@ func TestServerListUsersAdmin(t *testing.T) {
 		Permission: auth.PermissionRW,
 	}
 	_, err = s.CreateUser(ctx, newUser)
-	if err != nil {
-		t.Fatalf("CreateUser error %v", err)
-	}
+	require.NoError(t, err)
 	s.multidbmode = true
 
 	lr, err = s.Login(ctx, &schema.LoginRequest{User: []byte("rwuser"), Password: []byte("rwuserPas@1")})
-	if err != nil {
-		t.Fatalf("Login error %v", err)
-	}
+	require.NoError(t, err)
 	md = metadata.Pairs("authorization", lr.Token)
 	ctx = metadata.NewIncomingContext(context.Background(), md)
 
 	ur, err = s.UseDatabase(ctx, &schema.Database{
 		DatabaseName: testDatabase,
 	})
-	if err != nil {
-		t.Fatalf("UseDatabase error %v", err)
-	}
+	require.NoError(t, err)
 	md = metadata.Pairs("authorization", ur.Token)
 	ctx = metadata.NewIncomingContext(context.Background(), md)
 
 	users, err = s.ListUsers(ctx, &emptypb.Empty{})
-	if err != nil {
-		t.Fatalf("ListUsers error %v", err)
-	}
+	require.NoError(t, err)
 	if len(users.Users) < 1 {
 		t.Fatalf("List users, expected >1 got %v", len(users.Users))
 	}
@@ -280,9 +248,7 @@ func TestServerUsermanagement(t *testing.T) {
 	}
 	ctx := context.Background()
 	lr, err := s.Login(ctx, r)
-	if err != nil {
-		t.Fatalf("Login error %v", err)
-	}
+	require.NoError(t, err)
 
 	md := metadata.Pairs("authorization", lr.Token)
 	ctx = metadata.NewIncomingContext(context.Background(), md)
@@ -311,9 +277,7 @@ func testServerCreateUser(ctx context.Context, s *ImmuServer, t *testing.T) {
 		Permission: auth.PermissionAdmin,
 	}
 	_, err := s.CreateUser(ctx, newUser)
-	if err != nil {
-		t.Fatalf("CreateUser error %v", err)
-	}
+	require.NoError(t, err)
 
 	if !s.mandatoryAuth() {
 		t.Fatalf("mandatoryAuth expected true")
@@ -322,9 +286,7 @@ func testServerCreateUser(ctx context.Context, s *ImmuServer, t *testing.T) {
 
 func testServerListUsers(ctx context.Context, s *ImmuServer, t *testing.T) {
 	users, err := s.ListUsers(ctx, &emptypb.Empty{})
-	if err != nil {
-		t.Fatalf("ListUsers error %v", err)
-	}
+	require.NoError(t, err)
 	if len(users.Users) < 1 {
 		t.Fatalf("List users, expected >1 got %v", len(users.Users))
 	}
@@ -332,9 +294,7 @@ func testServerListUsers(ctx context.Context, s *ImmuServer, t *testing.T) {
 
 func testServerListDatabases(ctx context.Context, s *ImmuServer, t *testing.T) {
 	dbs, err := s.DatabaseList(ctx, &emptypb.Empty{})
-	if err != nil {
-		t.Fatalf("DatabaseList error %v", err)
-	}
+	require.NoError(t, err)
 	if len(dbs.Databases) < 1 {
 		t.Fatalf("List databases, expected >1 got %v", len(dbs.Databases))
 	}
@@ -344,9 +304,7 @@ func testServerUseDatabase(ctx context.Context, s *ImmuServer, t *testing.T) {
 	dbs, err := s.UseDatabase(ctx, &schema.Database{
 		DatabaseName: testDatabase,
 	})
-	if err != nil {
-		t.Fatalf("UseDatabase error %v", err)
-	}
+	require.NoError(t, err)
 	if len(dbs.Token) == 0 {
 		t.Fatalf("Expected token, got %v", dbs.Token)
 	}
@@ -360,9 +318,6 @@ func testServerChangePermission(ctx context.Context, s *ImmuServer, t *testing.T
 		Username:   string(testUsername),
 	})
 
-	if err != nil {
-		t.Fatalf("error changing permission, got %v", err.Error())
-	}
 	require.NoError(t, err)
 }
 
@@ -371,9 +326,7 @@ func testServerDeactivateUser(ctx context.Context, s *ImmuServer, t *testing.T) 
 		Active:   false,
 		Username: string(testUsername),
 	})
-	if err != nil {
-		t.Fatalf("DeactivateUser error %v", err)
-	}
+	require.NoError(t, err)
 }
 
 func testServerSetActiveUser(ctx context.Context, s *ImmuServer, t *testing.T) {
@@ -381,9 +334,7 @@ func testServerSetActiveUser(ctx context.Context, s *ImmuServer, t *testing.T) {
 		Active:   true,
 		Username: string(testUsername),
 	})
-	if err != nil {
-		t.Fatalf("SetActiveUser error %v", err)
-	}
+	require.NoError(t, err)
 }
 
 func testServerChangePassword(ctx context.Context, s *ImmuServer, t *testing.T) {
@@ -392,7 +343,5 @@ func testServerChangePassword(ctx context.Context, s *ImmuServer, t *testing.T) 
 		OldPassword: testPassword,
 		User:        testUsername,
 	})
-	if err != nil {
-		t.Fatalf("ChangePassword error %v", err)
-	}
+	require.NoError(t, err)
 }

--- a/pkg/server/user_test.go
+++ b/pkg/server/user_test.go
@@ -363,7 +363,7 @@ func testServerChangePermission(ctx context.Context, s *ImmuServer, t *testing.T
 	if err != nil {
 		t.Fatalf("error changing permission, got %v", err.Error())
 	}
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func testServerDeactivateUser(ctx context.Context, s *ImmuServer, t *testing.T) {

--- a/pkg/stdlib/connection_test.go
+++ b/pkg/stdlib/connection_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"database/sql/driver"
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
@@ -35,8 +34,9 @@ func TestConn(t *testing.T) {
 	port, cleanup := testServer(t)
 	defer cleanup()
 
-	opts := client.DefaultOptions()
-	opts.WithPort(port)
+	opts := client.DefaultOptions().
+		WithDir(t.TempDir()).
+		WithPort(port)
 	opts.Username = "immudb"
 	opts.Password = "immudb"
 	opts.Database = "defaultdb"
@@ -89,16 +89,14 @@ func TestConnErr(t *testing.T) {
 }
 
 func TestConn_QueryContextErr(t *testing.T) {
-	options := server.DefaultOptions().WithAuth(true)
+	options := server.DefaultOptions().WithAuth(true).WithDir(t.TempDir())
 	bs := servertest.NewBufconnServer(options)
 
 	bs.Start()
 	defer bs.Stop()
 
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
+	opts := client.DefaultOptions().WithDir(t.TempDir())
 
-	opts := client.DefaultOptions()
 	opts.Username = "immudb"
 	opts.Password = "immudb"
 	opts.Database = "defaultdb"
@@ -122,8 +120,7 @@ func TestConn_QueryContext(t *testing.T) {
 	port, cleanup := testServer(t)
 	defer cleanup()
 
-	opts := client.DefaultOptions()
-	opts.WithPort(port)
+	opts := client.DefaultOptions().WithDir(t.TempDir()).WithPort(port)
 	opts.Username = "immudb"
 	opts.Password = "immudb"
 	opts.Database = "defaultdb"
@@ -176,8 +173,7 @@ func TestConn_QueryContextEmptyTable(t *testing.T) {
 	port, cleanup := testServer(t)
 	defer cleanup()
 
-	opts := client.DefaultOptions()
-	opts.WithPort(port)
+	opts := client.DefaultOptions().WithDir(t.TempDir()).WithPort(port)
 	opts.Username = "immudb"
 	opts.Password = "immudb"
 	opts.Database = "defaultdb"

--- a/pkg/stdlib/driver_test.go
+++ b/pkg/stdlib/driver_test.go
@@ -19,8 +19,6 @@ package stdlib
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/codenotary/immudb/pkg/client"
@@ -31,20 +29,13 @@ import (
 )
 
 func TestRegisterConnConfig(t *testing.T) {
-	path, err := ioutil.TempDir(os.TempDir(), "sql_test_data")
-	require.NoError(t, err)
-	defer os.RemoveAll(path)
-
-	options := server.DefaultOptions().WithAuth(true).WithDir(path)
+	options := server.DefaultOptions().WithAuth(true).WithDir(t.TempDir())
 	bs := servertest.NewBufconnServer(options)
 
 	bs.Start()
 	defer bs.Stop()
 
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
-
-	opts := client.DefaultOptions()
+	opts := client.DefaultOptions().WithDir(t.TempDir())
 	opts.Username = "immudb"
 	opts.Password = "immudb"
 	opts.Database = "defaultdb"
@@ -58,7 +49,7 @@ func TestRegisterConnConfig(t *testing.T) {
 	defer UnregisterConnConfig(connStr)
 
 	db = Open(connStr)
-	_, err = db.ExecContext(context.TODO(), fmt.Sprintf("CREATE TABLE %s (id INTEGER, amount INTEGER, total INTEGER, title VARCHAR, content BLOB, isPresent BOOLEAN, PRIMARY KEY id)", "myTable"))
+	_, err := db.ExecContext(context.TODO(), fmt.Sprintf("CREATE TABLE %s (id INTEGER, amount INTEGER, total INTEGER, title VARCHAR, content BLOB, isPresent BOOLEAN, PRIMARY KEY id)", "myTable"))
 	require.NoError(t, err)
 
 }

--- a/pkg/stdlib/sql_test.go
+++ b/pkg/stdlib/sql_test.go
@@ -247,7 +247,8 @@ func TestImmuConnector_ConnectErr(t *testing.T) {
 	defer cancel()
 
 	_, err := db.ExecContext(ctx, "this will not be executed")
-	require.ErrorContains(t, err, "Error while dialing")
+	require.Error(t, err)
+	require.Regexp(t, "context deadline exceeded|Error while dialing", err.Error())
 }
 
 func TestImmuConnector_ConnectLoginErr(t *testing.T) {

--- a/pkg/stdlib/sql_test.go
+++ b/pkg/stdlib/sql_test.go
@@ -81,17 +81,13 @@ func TestOpenDB(t *testing.T) {
 
 	rows.Next()
 	err = rows.Scan(&id, &name)
-	if err != nil {
-		require.NoError(t, err)
-	}
+	require.NoError(t, err)
 	require.Equal(t, uint64(1), id)
 	require.Equal(t, "immu1", name)
 
 	rows.Next()
 	err = rows.Scan(&id, &name)
-	if err != nil {
-		require.NoError(t, err)
-	}
+	require.NoError(t, err)
 	require.Equal(t, uint64(2), id)
 	require.Equal(t, "immu2", name)
 
@@ -101,9 +97,7 @@ func TestOpenDB(t *testing.T) {
 	rowsw.Next()
 
 	err = rowsw.Scan(&id, &name)
-	if err != nil {
-		require.NoError(t, err)
-	}
+	require.NoError(t, err)
 	require.Equal(t, uint64(2), id)
 	require.Equal(t, "immu2", name)
 

--- a/pkg/stdlib/tx_test.go
+++ b/pkg/stdlib/tx_test.go
@@ -18,50 +18,17 @@ package stdlib
 
 import (
 	"context"
-	"database/sql"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
-	"net"
-	"os"
 	"testing"
-	"time"
 
 	"google.golang.org/grpc/status"
 
-	"github.com/codenotary/immudb/pkg/server"
 	"github.com/stretchr/testify/require"
 )
 
 func TestConn_BeginTx(t *testing.T) {
-	path, err := ioutil.TempDir(os.TempDir(), "tx_data")
-	require.NoError(t, err)
-	defer os.RemoveAll(path)
-
-	options := server.DefaultOptions().
-		WithMetricsServer(false).
-		WithWebServer(false).
-		WithPgsqlServer(false).
-		WithPort(0).
-		WithDir(path)
-
-	server := server.DefaultServer().WithOptions(options).(*server.ImmuServer)
-	server.Initialize()
-
-	defer server.Stop()
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
-
-	go func() {
-		server.Start()
-	}()
-
-	time.Sleep(500 * time.Millisecond)
-
-	port := server.Listener.Addr().(*net.TCPAddr).Port
-
-	db, err := sql.Open("immudb", fmt.Sprintf("immudb://immudb:immudb@127.0.0.1:%d/defaultdb?sslmode=disable", port))
-	require.NoError(t, err)
+	_, db := testServerClient(t)
 
 	table1 := getRandomTableName()
 	result, err := db.Exec(fmt.Sprintf("CREATE TABLE %s (id INTEGER, amount INTEGER, total INTEGER, title VARCHAR, content BLOB, isPresent BOOLEAN, PRIMARY KEY id)", table1))
@@ -105,34 +72,7 @@ func TestConn_BeginTx(t *testing.T) {
 }
 
 func TestTx_Rollback(t *testing.T) {
-	path, err := ioutil.TempDir(os.TempDir(), "tx_data")
-	require.NoError(t, err)
-	defer os.RemoveAll(path)
-
-	options := server.DefaultOptions().
-		WithMetricsServer(false).
-		WithWebServer(false).
-		WithPgsqlServer(false).
-		WithPort(0).
-		WithDir(path)
-
-	server := server.DefaultServer().WithOptions(options).(*server.ImmuServer)
-	server.Initialize()
-
-	defer server.Stop()
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
-
-	go func() {
-		server.Start()
-	}()
-
-	time.Sleep(500 * time.Millisecond)
-
-	port := server.Listener.Addr().(*net.TCPAddr).Port
-
-	db, err := sql.Open("immudb", fmt.Sprintf("immudb://immudb:immudb@127.0.0.1:%d/defaultdb?sslmode=disable", port))
-	require.NoError(t, err)
+	_, db := testServerClient(t)
 
 	tx, err := db.Begin()
 	require.NoError(t, err)
@@ -158,34 +98,7 @@ func TestTx_Rollback(t *testing.T) {
 }
 
 func TestTx_Errors(t *testing.T) {
-	path, err := ioutil.TempDir(os.TempDir(), "tx_data")
-	require.NoError(t, err)
-	defer os.RemoveAll(path)
-
-	options := server.DefaultOptions().
-		WithMetricsServer(false).
-		WithWebServer(false).
-		WithPgsqlServer(false).
-		WithPort(0).
-		WithDir(path)
-
-	server := server.DefaultServer().WithOptions(options).(*server.ImmuServer)
-	server.Initialize()
-
-	defer server.Stop()
-	defer os.RemoveAll(options.Dir)
-	defer os.Remove(".state-")
-
-	go func() {
-		server.Start()
-	}()
-
-	time.Sleep(500 * time.Millisecond)
-
-	port := server.Listener.Addr().(*net.TCPAddr).Port
-
-	db, err := sql.Open("immudb", fmt.Sprintf("immudb://immudb:immudb@127.0.0.1:%d/defaultdb?sslmode=disable", port))
-	require.NoError(t, err)
+	_, db := testServerClient(t)
 
 	tx, err := db.Begin()
 	require.NoError(t, err)

--- a/pkg/stdlib/uri_test.go
+++ b/pkg/stdlib/uri_test.go
@@ -20,9 +20,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
 	"net"
-	"os"
 	"testing"
 	"time"
 
@@ -32,15 +30,12 @@ import (
 )
 
 func testServer(t *testing.T) (port int, cleanup func()) {
-	path, err := ioutil.TempDir(os.TempDir(), "test_data")
-	require.NoError(t, err)
-
 	options := server.DefaultOptions().
 		WithMetricsServer(false).
 		WithWebServer(false).
 		WithPgsqlServer(false).
 		WithPort(0).
-		WithDir(path)
+		WithDir(t.TempDir())
 
 	server := server.DefaultServer().WithOptions(options).(*server.ImmuServer)
 	server.Initialize()
@@ -53,16 +48,12 @@ func testServer(t *testing.T) (port int, cleanup func()) {
 	time.Sleep(500 * time.Millisecond)
 
 	port = server.Listener.Addr().(*net.TCPAddr).Port
-	return port, func() {
-		server.Stop()
-		os.RemoveAll(options.Dir)
-		os.Remove(".state-")
-	}
+	return port, func() { server.Stop() }
 }
 
 func TestDriver_Open(t *testing.T) {
 	d := immuDriver
-	conn, err := d.Open("immudb://immudb:immudb@127.0.0.1:3324/defaultdb")
+	conn, err := d.Open("immudb://immudb:immudb@127.0.0.1:5555/defaultdb")
 	require.Error(t, err)
 	require.Nil(t, conn)
 }

--- a/pkg/stream/zreceiver_test.go
+++ b/pkg/stream/zreceiver_test.go
@@ -33,13 +33,9 @@ func TestNewZStreamReceiver(t *testing.T) {
 
 func TestNewZStreamReceiver_Next(t *testing.T) {
 	atTx, err := NumberToBytes(uint64(67))
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	score, err := NumberToBytes(float64(33.5))
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
 	me := []*streamtest.MsgError{
 		{M: []byte(`first`), E: io.EOF},
 		{M: []byte(`second`), E: io.EOF},


### PR DESCRIPTION
Use temporary folders for:
* immudb data of local test servers
* client state
* client tokens
* any other intermediate data

Also prefer using testing.T.TempDir() where possible.

Signed-off-by: Bartłomiej Święcki <bart@codenotary.com>