### PR TITLE
mvcc

### DIFF
--- a/embedded/sql/row_reader.go
+++ b/embedded/sql/row_reader.go
@@ -124,7 +124,7 @@ type rawRowReader struct {
 
 	params map[string]interface{}
 
-	reader          *store.KeyReader
+	reader          store.KeyReader
 	onCloseCallback func()
 }
 
@@ -155,7 +155,7 @@ func newRawRowReader(tx *SQLTx, params map[string]interface{}, table *Table, per
 		return nil, err
 	}
 
-	r, err := tx.newKeyReader(rSpec)
+	r, err := tx.newKeyReader(*rSpec)
 	if err != nil {
 		return nil, err
 	}
@@ -393,7 +393,7 @@ func (r *rawRowReader) Read() (row *Row, err error) {
 	if r.txRange == nil {
 		mkey, vref, err = r.reader.Read()
 	} else {
-		mkey, vref, _, err = r.reader.ReadBetween(r.txRange.initialTxID, r.txRange.finalTxID)
+		mkey, vref, err = r.reader.ReadBetween(r.txRange.initialTxID, r.txRange.finalTxID)
 	}
 	if err != nil {
 		return nil, err

--- a/embedded/sql/stmt.go
+++ b/embedded/sql/stmt.go
@@ -2068,7 +2068,7 @@ const (
 
 type DataSource interface {
 	SQLStmt
-	Resolve(tx *SQLTx, params map[string]interface{}, ScanSpecs *ScanSpecs) (RowReader, error)
+	Resolve(tx *SQLTx, params map[string]interface{}, scanSpecs *ScanSpecs) (RowReader, error)
 	Alias() string
 }
 
@@ -3665,7 +3665,7 @@ func (stmt *FnDataSourceStmt) Resolve(tx *SQLTx, params map[string]interface{}, 
 	return nil, fmt.Errorf("%w (%s)", ErrFunctionDoesNotExist, stmt.fnCall.fn)
 }
 
-func (stmt *FnDataSourceStmt) resolveListDatabases(tx *SQLTx, params map[string]interface{}, ScanSpecs *ScanSpecs) (rowReader RowReader, err error) {
+func (stmt *FnDataSourceStmt) resolveListDatabases(tx *SQLTx, params map[string]interface{}, _ *ScanSpecs) (rowReader RowReader, err error) {
 	if len(stmt.fnCall.params) > 0 {
 		return nil, fmt.Errorf("%w: function '%s' expect no parameters but %d were provided", ErrIllegalArguments, DatabasesFnCall, len(stmt.fnCall.params))
 	}
@@ -3700,7 +3700,7 @@ func (stmt *FnDataSourceStmt) resolveListDatabases(tx *SQLTx, params map[string]
 	return newValuesRowReader(tx, cols, "*", stmt.Alias(), values)
 }
 
-func (stmt *FnDataSourceStmt) resolveListTables(tx *SQLTx, params map[string]interface{}, ScanSpecs *ScanSpecs) (rowReader RowReader, err error) {
+func (stmt *FnDataSourceStmt) resolveListTables(tx *SQLTx, params map[string]interface{}, _ *ScanSpecs) (rowReader RowReader, err error) {
 	if len(stmt.fnCall.params) > 0 {
 		return nil, fmt.Errorf("%w: function '%s' expect no parameters but %d were provided", ErrIllegalArguments, TablesFnCall, len(stmt.fnCall.params))
 	}
@@ -3724,7 +3724,7 @@ func (stmt *FnDataSourceStmt) resolveListTables(tx *SQLTx, params map[string]int
 	return newValuesRowReader(tx, cols, db.name, stmt.Alias(), values)
 }
 
-func (stmt *FnDataSourceStmt) resolveListColumns(tx *SQLTx, params map[string]interface{}, ScanSpecs *ScanSpecs) (RowReader, error) {
+func (stmt *FnDataSourceStmt) resolveListColumns(tx *SQLTx, params map[string]interface{}, _ *ScanSpecs) (RowReader, error) {
 	if len(stmt.fnCall.params) != 1 {
 		return nil, fmt.Errorf("%w: function '%s' expect table name as parameter", ErrIllegalArguments, ColumnsFnCall)
 	}
@@ -3819,7 +3819,7 @@ func (stmt *FnDataSourceStmt) resolveListColumns(tx *SQLTx, params map[string]in
 	return newValuesRowReader(tx, cols, table.db.name, stmt.Alias(), values)
 }
 
-func (stmt *FnDataSourceStmt) resolveListIndexes(tx *SQLTx, params map[string]interface{}, ScanSpecs *ScanSpecs) (RowReader, error) {
+func (stmt *FnDataSourceStmt) resolveListIndexes(tx *SQLTx, params map[string]interface{}, _ *ScanSpecs) (RowReader, error) {
 	if len(stmt.fnCall.params) != 1 {
 		return nil, fmt.Errorf("%w: function '%s' expect table name as parameter", ErrIllegalArguments, IndexesFnCall)
 	}

--- a/embedded/store/immustore.go
+++ b/embedded/store/immustore.go
@@ -759,8 +759,8 @@ func (s *ImmuStore) NewTxHolderPool(poolSize int, preallocated bool) (TxPool, er
 	})
 }
 
-func (s *ImmuStore) unsafeSnapshot() (*Snapshot, error) {
-	snap, err := s.indexer.index.UnsafeSnapshot()
+func (s *ImmuStore) syncSnapshot() (*Snapshot, error) {
+	snap, err := s.indexer.index.SyncSnapshot()
 	if err != nil {
 		return nil, err
 	}

--- a/embedded/store/immustore.go
+++ b/embedded/store/immustore.go
@@ -759,6 +759,19 @@ func (s *ImmuStore) NewTxHolderPool(poolSize int, preallocated bool) (TxPool, er
 	})
 }
 
+func (s *ImmuStore) unsafeSnapshot() (*Snapshot, error) {
+	snap, err := s.indexer.index.UnsafeSnapshot()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Snapshot{
+		st:   s,
+		snap: snap,
+		ts:   time.Now(),
+	}, nil
+}
+
 func (s *ImmuStore) Snapshot() (*Snapshot, error) {
 	snap, err := s.indexer.Snapshot()
 	if err != nil {

--- a/embedded/store/immustore_test.go
+++ b/embedded/store/immustore_test.go
@@ -1089,6 +1089,12 @@ func TestImmudbStoreRWTransactions(t *testing.T) {
 		err = tx.Set([]byte("key1"), nil, []byte("value1"))
 		require.NoError(t, err)
 
+		_, err = tx.GetWithFilters([]byte("key1"), nil)
+		require.ErrorIs(t, err, ErrIllegalArguments)
+
+		_, _, err = tx.GetWithPrefixAndFilters([]byte("key1"), nil, nil)
+		require.ErrorIs(t, err, ErrIllegalArguments)
+
 		key, valRef, err := tx.GetWithPrefix([]byte("key1"), []byte("key"))
 		require.NoError(t, err)
 		require.NotNil(t, key)
@@ -1260,6 +1266,9 @@ func TestImmudbStoreRWTransactions(t *testing.T) {
 		require.ErrorIs(t, err, ErrKeyNotFound)
 
 		_, err = immuStore.GetWithFilters([]byte{1, 2, 3}, nil)
+		require.ErrorIs(t, err, ErrIllegalArguments)
+
+		_, _, err = immuStore.GetWithPrefixAndFilters([]byte{1, 2, 3}, nil, nil)
 		require.ErrorIs(t, err, ErrIllegalArguments)
 
 		valRef, err := immuStore.GetWithFilters([]byte{1, 2, 3})

--- a/embedded/store/indexer.go
+++ b/embedded/store/indexer.go
@@ -163,15 +163,15 @@ func (idx *indexer) SnapshotSince(tx uint64) (*tbtree.Snapshot, error) {
 	return idx.index.SnapshotSince(tx)
 }
 
-func (idx *indexer) ExistKeyWith(prefix []byte, neq []byte) (bool, error) {
+func (idx *indexer) GetWithPrefix(prefix []byte, neq []byte) (key []byte, value []byte, tx uint64, hc uint64, err error) {
 	idx.mutex.Lock()
 	defer idx.mutex.Unlock()
 
 	if idx.closed {
-		return false, ErrAlreadyClosed
+		return nil, nil, 0, 0, ErrAlreadyClosed
 	}
 
-	return idx.index.ExistKeyWith(prefix, neq)
+	return idx.index.GetWithPrefix(prefix, neq)
 }
 
 func (idx *indexer) Sync() error {

--- a/embedded/store/indexer_test.go
+++ b/embedded/store/indexer_test.go
@@ -65,8 +65,7 @@ func TestClosedIndexerFailures(t *testing.T) {
 	require.Zero(t, snap)
 	require.ErrorIs(t, err, ErrAlreadyClosed)
 
-	exists, err := indexer.ExistKeyWith(nil, nil)
-	require.Zero(t, exists)
+	_, _, _, _, err = indexer.GetWithPrefix(nil, nil)
 	require.ErrorIs(t, err, ErrAlreadyClosed)
 
 	err = indexer.Sync()
@@ -190,8 +189,7 @@ func TestClosedIndexer(t *testing.T) {
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, ErrAlreadyClosed)
 
-	_, err = i.ExistKeyWith(dummy, dummy)
-	assert.Error(t, err)
+	_, _, _, _, err = i.GetWithPrefix(dummy, dummy)
 	assert.ErrorIs(t, err, ErrAlreadyClosed)
 
 	err = i.Sync()

--- a/embedded/store/key_reader.go
+++ b/embedded/store/key_reader.go
@@ -355,17 +355,17 @@ func (r *storeKeyReader) ReadBetween(initialTxID, finalTxID uint64) (key []byte,
 
 		valRef := r.refInterceptor(key, val)
 
-		skipEntry := false
+		filterEntry := false
 
 		for _, filter := range r.filters {
 			err = filter(valRef, r.snap.ts)
 			if err != nil {
-				skipEntry = true
+				filterEntry = true
 				break
 			}
 		}
 
-		if skipEntry {
+		if filterEntry {
 			continue
 		}
 
@@ -392,17 +392,17 @@ func (r *storeKeyReader) Read() (key []byte, val ValueRef, err error) {
 
 		valRef := r.refInterceptor(key, val)
 
-		skipEntry := false
+		filterEntry := false
 
 		for _, filter := range r.filters {
 			err = filter(valRef, r.snap.ts)
 			if err != nil {
-				skipEntry = true
+				filterEntry = true
 				break
 			}
 		}
 
-		if skipEntry {
+		if filterEntry {
 			continue
 		}
 

--- a/embedded/store/key_reader_test.go
+++ b/embedded/store/key_reader_test.go
@@ -57,10 +57,7 @@ func TestImmudbStoreReader(t *testing.T) {
 
 	defer snap.Close()
 
-	_, err = snap.NewKeyReader(nil)
-	require.ErrorIs(t, err, ErrIllegalArguments)
-
-	reader, err := snap.NewKeyReader(&KeyReaderSpec{})
+	reader, err := snap.NewKeyReader(KeyReaderSpec{})
 	require.NoError(t, err)
 
 	defer reader.Close()
@@ -119,7 +116,7 @@ func TestImmudbStoreReaderAsBefore(t *testing.T) {
 
 	defer snap.Close()
 
-	reader, err := snap.NewKeyReader(&KeyReaderSpec{})
+	reader, err := snap.NewKeyReader(KeyReaderSpec{})
 	require.NoError(t, err)
 
 	defer reader.Close()
@@ -132,7 +129,7 @@ func TestImmudbStoreReaderAsBefore(t *testing.T) {
 			var v [8]byte
 			binary.BigEndian.PutUint64(v[:], uint64(i))
 
-			rk, vref, _, err := reader.ReadBetween(0, uint64(i+1))
+			rk, vref, err := reader.ReadBetween(0, uint64(i+1))
 			require.NoError(t, err)
 			require.Equal(t, k[:], rk)
 
@@ -185,7 +182,7 @@ func TestImmudbStoreReaderWithOffset(t *testing.T) {
 
 	offset := eCount - 10
 
-	reader, err := snap.NewKeyReader(&KeyReaderSpec{
+	reader, err := snap.NewKeyReader(KeyReaderSpec{
 		Offset: uint64(offset),
 	})
 	require.NoError(t, err)
@@ -248,7 +245,7 @@ func TestImmudbStoreReaderAsBeforeWithOffset(t *testing.T) {
 
 	offset := eCount - 10
 
-	reader, err := snap.NewKeyReader(&KeyReaderSpec{
+	reader, err := snap.NewKeyReader(KeyReaderSpec{
 		Offset: uint64(offset),
 	})
 	require.NoError(t, err)
@@ -263,7 +260,7 @@ func TestImmudbStoreReaderAsBeforeWithOffset(t *testing.T) {
 			var v [8]byte
 			binary.BigEndian.PutUint64(v[:], uint64(i))
 
-			rk, vref, _, err := reader.ReadBetween(0, uint64(i+1))
+			rk, vref, err := reader.ReadBetween(0, uint64(i+1))
 			require.NoError(t, err)
 			require.Equal(t, k[:], rk)
 

--- a/embedded/store/ongoing_tx.go
+++ b/embedded/store/ongoing_tx.go
@@ -35,6 +35,7 @@ type OngoingTx struct {
 
 	preconditions []Precondition
 
+	//MVCC
 	expectedGets           []expectedGet
 	expectedGetsWithPrefix []expectedGetWithPrefix
 	expectedReaders        []*expectedReader
@@ -437,7 +438,7 @@ func (tx *OngoingTx) checkPreconditions(st *ImmuStore) error {
 	}
 
 	for _, e := range tx.expectedGetsWithPrefix {
-		key, valRef, err := snap.GetWithPrefix(e.prefix, e.neq)
+		key, valRef, err := snap.GetWithPrefixAndFilters(e.prefix, e.neq, e.filters...)
 		if errors.Is(err, ErrKeyNotFound) {
 			if e.expectedTx > 0 {
 				return ErrTxReadConflict

--- a/embedded/store/ongoing_tx.go
+++ b/embedded/store/ongoing_tx.go
@@ -49,7 +49,7 @@ type OngoingTx struct {
 type expectedGet struct {
 	key        []byte
 	filters    []FilterFn
-	expectedTx uint64 // 0 used denotes non-existence
+	expectedTx uint64 // 0 used to denote non-existence
 }
 
 type expectedGetWithPrefix struct {
@@ -57,7 +57,7 @@ type expectedGetWithPrefix struct {
 	neq         []byte
 	filters     []FilterFn
 	expectedKey []byte
-	expectedTx  uint64 // 0 used denotes non-existence
+	expectedTx  uint64 // 0 used to denote non-existence
 }
 
 type EntrySpec struct {

--- a/embedded/store/ongoing_tx.go
+++ b/embedded/store/ongoing_tx.go
@@ -400,11 +400,9 @@ func (tx *OngoingTx) checkPreconditions(st *ImmuStore) error {
 		}
 	}
 
-	/*
-		if tx.IsWriteOnly() || tx.snap.Ts() >= st.lastPrecommittedTxID() {
-			return nil
-		}
-	*/
+	if tx.IsWriteOnly() || tx.snap.Ts() >= st.lastPrecommittedTxID() {
+		return nil
+	}
 
 	snap, err := st.unsafeSnapshot()
 	if err != nil {

--- a/embedded/store/ongoing_tx.go
+++ b/embedded/store/ongoing_tx.go
@@ -400,7 +400,7 @@ func (tx *OngoingTx) checkPreconditions(st *ImmuStore) error {
 		}
 	}
 
-	if tx.IsWriteOnly() || tx.snap.Ts() >= st.lastPrecommittedTxID() {
+	if tx.IsWriteOnly() {
 		return nil
 	}
 

--- a/embedded/store/ongoing_tx.go
+++ b/embedded/store/ongoing_tx.go
@@ -408,9 +408,11 @@ func (tx *OngoingTx) checkPreconditions(st *ImmuStore) error {
 	}
 
 	if tx.IsWriteOnly() || tx.snap.Ts() > st.lastPrecommittedTxID() {
+		// read-only transactions or read-write transactions when no other transaction was committed won't be invalidated
 		return nil
 	}
 
+	// current snapshot is fetched without flushing
 	snap, err := st.syncSnapshot()
 	if err != nil {
 		return err

--- a/embedded/store/ongoing_tx.go
+++ b/embedded/store/ongoing_tx.go
@@ -400,7 +400,7 @@ func (tx *OngoingTx) checkPreconditions(st *ImmuStore) error {
 		}
 	}
 
-	if tx.IsWriteOnly() {
+	if tx.IsWriteOnly() || tx.snap.Ts() > st.lastPrecommittedTxID() {
 		return nil
 	}
 

--- a/embedded/store/ongoing_tx.go
+++ b/embedded/store/ongoing_tx.go
@@ -404,11 +404,11 @@ func (tx *OngoingTx) checkPreconditions(st *ImmuStore) error {
 		return nil
 	}
 
-	snap, err := st.unsafeSnapshot()
+	snap, err := st.syncSnapshot()
 	if err != nil {
 		return err
 	}
-	// defer snap.Close() <- TODO: snap, err := st.lockedSnapshot()
+	defer snap.Close()
 
 	for _, e := range tx.expectedGetsWithFilters {
 		valRef, err := snap.GetWithFilters(e.key, e.filters...)

--- a/embedded/store/ongoing_tx_keyreader.go
+++ b/embedded/store/ongoing_tx_keyreader.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2022 Codenotary Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package store
+
+type expectedReader struct {
+	spec          KeyReaderSpec
+	expectedReads [][]expectedRead
+}
+
+type expectedRead struct {
+	initialTxID uint64
+	finalTxID   uint64
+
+	expectedKey []byte
+	expectedTx  uint64
+}
+
+type ongoingTxKeyReader struct {
+	keyReader      KeyReader
+	expectedReader *expectedReader
+}
+
+func newExpectedReader(spec KeyReaderSpec) *expectedReader {
+	return &expectedReader{
+		spec:          spec,
+		expectedReads: make([][]expectedRead, 1),
+	}
+}
+
+func newOngoingTxKeyReader(keyReader KeyReader, expectedReader *expectedReader) *ongoingTxKeyReader {
+	return &ongoingTxKeyReader{
+		keyReader:      keyReader,
+		expectedReader: expectedReader,
+	}
+}
+
+func (r *ongoingTxKeyReader) Read() (key []byte, val ValueRef, err error) {
+	key, valRef, err := r.keyReader.Read()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if valRef.Tx() > 0 {
+		// it only requires validation when the entry was pre-existent to ongoing tx
+		expectedRead := expectedRead{
+			expectedKey: key,
+			expectedTx:  valRef.Tx(),
+		}
+
+		i := len(r.expectedReader.expectedReads) - 1
+
+		r.expectedReader.expectedReads[i] = append(r.expectedReader.expectedReads[i], expectedRead)
+	}
+
+	return key, valRef, nil
+}
+
+func (r *ongoingTxKeyReader) ReadBetween(initialTxID, finalTxID uint64) (key []byte, val ValueRef, err error) {
+	key, valRef, err := r.keyReader.ReadBetween(initialTxID, finalTxID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if valRef.Tx() > 0 {
+		// it only requires validation when the entry was pre-existent to ongoing tx
+
+		expectedRead := expectedRead{
+			initialTxID: initialTxID,
+			finalTxID:   finalTxID,
+			expectedKey: key,
+			expectedTx:  valRef.Tx(),
+		}
+
+		i := len(r.expectedReader.expectedReads) - 1
+
+		r.expectedReader.expectedReads[i] = append(r.expectedReader.expectedReads[i], expectedRead)
+	}
+
+	return key, valRef, nil
+}
+
+func (r *ongoingTxKeyReader) Reset() error {
+	err := r.keyReader.Reset()
+	if err != nil {
+		return err
+	}
+
+	r.expectedReader.expectedReads = append(r.expectedReader.expectedReads, nil)
+
+	return nil
+}
+
+func (r *ongoingTxKeyReader) Close() error {
+	return r.keyReader.Close()
+}

--- a/embedded/store/ongoing_tx_keyreader.go
+++ b/embedded/store/ongoing_tx_keyreader.go
@@ -34,11 +34,13 @@ type expectedRead struct {
 	expectedNoMoreEntries bool
 }
 
+// ongoingTxKeyReader wraps a keyReader and keeps track of read entries
+// read entries are validated against the current database state at commit time
 type ongoingTxKeyReader struct {
 	tx *OngoingTx
 
 	keyReader KeyReader
-	offset    uint64
+	offset    uint64 // offset and filtering is handled by the wrapper in order to have full control of read entries
 	skipped   uint64
 
 	expectedReader *expectedReader

--- a/embedded/store/ongoing_tx_keyreader.go
+++ b/embedded/store/ongoing_tx_keyreader.go
@@ -57,7 +57,7 @@ func (r *ongoingTxKeyReader) Read() (key []byte, val ValueRef, err error) {
 	if valRef.Tx() > 0 {
 		// it only requires validation when the entry was pre-existent to ongoing tx
 		expectedRead := expectedRead{
-			expectedKey: key,
+			expectedKey: cp(key),
 			expectedTx:  valRef.Tx(),
 		}
 
@@ -81,7 +81,7 @@ func (r *ongoingTxKeyReader) ReadBetween(initialTxID, finalTxID uint64) (key []b
 		expectedRead := expectedRead{
 			initialTxID: initialTxID,
 			finalTxID:   finalTxID,
-			expectedKey: key,
+			expectedKey: cp(key),
 			expectedTx:  valRef.Tx(),
 		}
 

--- a/embedded/store/ongoing_tx_keyreader.go
+++ b/embedded/store/ongoing_tx_keyreader.go
@@ -92,6 +92,13 @@ func (r *ongoingTxKeyReader) Read() (key []byte, val ValueRef, err error) {
 			return nil, nil, err
 		}
 
+		expectedRead := expectedRead{
+			expectedKey: cp(key),
+			expectedTx:  valRef.Tx(),
+		}
+
+		r.expectedReader.expectedReads[r.expectedReader.i] = append(r.expectedReader.expectedReads[r.expectedReader.i], expectedRead)
+
 		filterEntry := false
 
 		for _, filter := range r.expectedReader.spec.Filters {
@@ -102,14 +109,6 @@ func (r *ongoingTxKeyReader) Read() (key []byte, val ValueRef, err error) {
 			}
 		}
 
-		if valRef.Tx() == 0 && !filterEntry {
-			expectedRead := expectedRead{
-				expectedKey: cp(key),
-			}
-
-			r.expectedReader.expectedReads[r.expectedReader.i] = append(r.expectedReader.expectedReads[r.expectedReader.i], expectedRead)
-		}
-
 		if filterEntry {
 			continue
 		}
@@ -117,15 +116,6 @@ func (r *ongoingTxKeyReader) Read() (key []byte, val ValueRef, err error) {
 		if r.skipped < r.offset {
 			r.skipped++
 			continue
-		}
-
-		if valRef.Tx() > 0 {
-			expectedRead := expectedRead{
-				expectedKey: cp(key),
-				expectedTx:  valRef.Tx(),
-			}
-
-			r.expectedReader.expectedReads[r.expectedReader.i] = append(r.expectedReader.expectedReads[r.expectedReader.i], expectedRead)
 		}
 
 		return key, valRef, nil

--- a/embedded/store/preconditions.go
+++ b/embedded/store/preconditions.go
@@ -111,7 +111,7 @@ func (cs *PreconditionKeyNotModifiedAfterTx) Validate(st *ImmuStore) error {
 
 func (cs *PreconditionKeyNotModifiedAfterTx) Check(idx KeyIndex) (bool, error) {
 	// get the latest entry (it could be deleted or even expired)
-	valRef, err := idx.GetWith(cs.Key)
+	valRef, err := idx.GetWithFilters(cs.Key)
 	if err != nil && errors.Is(err, ErrKeyNotFound) {
 		// key does not exist thus not modified at all
 		return true, nil

--- a/embedded/tbtree/consistency_error_test.go
+++ b/embedded/tbtree/consistency_error_test.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2022 Codenotary Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package tbtree
 
 import (

--- a/embedded/tbtree/metrics.go
+++ b/embedded/tbtree/metrics.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2022 Codenotary Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package tbtree
 
 import (
@@ -6,7 +21,8 @@ import (
 )
 
 // TODO: Those should be put behind abstract metrics system to avoid dependency on
-//       prometheus inside embedded package
+//
+//	prometheus inside embedded package
 var metricsFlushedNodesLastCycle = promauto.NewGaugeVec(prometheus.GaugeOpts{
 	Name: "immudb_btree_flushed_nodes_last_cycle",
 	Help: "Numbers of btree nodes written to disk during the last flush process",

--- a/embedded/tbtree/reader_test.go
+++ b/embedded/tbtree/reader_test.go
@@ -33,7 +33,7 @@ func TestReaderForEmptyTreeShouldReturnError(t *testing.T) {
 	require.NoError(t, err)
 	defer snapshot.Close()
 
-	r, err := snapshot.NewReader(&ReaderSpec{SeekKey: []byte{0, 0, 0, 0}, DescOrder: false})
+	r, err := snapshot.NewReader(ReaderSpec{SeekKey: []byte{0, 0, 0, 0}, DescOrder: false})
 	require.NoError(t, err)
 
 	_, _, _, _, err = r.Read()
@@ -51,9 +51,6 @@ func TestReaderWithInvalidSpec(t *testing.T) {
 	require.NotNil(t, snapshot)
 	require.NoError(t, err)
 	defer snapshot.Close()
-
-	_, err = snapshot.NewReader(nil)
-	require.ErrorIs(t, err, ErrIllegalArguments)
 }
 
 func TestReaderAscendingScan(t *testing.T) {
@@ -76,7 +73,7 @@ func TestReaderAscendingScan(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	rspec := &ReaderSpec{
+	rspec := ReaderSpec{
 		SeekKey:   []byte{0, 0, 0, 250},
 		Prefix:    []byte{0, 0, 0, 250},
 		DescOrder: false,
@@ -103,6 +100,9 @@ func TestReaderAscendingScan(t *testing.T) {
 	_, _, _, _, err = reader.Read()
 	require.ErrorIs(t, err, ErrAlreadyClosed)
 
+	err = reader.Reset()
+	require.ErrorIs(t, err, ErrAlreadyClosed)
+
 	err = reader.Close()
 	require.ErrorIs(t, err, ErrAlreadyClosed)
 }
@@ -127,7 +127,7 @@ func TestReaderAscendingScanWithEndingKey(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	rspec := &ReaderSpec{
+	rspec := ReaderSpec{
 		EndKey:       []byte{0, 0, 0, 100},
 		InclusiveEnd: true,
 		Prefix:       []byte{0, 0, 0},
@@ -185,7 +185,7 @@ func TestReaderAscendingScanAsBefore(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	rspec := &ReaderSpec{
+	rspec := ReaderSpec{
 		SeekKey:   []byte{0, 0, 0, 250},
 		Prefix:    []byte{0, 0, 0, 250},
 		DescOrder: false,
@@ -245,7 +245,7 @@ func TestReaderAsBefore(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	rspec := &ReaderSpec{
+	rspec := ReaderSpec{
 		Prefix: key,
 	}
 	reader, err := snapshot.NewReader(rspec)
@@ -281,7 +281,7 @@ func TestReaderAscendingScanWithoutSeekKey(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	rspec := &ReaderSpec{
+	rspec := ReaderSpec{
 		SeekKey:   nil,
 		Prefix:    []byte{0, 0, 0, 250},
 		DescOrder: false,
@@ -336,7 +336,7 @@ func TestReaderDescendingScan(t *testing.T) {
 	prefixKey := make([]byte, 3)
 	prefixKey[2] = 1
 
-	rspec := &ReaderSpec{
+	rspec := ReaderSpec{
 		SeekKey:   seekKey,
 		Prefix:    prefixKey,
 		DescOrder: true,
@@ -385,7 +385,7 @@ func TestReaderDescendingScanAsBefore(t *testing.T) {
 	prefixKey := make([]byte, 3)
 	prefixKey[2] = 1
 
-	rspec := &ReaderSpec{
+	rspec := ReaderSpec{
 		SeekKey:   seekKey,
 		Prefix:    prefixKey,
 		DescOrder: true,
@@ -436,7 +436,7 @@ func TestReaderDescendingWithoutSeekKeyScan(t *testing.T) {
 	prefixKey := make([]byte, 3)
 	prefixKey[2] = 1
 
-	rspec := &ReaderSpec{
+	rspec := ReaderSpec{
 		SeekKey:   nil,
 		Prefix:    prefixKey,
 		DescOrder: true,
@@ -481,7 +481,7 @@ func TestFullScanAscendingOrder(t *testing.T) {
 	require.Equal(t, uint64(keyCount), snapshot.Ts())
 	defer snapshot.Close()
 
-	rspec := &ReaderSpec{
+	rspec := ReaderSpec{
 		SeekKey:   nil,
 		Prefix:    nil,
 		DescOrder: false,
@@ -518,7 +518,7 @@ func TestFullScanDescendingOrder(t *testing.T) {
 	require.NoError(t, err)
 	defer snapshot.Close()
 
-	rspec := &ReaderSpec{
+	rspec := ReaderSpec{
 		SeekKey:   []byte{255, 255, 255, 255},
 		Prefix:    nil,
 		DescOrder: true,

--- a/embedded/tbtree/reader_test.go
+++ b/embedded/tbtree/reader_test.go
@@ -33,6 +33,9 @@ func TestReaderForEmptyTreeShouldReturnError(t *testing.T) {
 	require.NoError(t, err)
 	defer snapshot.Close()
 
+	_, err = snapshot.NewReader(ReaderSpec{SeekKey: make([]byte, tbtree.maxKeySize+1)})
+	require.ErrorIs(t, err, ErrIllegalArguments)
+
 	r, err := snapshot.NewReader(ReaderSpec{SeekKey: []byte{0, 0, 0, 0}, DescOrder: false})
 	require.NoError(t, err)
 

--- a/embedded/tbtree/snapshot.go
+++ b/embedded/tbtree/snapshot.go
@@ -138,15 +138,7 @@ func (s *Snapshot) GetWithPrefix(prefix []byte, neq []byte) (key []byte, value [
 
 	leafValue := leaf.values[off]
 
-	if len(prefix) > len(leafValue.key) {
-		return nil, nil, 0, 0, ErrKeyNotFound
-	}
-
-	if bytes.Equal(prefix, leafValue.key[:len(prefix)]) {
-		return leafValue.key, cp(leafValue.value), leafValue.ts, leafValue.hCount + uint64(len(leafValue.tss)), nil
-	}
-
-	return nil, nil, 0, 0, ErrKeyNotFound
+	return leafValue.key, cp(leafValue.value), leafValue.ts, leafValue.hCount + uint64(len(leafValue.tss)), nil
 }
 
 func (s *Snapshot) NewHistoryReader(spec *HistoryReaderSpec) (*HistoryReader, error) {

--- a/embedded/tbtree/snapshot_test.go
+++ b/embedded/tbtree/snapshot_test.go
@@ -167,7 +167,10 @@ func TestSnapshotIsolation(t *testing.T) {
 		require.NoError(t, err)
 		require.NotZero(t, ts)
 
-		_, _, _, _, err = snap1.GetWithPrefix([]byte("key3"), []byte("key3"))
+		_, _, _, _, err = snap1.GetWithPrefix([]byte("key3"), nil)
+		require.ErrorIs(t, err, ErrKeyNotFound)
+
+		_, _, _, _, err = snap1.GetWithPrefix([]byte("key1"), []byte("key1"))
 		require.ErrorIs(t, err, ErrKeyNotFound)
 	})
 

--- a/embedded/tbtree/tbtree.go
+++ b/embedded/tbtree/tbtree.go
@@ -1655,7 +1655,7 @@ func (t *TBtree) Ts() uint64 {
 	return t.root.ts()
 }
 
-func (t *TBtree) RSnapshot() (*Snapshot, error) {
+func (t *TBtree) UnsafeSnapshot() (*Snapshot, error) {
 	t.rwmutex.RLock()
 	defer t.rwmutex.RUnlock()
 

--- a/pkg/database/scan.go
+++ b/pkg/database/scan.go
@@ -75,7 +75,7 @@ func (d *db) Scan(req *schema.ScanRequest) (*schema.Entries, error) {
 	}
 
 	r, err := snap.NewKeyReader(
-		&store.KeyReaderSpec{
+		store.KeyReaderSpec{
 			SeekKey:       seekKey,
 			EndKey:        endKey,
 			Prefix:        EncodeKey(req.Prefix),

--- a/pkg/database/sorted_set.go
+++ b/pkg/database/sorted_set.go
@@ -174,7 +174,7 @@ func (d *db) ZScan(req *schema.ZScanRequest) (*schema.ZEntries, error) {
 	}
 
 	r, err := snap.NewKeyReader(
-		&store.KeyReaderSpec{
+		store.KeyReaderSpec{
 			SeekKey:       seekKey,
 			Prefix:        prefix,
 			InclusiveSeek: req.InclusiveSeek,


### PR DESCRIPTION
This PR implements multi-version concurrency control in  order to support simultaneous read-write transactions

Read conflicts may still be raised if data read by the transaction being committed has been invalidated by another recently committed one