### PR TITLE
chore(ci): migrate deprecating set-output commands

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -31,7 +31,7 @@ jobs:
           RES="$(echo "${PERF_TEST_RUNS_ON:-${PERF_TEST_RUNS_ON_DEFAULT}}" | jq -c '.targets')"
           echo "Detected targets:"
           echo "$RES" | jq .
-          echo "::set-output name=matrix::${RES}"
+          echo "matrix=${RES}" >> $GITHUB_OUTPUT
 
   performance-test-suite:
     name: Performance Test Suite (${{ matrix.target.name }})

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -177,7 +177,7 @@ jobs:
           RES="$(echo "${PERF_TEST_RUNS_ON:-${PERF_TEST_RUNS_ON_DEFAULT}}" | jq -c '.targets')"
           echo "Detected targets:"
           echo "$RES" | jq .
-          echo "::set-output name=matrix::${RES}"
+          echo "matrix=${RES}" >> $GITHUB_OUTPUT
 
   performance-test-suite:
     needs: performance-test-suite-detect-runners

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -62,7 +62,7 @@ jobs:
             args: n git://. --host cas.codenotary.com --api-key ${{ secrets.CAS_API_KEY }}
         - id: list-binaries
           run: |
-            echo "::set-output name=matrix::$(ls dist | jq -R -s -c 'split("\n")[:-1] | {binary: .}')"
+            echo "matrix=$(ls dist | jq -R -s -c 'split("\n")[:-1] | {binary: .}')" >> $GITHUB_OUTPUT
         - name: Upload binary artifacts
           uses: actions/upload-artifact@v3
           with:


### PR DESCRIPTION
Replace deprecating `set-output` command with `$GITHUB_OUTPUT`.

Closes #1438.