### PR TITLE
Replaced assert with require in pkg/

### DIFF
--- a/pkg/auth/clientinterceptors_test.go
+++ b/pkg/auth/clientinterceptors_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -36,7 +35,7 @@ func TestClientUnaryInterceptor(t *testing.T) {
 		return nil
 	}
 	err := f(context.Background(), "", "", "", nil, invoker)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestClientStreamInterceptor(t *testing.T) {
@@ -48,5 +47,5 @@ func TestClientStreamInterceptor(t *testing.T) {
 		return nil, nil
 	}
 	_, err := f(context.Background(), nil, nil, "", streamer)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/pkg/client/homedir/homedir_test.go
+++ b/pkg/client/homedir/homedir_test.go
@@ -22,7 +22,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWriteFileToUserHomeDir(t *testing.T) {
@@ -31,8 +31,8 @@ func TestWriteFileToUserHomeDir(t *testing.T) {
 	pathToFile := "testfile"
 	user, _ := user.Current()
 	err := hds.WriteFileToUserHomeDir(content, pathToFile)
-	assert.FileExists(t, filepath.Join(user.HomeDir, pathToFile))
-	assert.NoError(t, err)
+	require.FileExists(t, filepath.Join(user.HomeDir, pathToFile))
+	require.NoError(t, err)
 	os.RemoveAll(filepath.Join(user.HomeDir, pathToFile))
 }
 
@@ -43,13 +43,13 @@ func TestFileExistsInUserHomeDir(t *testing.T) {
 
 	user, _ := user.Current()
 	exists, err := hds.FileExistsInUserHomeDir(filepath.Join(user.HomeDir, pathToFile))
-	assert.False(t, exists)
-	assert.NoError(t, err)
+	require.False(t, exists)
+	require.NoError(t, err)
 	err = hds.WriteFileToUserHomeDir(content, pathToFile)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	exists, err = hds.FileExistsInUserHomeDir(pathToFile)
-	assert.True(t, exists)
-	assert.NoError(t, err)
+	require.True(t, exists)
+	require.NoError(t, err)
 	os.RemoveAll(filepath.Join(user.HomeDir, pathToFile))
 }
 
@@ -60,15 +60,15 @@ func TestReadFileFromUserHomeDir(t *testing.T) {
 	user, _ := user.Current()
 
 	_, err := hds.ReadFileFromUserHomeDir(pathToFile)
-	assert.ErrorIs(t, err, os.ErrNotExist)
+	require.ErrorIs(t, err, os.ErrNotExist)
 
 	err = hds.WriteFileToUserHomeDir(content, pathToFile)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer os.RemoveAll(filepath.Join(user.HomeDir, pathToFile))
 
 	strcontent, err := hds.ReadFileFromUserHomeDir(pathToFile)
-	assert.NoError(t, err)
-	assert.NotEmpty(t, strcontent)
+	require.NoError(t, err)
+	require.NotEmpty(t, strcontent)
 }
 
 func TestDeleteFileFromUserHomeDir(t *testing.T) {
@@ -78,15 +78,15 @@ func TestDeleteFileFromUserHomeDir(t *testing.T) {
 	pathToFile := "testfile"
 	user, _ := user.Current()
 	err := hds.DeleteFileFromUserHomeDir(pathToFile)
-	assert.ErrorIs(t, err, os.ErrNotExist)
+	require.ErrorIs(t, err, os.ErrNotExist)
 
 	err = hds.WriteFileToUserHomeDir(content, pathToFile)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer os.RemoveAll(filepath.Join(user.HomeDir, pathToFile))
 
 	err = hds.DeleteFileFromUserHomeDir(pathToFile)
-	assert.NoError(t, err)
-	assert.NoFileExists(t, filepath.Join(user.HomeDir, pathToFile))
+	require.NoError(t, err)
+	require.NoFileExists(t, filepath.Join(user.HomeDir, pathToFile))
 }
 
 func TestWriteDirFileToUserHomeDir(t *testing.T) {
@@ -95,8 +95,8 @@ func TestWriteDirFileToUserHomeDir(t *testing.T) {
 	pathToFile := filepath.Join(t.TempDir(), "testfile")
 
 	err := hds.WriteFileToUserHomeDir(content, pathToFile)
-	assert.NoError(t, err)
-	assert.FileExists(t, pathToFile)
+	require.NoError(t, err)
+	require.FileExists(t, pathToFile)
 }
 
 func TestDirFileExistsInUserHomeDir(t *testing.T) {
@@ -105,15 +105,15 @@ func TestDirFileExistsInUserHomeDir(t *testing.T) {
 	pathToFile := filepath.Join(t.TempDir(), "testfile")
 
 	exists, err := hds.FileExistsInUserHomeDir(pathToFile)
-	assert.NoError(t, err)
-	assert.False(t, exists)
+	require.NoError(t, err)
+	require.False(t, exists)
 
 	err = hds.WriteFileToUserHomeDir(content, pathToFile)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	exists, err = hds.FileExistsInUserHomeDir(pathToFile)
-	assert.NoError(t, err)
-	assert.True(t, exists)
+	require.NoError(t, err)
+	require.True(t, exists)
 }
 
 func TestDirFileFileFromUserHomeDir(t *testing.T) {
@@ -122,14 +122,14 @@ func TestDirFileFileFromUserHomeDir(t *testing.T) {
 	pathToFile := filepath.Join(t.TempDir(), "testfile")
 
 	_, err := hds.ReadFileFromUserHomeDir(pathToFile)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	err = hds.WriteFileToUserHomeDir(content, pathToFile)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	strcontent, err := hds.ReadFileFromUserHomeDir(pathToFile)
-	assert.NoError(t, err)
-	assert.NotEmpty(t, strcontent)
+	require.NoError(t, err)
+	require.NotEmpty(t, strcontent)
 }
 
 func TestDeleteDirFileFromUserHomeDir(t *testing.T) {
@@ -138,12 +138,12 @@ func TestDeleteDirFileFromUserHomeDir(t *testing.T) {
 	pathToFile := filepath.Join(t.TempDir(), "testfile")
 
 	err := hds.DeleteFileFromUserHomeDir(pathToFile)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	err = hds.WriteFileToUserHomeDir(content, pathToFile)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = hds.DeleteFileFromUserHomeDir(pathToFile)
-	assert.NoError(t, err)
-	assert.NoFileExists(t, pathToFile)
+	require.NoError(t, err)
+	require.NoFileExists(t, pathToFile)
 }

--- a/pkg/client/streams_verified_integration_test.go
+++ b/pkg/client/streams_verified_integration_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/codenotary/immudb/pkg/streamutils"
 
 	"github.com/codenotary/immudb/pkg/api/schema"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -46,6 +45,6 @@ func TestImmuServer_StreamVerifiedSetAndGet(t *testing.T) {
 	entry, err := cliIF.StreamVerifiedGet(ctx, &schema.VerifiableGetRequest{
 		KeyRequest: &schema.KeyRequest{Key: []byte(tmpFile.Name())},
 	})
-	assert.NoError(t, err)
-	assert.Equal(t, (8<<20)-1, len(entry.Value))
+	require.NoError(t, err)
+	require.Equal(t, (8<<20)-1, len(entry.Value))
 }

--- a/pkg/client/timestamp/timestamp_test.go
+++ b/pkg/client/timestamp/timestamp_test.go
@@ -20,13 +20,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDefault(t *testing.T) {
 	def, err := NewDefaultTimestamp()
-	assert.NoError(t, err)
-	assert.IsType(t, def, &timestampDefault{})
+	require.NoError(t, err)
+	require.IsType(t, def, &timestampDefault{})
 	ts := def.Now()
-	assert.IsType(t, ts, time.Time{})
+	require.IsType(t, ts, time.Time{})
 }

--- a/pkg/client/timestamp_service_test.go
+++ b/pkg/client/timestamp_service_test.go
@@ -21,12 +21,12 @@ import (
 	"time"
 
 	"github.com/codenotary/immudb/pkg/client/timestamp"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTimestampService(t *testing.T) {
 	tg, _ := timestamp.NewDefaultTimestamp()
 	tss := NewTimestampService(tg)
 	tim := tss.GetTime()
-	assert.IsType(t, tim, time.Time{})
+	require.IsType(t, tim, time.Time{})
 }

--- a/pkg/logger/json_test.go
+++ b/pkg/logger/json_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestJSONLogger(t *testing.T) {
@@ -35,7 +35,7 @@ func TestJSONLogger(t *testing.T) {
 			Name:   "test",
 			Output: &buf,
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		logger.Info("test call", "user", "foo")
 
@@ -46,10 +46,10 @@ func TestJSONLogger(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		assert.Equal(t, "test call", raw["message"])
-		assert.Equal(t, "foo", raw["user"])
+		require.Equal(t, "test call", raw["message"])
+		require.Equal(t, "foo", raw["user"])
 
-		assert.NoError(t, logger.Close())
+		require.NoError(t, logger.Close())
 	})
 
 	t.Run("use UTC time zone", func(t *testing.T) {
@@ -61,7 +61,7 @@ func TestJSONLogger(t *testing.T) {
 			TimeFormat: time.Kitchen,
 			TimeFnc:    func() time.Time { return time.Now().UTC() },
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		logger.Info("foobar")
 
@@ -77,7 +77,7 @@ func TestJSONLogger(t *testing.T) {
 			t.Fatal("missing 'timestamp' key")
 		}
 
-		assert.Equal(t, val, time.Now().UTC().Format(time.Kitchen))
+		require.Equal(t, val, time.Now().UTC().Format(time.Kitchen))
 	})
 
 	t.Run("log error type", func(t *testing.T) {
@@ -87,7 +87,7 @@ func TestJSONLogger(t *testing.T) {
 			Name:   "test",
 			Output: &buf,
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		errMsg := errors.New("this is an error")
 		logger.Info("test call", "user", "foo", "err", errMsg)
@@ -99,9 +99,9 @@ func TestJSONLogger(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		assert.Equal(t, "test call", raw["message"])
-		assert.Equal(t, "foo", raw["user"])
-		assert.Equal(t, errMsg.Error(), raw["err"])
+		require.Equal(t, "test call", raw["message"])
+		require.Equal(t, "foo", raw["user"])
+		require.Equal(t, errMsg.Error(), raw["err"])
 	})
 
 	t.Run("handles non-serializable args", func(t *testing.T) {
@@ -111,7 +111,7 @@ func TestJSONLogger(t *testing.T) {
 			Name:   "test",
 			Output: &buf,
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		myfunc := func() int { return 42 }
 		logger.Info("test call", "production", myfunc)
@@ -123,13 +123,13 @@ func TestJSONLogger(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		assert.Equal(t, "test call", raw["message"])
-		assert.Equal(t, errInvalidTypeMsg, raw["warn"])
+		require.Equal(t, "test call", raw["message"])
+		require.Equal(t, errInvalidTypeMsg, raw["warn"])
 	})
 
 	t.Run("use file output for logging", func(t *testing.T) {
 		file, err := ioutil.TempFile("", "logger")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		defer os.Remove(file.Name())
 
 		logger, err := NewJSONLogger(&Options{
@@ -138,22 +138,22 @@ func TestJSONLogger(t *testing.T) {
 			TimeFormat: time.Kitchen,
 			TimeFnc:    func() time.Time { return time.Now().UTC() },
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		logger.Info("some info", "foo", "bar")
 
 		logBytes, err := ioutil.ReadFile(file.Name())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		var raw map[string]interface{}
 		if err := json.Unmarshal(logBytes, &raw); err != nil {
 			t.Fatal(err)
 		}
 
-		assert.Equal(t, "some info", raw["message"])
-		assert.Equal(t, "bar", raw["foo"])
+		require.Equal(t, "some info", raw["message"])
+		require.Equal(t, "bar", raw["foo"])
 
-		assert.NoError(t, logger.Close())
+		require.NoError(t, logger.Close())
 	})
 
 	t.Run("log with debug", func(t *testing.T) {
@@ -162,7 +162,7 @@ func TestJSONLogger(t *testing.T) {
 			Name:   "test",
 			Output: &buf,
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		logger.Debug("some info", "foo", "bar")
 
@@ -173,9 +173,9 @@ func TestJSONLogger(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		assert.Equal(t, "some info", raw["message"])
-		assert.Equal(t, "bar", raw["foo"])
-		assert.Equal(t, "debug", raw["level"])
+		require.Equal(t, "some info", raw["message"])
+		require.Equal(t, "bar", raw["foo"])
+		require.Equal(t, "debug", raw["level"])
 	})
 
 	t.Run("log with warning", func(t *testing.T) {
@@ -184,7 +184,7 @@ func TestJSONLogger(t *testing.T) {
 			Name:   "test",
 			Output: &buf,
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		logger.Warning("some info", "foo", "bar")
 		b := buf.Bytes()
@@ -194,9 +194,9 @@ func TestJSONLogger(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		assert.Equal(t, "some info", raw["message"])
-		assert.Equal(t, "bar", raw["foo"])
-		assert.Equal(t, "warn", raw["level"])
+		require.Equal(t, "some info", raw["message"])
+		require.Equal(t, "bar", raw["foo"])
+		require.Equal(t, "warn", raw["level"])
 	})
 
 	t.Run("log with error", func(t *testing.T) {
@@ -205,7 +205,7 @@ func TestJSONLogger(t *testing.T) {
 			Name:   "test",
 			Output: &buf,
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		logger.Error("some info", "foo", "bar")
 		b := buf.Bytes()
@@ -215,9 +215,9 @@ func TestJSONLogger(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		assert.Equal(t, "some info", raw["message"])
-		assert.Equal(t, "bar", raw["foo"])
-		assert.Equal(t, "error", raw["level"])
+		require.Equal(t, "some info", raw["message"])
+		require.Equal(t, "bar", raw["foo"])
+		require.Equal(t, "error", raw["level"])
 	})
 
 	t.Run("log with infof", func(t *testing.T) {
@@ -226,7 +226,7 @@ func TestJSONLogger(t *testing.T) {
 			Name:   "test",
 			Output: &buf,
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		logger.Infof("some info %s %s", "foo", "bar")
 
@@ -237,8 +237,8 @@ func TestJSONLogger(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		assert.Equal(t, "some info foo bar", raw["message"])
-		assert.Equal(t, "info", raw["level"])
+		require.Equal(t, "some info foo bar", raw["message"])
+		require.Equal(t, "info", raw["level"])
 	})
 
 	t.Run("log with debugf", func(t *testing.T) {
@@ -247,7 +247,7 @@ func TestJSONLogger(t *testing.T) {
 			Name:   "test",
 			Output: &buf,
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		logger.Debugf("some info %s %s", "foo", "bar")
 
@@ -258,8 +258,8 @@ func TestJSONLogger(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		assert.Equal(t, "some info foo bar", raw["message"])
-		assert.Equal(t, "debug", raw["level"])
+		require.Equal(t, "some info foo bar", raw["message"])
+		require.Equal(t, "debug", raw["level"])
 	})
 
 	t.Run("log with warningf", func(t *testing.T) {
@@ -268,7 +268,7 @@ func TestJSONLogger(t *testing.T) {
 			Name:   "test",
 			Output: &buf,
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		logger.Warningf("some info %s %s", "foo", "bar")
 		b := buf.Bytes()
@@ -278,8 +278,8 @@ func TestJSONLogger(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		assert.Equal(t, "some info foo bar", raw["message"])
-		assert.Equal(t, "warn", raw["level"])
+		require.Equal(t, "some info foo bar", raw["message"])
+		require.Equal(t, "warn", raw["level"])
 	})
 
 	t.Run("log with errorf", func(t *testing.T) {
@@ -288,7 +288,7 @@ func TestJSONLogger(t *testing.T) {
 			Name:   "test",
 			Output: &buf,
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		logger.Errorf("some info %s %s", "foo", "bar")
 		b := buf.Bytes()
@@ -298,8 +298,8 @@ func TestJSONLogger(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		assert.Equal(t, "some info foo bar", raw["message"])
-		assert.Equal(t, "error", raw["level"])
+		require.Equal(t, "some info foo bar", raw["message"])
+		require.Equal(t, "error", raw["level"])
 	})
 
 	t.Run("log with component", func(t *testing.T) {
@@ -308,7 +308,7 @@ func TestJSONLogger(t *testing.T) {
 			Name:   "test",
 			Output: &buf,
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		logWithFunc(logger, "some info foo bar")
 
@@ -319,7 +319,7 @@ func TestJSONLogger(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		assert.Equal(t, "github.com/codenotary/immudb/pkg/logger.logWithFunc", raw["component"])
+		require.Equal(t, "github.com/codenotary/immudb/pkg/logger.logWithFunc", raw["component"])
 	})
 
 }

--- a/pkg/server/errors_test.go
+++ b/pkg/server/errors_test.go
@@ -23,20 +23,20 @@ import (
 
 	"github.com/codenotary/immudb/embedded/store"
 	immuerrors "github.com/codenotary/immudb/pkg/errors"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMapServerError(t *testing.T) {
 	err := mapServerError(store.ErrIllegalState)
-	assert.Equal(t, ErrIllegalState, err)
+	require.Equal(t, ErrIllegalState, err)
 
 	err = mapServerError(store.ErrIllegalArguments)
-	assert.Equal(t, ErrIllegalArguments, err)
+	require.Equal(t, ErrIllegalArguments, err)
 
 	someError := errors.New("some error")
 	err = mapServerError(someError)
-	assert.Equal(t, someError, err)
+	require.Equal(t, someError, err)
 
 	err = mapServerError(fmt.Errorf("%w: test", store.ErrPreconditionFailed))
-	assert.Equal(t, immuerrors.CodIntegrityConstraintViolation, err.(immuerrors.Error).Code())
+	require.Equal(t, immuerrors.CodIntegrityConstraintViolation, err.(immuerrors.Error).Code())
 }

--- a/pkg/server/metrics_test.go
+++ b/pkg/server/metrics_test.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/peer"
 )
@@ -45,7 +44,7 @@ func TestStartMetrics(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 	defer server.Close()
 
-	assert.IsType(t, &http.Server{}, server)
+	require.IsType(t, &http.Server{}, server)
 }
 
 func TestStartMetricsFail(t *testing.T) {
@@ -65,7 +64,7 @@ func TestStartMetricsFail(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 	defer server.Close()
 
-	assert.IsType(t, &http.Server{}, server)
+	require.IsType(t, &http.Server{}, server)
 }
 
 func TestMetricsCollection_UpdateClientMetrics(t *testing.T) {
@@ -104,7 +103,7 @@ func TestMetricsCollection_UpdateClientMetrics(t *testing.T) {
 	ctx := peer.NewContext(context.TODO(), p)
 	mc.UpdateClientMetrics(ctx)
 
-	assert.IsType(t, MetricsCollection{}, mc)
+	require.IsType(t, MetricsCollection{}, mc)
 }
 
 func TestMetricsCollection_UpdateDBMetrics(t *testing.T) {
@@ -140,7 +139,7 @@ func TestMetricsCollection_UpdateDBMetrics(t *testing.T) {
 	// update after injecting the funcs, to catch the normal execution path
 	mc.UpdateDBMetrics()
 
-	assert.IsType(t, MetricsCollection{}, mc)
+	require.IsType(t, MetricsCollection{}, mc)
 }
 
 func TestImmudbHealthHandlerFunc(t *testing.T) {

--- a/pkg/server/options_test.go
+++ b/pkg/server/options_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/codenotary/immudb/pkg/logger"
 	"github.com/codenotary/immudb/pkg/stream"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -178,7 +177,7 @@ Superadmin default credentials
 		WithPidfile("immu.pid").
 		WithLogfile("immu.log")
 
-	assert.Equal(t, expected, op.String())
+	require.Equal(t, expected, op.String())
 }
 
 func TestOptionsWithSyncReplicationString(t *testing.T) {
@@ -211,7 +210,7 @@ Superadmin default credentials
 		WithSyncReplication(true).
 		WithSyncAcks(1)
 
-	assert.Equal(t, expected, op.String())
+	require.Equal(t, expected, op.String())
 }
 
 func TestOptionsStringWithS3(t *testing.T) {
@@ -252,7 +251,7 @@ Superadmin default credentials
 				WithS3PathPrefix("s3-path-prefix"),
 		)
 
-	assert.Equal(t, expected, op.String())
+	require.Equal(t, expected, op.String())
 }
 
 func TestOptionsStringWithPProf(t *testing.T) {
@@ -282,5 +281,5 @@ Superadmin default credentials
 		WithLogfile("immu.log").
 		WithPProf(true)
 
-	assert.Equal(t, expected, op.String())
+	require.Equal(t, expected, op.String())
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -40,7 +40,6 @@ import (
 	"github.com/codenotary/immudb/pkg/immuos"
 	"github.com/codenotary/immudb/pkg/logger"
 	"github.com/golang/protobuf/ptypes/empty"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -329,7 +328,7 @@ func TestServerWithEmptyAdminPassword(t *testing.T) {
 	defer closer()
 
 	err := s.Initialize()
-	assert.ErrorIs(t, err, ErrEmptyAdminPassword)
+	require.ErrorIs(t, err, ErrEmptyAdminPassword)
 }
 
 func TestServerWithInvalidAdminPassword(t *testing.T) {
@@ -342,7 +341,7 @@ func TestServerWithInvalidAdminPassword(t *testing.T) {
 	defer closer()
 
 	err := s.Initialize()
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestServerErrChunkSizeTooSmall(t *testing.T) {
@@ -354,7 +353,7 @@ func TestServerErrChunkSizeTooSmall(t *testing.T) {
 	defer closer()
 
 	err := s.Initialize()
-	assert.ErrorContains(t, err, stream.ErrChunkTooSmall)
+	require.ErrorContains(t, err, stream.ErrChunkTooSmall)
 }
 
 func TestServerCreateDatabase(t *testing.T) {
@@ -427,12 +426,12 @@ func TestServerCreateDatabaseCaseError(t *testing.T) {
 	ctx = metadata.NewIncomingContext(context.Background(), md)
 
 	_, err = s.CreateDatabaseWith(ctx, newdb)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	newdb.DatabaseName = strings.ToLower(newdb.DatabaseName)
 
 	_, err = s.CreateDatabaseWith(ctx, newdb)
-	assert.ErrorIs(t, err, database.ErrDatabaseAlreadyExists)
+	require.ErrorIs(t, err, database.ErrDatabaseAlreadyExists)
 }
 
 func TestServerCreateMultipleDatabases(t *testing.T) {

--- a/pkg/server/sever_current_state_test.go
+++ b/pkg/server/sever_current_state_test.go
@@ -41,7 +41,7 @@ func TestServerCurrentStateSigned(t *testing.T) {
 	dbRootpath := dir
 
 	sig, err := signer.NewSigner("./../../test/signer/ec3.key")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	stSig := NewStateSigner(sig)
 	s = s.WithOptions(s.Options.WithAuth(false).WithSigningKey("foo")).WithStateSigner(stSig).(*ImmuServer)
@@ -66,7 +66,7 @@ func TestServerCurrentStateSigned(t *testing.T) {
 
 	state, err := s.CurrentState(ctx, &emptypb.Empty{})
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.IsType(t, &schema.ImmutableState{}, state)
 	assert.IsType(t, &schema.Signature{}, state.Signature)
 	assert.NotNil(t, state.Signature.Signature)
@@ -76,6 +76,6 @@ func TestServerCurrentStateSigned(t *testing.T) {
 	require.NoError(t, err)
 
 	ok, err := signer.Verify(state.ToBytes(), state.Signature.Signature, ecdsaPK)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, ok)
 }

--- a/pkg/server/sever_current_state_test.go
+++ b/pkg/server/sever_current_state_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/codenotary/immudb/pkg/api/schema"
 	"github.com/codenotary/immudb/pkg/signer"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
@@ -66,15 +67,15 @@ func TestServerCurrentStateSigned(t *testing.T) {
 	state, err := s.CurrentState(ctx, &emptypb.Empty{})
 
 	require.NoError(t, err)
-	require.IsType(t, &schema.ImmutableState{}, state)
-	require.IsType(t, &schema.Signature{}, state.Signature)
-	require.NotNil(t, state.Signature.Signature)
-	require.NotNil(t, state.Signature.PublicKey)
+	assert.IsType(t, &schema.ImmutableState{}, state)
+	assert.IsType(t, &schema.Signature{}, state.Signature)
+	assert.NotNil(t, state.Signature.Signature)
+	assert.NotNil(t, state.Signature.PublicKey)
 
 	ecdsaPK, err := signer.UnmarshalKey(state.Signature.PublicKey)
 	require.NoError(t, err)
 
 	ok, err := signer.Verify(state.ToBytes(), state.Signature.Signature, ecdsaPK)
 	require.NoError(t, err)
-	require.True(t, ok)
+	assert.True(t, ok)
 }

--- a/pkg/server/sever_current_state_test.go
+++ b/pkg/server/sever_current_state_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/codenotary/immudb/pkg/api/schema"
 	"github.com/codenotary/immudb/pkg/signer"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
@@ -67,15 +66,15 @@ func TestServerCurrentStateSigned(t *testing.T) {
 	state, err := s.CurrentState(ctx, &emptypb.Empty{})
 
 	require.NoError(t, err)
-	assert.IsType(t, &schema.ImmutableState{}, state)
-	assert.IsType(t, &schema.Signature{}, state.Signature)
-	assert.NotNil(t, state.Signature.Signature)
-	assert.NotNil(t, state.Signature.PublicKey)
+	require.IsType(t, &schema.ImmutableState{}, state)
+	require.IsType(t, &schema.Signature{}, state.Signature)
+	require.NotNil(t, state.Signature.Signature)
+	require.NotNil(t, state.Signature.PublicKey)
 
 	ecdsaPK, err := signer.UnmarshalKey(state.Signature.PublicKey)
 	require.NoError(t, err)
 
 	ok, err := signer.Verify(state.ToBytes(), state.Signature.Signature, ecdsaPK)
 	require.NoError(t, err)
-	assert.True(t, ok)
+	require.True(t, ok)
 }

--- a/pkg/server/state_signer_test.go
+++ b/pkg/server/state_signer_test.go
@@ -22,13 +22,13 @@ import (
 	"github.com/codenotary/immudb/embedded/store"
 	"github.com/codenotary/immudb/pkg/api/schema"
 	"github.com/codenotary/immudb/pkg/signer"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewStateSigner(t *testing.T) {
 	s, _ := signer.NewSigner("./../../test/signer/ec3.key")
 	rs := NewStateSigner(s)
-	assert.IsType(t, &stateSigner{}, rs)
+	require.IsType(t, &stateSigner{}, rs)
 }
 
 func TestStateSigner_Sign(t *testing.T) {
@@ -36,13 +36,13 @@ func TestStateSigner_Sign(t *testing.T) {
 	stSigner := NewStateSigner(s)
 	state := &schema.ImmutableState{}
 	err := stSigner.Sign(state)
-	assert.NoError(t, err)
-	assert.IsType(t, &schema.ImmutableState{}, state)
+	require.NoError(t, err)
+	require.IsType(t, &schema.ImmutableState{}, state)
 }
 
 func TestStateSigner_Err(t *testing.T) {
 	s, _ := signer.NewSigner("./../../test/signer/ec3.key")
 	stSigner := NewStateSigner(s)
 	err := stSigner.Sign(nil)
-	assert.Error(t, store.ErrIllegalArguments, err)
+	require.Error(t, store.ErrIllegalArguments, err)
 }

--- a/pkg/server/webserver_test.go
+++ b/pkg/server/webserver_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -49,10 +48,10 @@ func TestStartWebServerHTTP(t *testing.T) {
 	require.NoError(t, err)
 	defer webServer.Close()
 
-	assert.IsType(t, &http.Server{}, webServer)
+	require.IsType(t, &http.Server{}, webServer)
 
 	client := &http.Client{}
-	assert.Eventually(t, func() bool {
+	require.Eventually(t, func() bool {
 		_, err = client.Get("http://0.0.0.0:8080")
 		return err == nil
 	}, 10*time.Second, 30*time.Millisecond)
@@ -94,11 +93,11 @@ EKTcWGekdmdDPsHloRNtsiCa697B2O9IFA==
 	require.NoError(t, err)
 	defer webServer.Close()
 
-	assert.IsType(t, &http.Server{}, webServer)
+	require.IsType(t, &http.Server{}, webServer)
 
 	tr := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
 	client := &http.Client{Transport: tr}
-	assert.Eventually(t, func() bool {
+	require.Eventually(t, func() bool {
 		_, err = client.Get("https://0.0.0.0:8080")
 		return err == nil
 	}, 10*time.Second, 30*time.Millisecond)

--- a/pkg/signer/ecdsa_test.go
+++ b/pkg/signer/ecdsa_test.go
@@ -26,16 +26,15 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewSigner(t *testing.T) {
 	s, err := NewSigner("./../../test/signer/ec3.key")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	var i interface{} = s
 	_, ok := i.(Signer)
-	assert.True(t, ok)
+	require.True(t, ok)
 }
 
 func TestNewSignerFromPKey(t *testing.T) {
@@ -46,33 +45,33 @@ func TestNewSignerFromPKey(t *testing.T) {
 	s := NewSignerFromPKey(r, pk)
 	var i interface{} = s
 	_, ok := i.(Signer)
-	assert.True(t, ok)
+	require.True(t, ok)
 }
 
 func TestNewSignerKeyNotExistent(t *testing.T) {
 	s, err := NewSigner("./not_exists")
-	assert.Error(t, err)
-	assert.Nil(t, s)
+	require.Error(t, err)
+	require.Nil(t, s)
 }
 
 func TestNewSignerNoKeyFound(t *testing.T) {
 	s, err := NewSigner("./../../test/signer/unparsable.key")
-	assert.Error(t, err)
-	assert.Nil(t, s)
+	require.Error(t, err)
+	require.Nil(t, s)
 }
 
 func TestNewSignerKeyUnparsable(t *testing.T) {
 	s, err := NewSigner("./../../test/signer/ec3.pub")
-	assert.Error(t, err)
-	assert.Nil(t, s)
+	require.Error(t, err)
+	require.Nil(t, s)
 }
 
 func TestSignature_Sign(t *testing.T) {
 	s, err := NewSigner("./../../test/signer/ec3.key")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	rawMessage := sha256.Sum256([]byte(`myhash`))
 	_, _, err = s.Sign(rawMessage[:])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestSignature_SignError(t *testing.T) {
@@ -83,38 +82,38 @@ func TestSignature_SignError(t *testing.T) {
 	r := strings.NewReader("")
 	s := NewSignerFromPKey(r, pk)
 	_, _, err := s.Sign([]byte(``))
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestSignature_Verify(t *testing.T) {
 	s, err := NewSigner("./../../test/signer/ec3.key")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	rawMessage := sha256.Sum256([]byte(`myhash`))
 	signature, publicKey, _ := s.Sign(rawMessage[:])
 	ecdsaPK, err := UnmarshalKey(publicKey)
 	require.NoError(t, err)
 	ok, err := Verify(rawMessage[:], signature, ecdsaPK)
-	assert.True(t, ok)
-	assert.NoError(t, err)
+	require.True(t, ok)
+	require.NoError(t, err)
 }
 
 func TestSignature_VerifyError(t *testing.T) {
 	s, err := NewSigner("./../../test/signer/ec3.key")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	rawMessage := sha256.Sum256([]byte(`myhash`))
 	_, publicKey, _ := s.Sign(rawMessage[:])
 	ecdsaPK, err := UnmarshalKey(publicKey)
 	require.NoError(t, err)
 	ok, err := Verify(rawMessage[:], []byte(`wrongsignature`), ecdsaPK)
-	assert.False(t, ok)
-	assert.Error(t, err)
+	require.False(t, ok)
+	require.Error(t, err)
 }
 
 func TestSignature_VerifyFalse(t *testing.T) {
 	s, err := NewSigner("./../../test/signer/ec3.key")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	rawMessage := sha256.Sum256([]byte(`myhash`))
 	_, publicKey, _ := s.Sign(rawMessage[:])
 	sigToMarshal := ecdsaSignature{R: &big.Int{}, S: &big.Int{}}
@@ -122,8 +121,8 @@ func TestSignature_VerifyFalse(t *testing.T) {
 	ecdsaPK, err := UnmarshalKey(publicKey)
 	require.NoError(t, err)
 	ok, err := Verify(rawMessage[:], m, ecdsaPK)
-	assert.False(t, ok)
-	assert.NoError(t, err)
+	require.False(t, ok)
+	require.NoError(t, err)
 }
 
 func TestUnmarshalKey_Error(t *testing.T) {

--- a/pkg/stream/sender_test.go
+++ b/pkg/stream/sender_test.go
@@ -23,13 +23,13 @@ import (
 	"testing"
 
 	"github.com/codenotary/immudb/pkg/stream/streamtest"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewMsgSender(t *testing.T) {
 	sm := streamtest.DefaultImmuServiceSenderStreamMock()
 	s := NewMsgSender(sm, 4096)
-	assert.IsType(t, new(msgSender), s)
+	require.IsType(t, new(msgSender), s)
 }
 
 func TestMsgSender_Send(t *testing.T) {
@@ -40,7 +40,7 @@ func TestMsgSender_Send(t *testing.T) {
 	message := bytes.Join([][]byte{streamtest.GetTrailer(len(content)), content}, nil)
 	b := bytes.NewBuffer(message)
 	err := s.Send(b, b.Len())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestMsgSender_SendPayloadSizeZero(t *testing.T) {
@@ -48,7 +48,7 @@ func TestMsgSender_SendPayloadSizeZero(t *testing.T) {
 	s := NewMsgSender(sm, 4096)
 	b := bytes.NewBuffer(nil)
 	err := s.Send(b, 0)
-	assert.Equal(t, ErrMessageLengthIsZero, err.Error())
+	require.Equal(t, ErrMessageLengthIsZero, err.Error())
 }
 
 func TestMsgSender_SendErrReader(t *testing.T) {
@@ -60,7 +60,7 @@ func TestMsgSender_SendErrReader(t *testing.T) {
 		},
 	}
 	err := s.Send(r, 5000)
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestMsgSender_SendEmptyReader(t *testing.T) {
@@ -72,7 +72,7 @@ func TestMsgSender_SendEmptyReader(t *testing.T) {
 		},
 	}
 	err := s.Send(r, 5000)
-	assert.Equal(t, ErrReaderIsEmpty, err.Error())
+	require.Equal(t, ErrReaderIsEmpty, err.Error())
 }
 
 func TestMsgSender_SendEErrNotEnoughDataOnStream(t *testing.T) {
@@ -83,7 +83,7 @@ func TestMsgSender_SendEErrNotEnoughDataOnStream(t *testing.T) {
 	message := streamtest.GetTrailer(len(content))
 	b := bytes.NewBuffer(message)
 	err := s.Send(b, 5000)
-	assert.Equal(t, ErrNotEnoughDataOnStream, err.Error())
+	require.Equal(t, ErrNotEnoughDataOnStream, err.Error())
 }
 
 func TestMsgSender_SendLastChunk(t *testing.T) {
@@ -93,7 +93,7 @@ func TestMsgSender_SendLastChunk(t *testing.T) {
 	content := []byte(`mycontent`)
 	b := bytes.NewBuffer(content)
 	err := s.Send(b, len(content))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestMsgSender_SendMultipleChunks(t *testing.T) {
@@ -103,12 +103,12 @@ func TestMsgSender_SendMultipleChunks(t *testing.T) {
 	content := []byte(`mycontent`)
 	b := bytes.NewBuffer(content)
 	err := s.Send(b, len(content))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestMsgSender_RecvMsg(t *testing.T) {
 	sm := streamtest.DefaultImmuServiceSenderStreamMock()
 	s := NewMsgSender(sm, 4096)
 	err := s.RecvMsg(nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
Replaced assert with require as mentioned in [this issue](https://github.com/codenotary/immudb/issues/1436).
As this is my first contribution to your project and to open source at all I'm making this pull request only in scope of `pkg/`.

I intentionally omitted replacement in `pkg/server/sessions/options_test.go` because I would argue that it's beneficial to see all errors related to configuration at once instead of only the first that is raised. I did not revert existing `require` to `assert` tho.

I'm open for suggestions, and if pull is accepted I'm happy to contribute further.