### PR TITLE
read-only transactions

### DIFF
--- a/embedded/store/immustore.go
+++ b/embedded/store/immustore.go
@@ -50,6 +50,7 @@ var ErrAlreadyClosed = embedded.ErrAlreadyClosed
 var ErrUnexpectedLinkingError = errors.New("internal inconsistency between linear and binary linking")
 var ErrorNoEntriesProvided = errors.New("no entries provided")
 var ErrWriteOnlyTx = errors.New("write-only transaction")
+var ErrReadOnlyTx = errors.New("read-only transaction")
 var ErrTxReadConflict = errors.New("tx read conflict")
 var ErrTxAlreadyCommitted = errors.New("tx already committed")
 var ErrorMaxTxEntriesLimitExceeded = errors.New("max number of entries per tx exceeded")


### PR DESCRIPTION
This PR introduces support for read-only transactions.

The benefit of this type of transactions is that MVCC validations are disabled for this type of transactions. It means, read-only transactions should be faster and lighter than read-write ones.

Note: This PR may be reviewed after PR #1470 