### PR TITLE
Remove useless code.

### DIFF
--- a/pkg/client/streams.go
+++ b/pkg/client/streams.go
@@ -301,7 +301,7 @@ func (c *immuClient) _streamVerifiedGet(ctx context.Context, req *schema.Verifia
 		return nil, err
 	}
 
-	gs, err := c.streamVerifiableGet(ctx, req)
+	gs, _ := c.streamVerifiableGet(ctx, req)
 
 	ver := c.StreamServiceFactory.NewVEntryStreamReceiver(c.StreamServiceFactory.NewMsgReceiver(gs))
 

--- a/pkg/client/streams.go
+++ b/pkg/client/streams.go
@@ -301,7 +301,10 @@ func (c *immuClient) _streamVerifiedGet(ctx context.Context, req *schema.Verifia
 		return nil, err
 	}
 
-	gs, _ := c.streamVerifiableGet(ctx, req)
+	gs, err := c.streamVerifiableGet(ctx, req)
+	if err != nil {
+		return nil, err
+	}
 
 	ver := c.StreamServiceFactory.NewVEntryStreamReceiver(c.StreamServiceFactory.NewMsgReceiver(gs))
 

--- a/pkg/client/streams_integration_test.go
+++ b/pkg/client/streams_integration_test.go
@@ -20,7 +20,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -37,7 +36,7 @@ import (
 func externalImmudbClient(t *testing.T) (*immuClient, context.Context) {
 	extImmudb := os.Getenv("TEST_EXTERNAL_IMMUDB")
 	if extImmudb == "" {
-		t.Skip(fmt.Sprintf("Please launch an immudb server and set TEST_EXTERNAL_IMMUDB to its <host:port> value"))
+		t.Skip("Please launch an immudb server and set TEST_EXTERNAL_IMMUDB to its <host:port> value")
 	}
 
 	s := strings.SplitN(extImmudb, ":", 2)


### PR DESCRIPTION
Signed-off-by: Axay sagathiya <axaysagathiya@gmail.com>

- Returned error when verifiedGet operation fails.
- Removed unneeded fmt.Sprintf().