### PR TITLE
tbtree optimizations

### DIFF
--- a/embedded/store/immustore.go
+++ b/embedded/store/immustore.go
@@ -50,6 +50,7 @@ var ErrAlreadyClosed = embedded.ErrAlreadyClosed
 var ErrUnexpectedLinkingError = errors.New("internal inconsistency between linear and binary linking")
 var ErrorNoEntriesProvided = errors.New("no entries provided")
 var ErrWriteOnlyTx = errors.New("write-only transaction")
+var ErrReadOnlyTx = errors.New("read-only transaction")
 var ErrTxReadConflict = errors.New("tx read conflict")
 var ErrTxAlreadyCommitted = errors.New("tx already committed")
 var ErrorMaxTxEntriesLimitExceeded = errors.New("max number of entries per tx exceeded")

--- a/embedded/store/indexer.go
+++ b/embedded/store/indexer.go
@@ -152,7 +152,7 @@ func (idx *indexer) Snapshot() (*tbtree.Snapshot, error) {
 	return idx.index.Snapshot()
 }
 
-func (idx *indexer) SnapshotMustIncludeTxIDWithRenewalPeriod(snapshotMustIncludeTxID uint64, snapshotRenewalPeriod time.Duration) (*tbtree.Snapshot, error) {
+func (idx *indexer) SnapshotMustIncludeTxIDWithRenewalPeriod(txID uint64, renewalPeriod time.Duration) (*tbtree.Snapshot, error) {
 	idx.mutex.Lock()
 	defer idx.mutex.Unlock()
 
@@ -160,7 +160,7 @@ func (idx *indexer) SnapshotMustIncludeTxIDWithRenewalPeriod(snapshotMustInclude
 		return nil, ErrAlreadyClosed
 	}
 
-	return idx.index.SnapshotMustIncludeTsWithRenewalPeriod(snapshotMustIncludeTxID, snapshotRenewalPeriod)
+	return idx.index.SnapshotMustIncludeTsWithRenewalPeriod(txID, renewalPeriod)
 }
 
 func (idx *indexer) GetWithPrefix(prefix []byte, neq []byte) (key []byte, value []byte, tx uint64, hc uint64, err error) {

--- a/embedded/store/ongoing_tx_options.go
+++ b/embedded/store/ongoing_tx_options.go
@@ -32,7 +32,9 @@ const (
 type TxOptions struct {
 	Mode TxMode
 	// SnapshotMustIncludeTxID is a function which receives the latest precommitted transaction ID as parameter.
-	// It gaves the possibility to require a snapshot which includes a percentage of the transactions already indexed.
+	// It gives the possibility to reuse a snapshot which includes a percentage of the transactions already indexed
+	// e.g. func(lastPrecommittedTxID uint64) uint64 { return  lastPrecommittedTxID * 90 / 100 }
+	// or just a fixed transaction ID e.g. func(_ uint64) uint64 { return  1_000 }
 	SnapshotMustIncludeTxID func(lastPrecommittedTxID uint64) uint64
 	// SnapshotRenewalPeriod determines for how long a snaphsot may reuse existent dumped root
 	SnapshotRenewalPeriod time.Duration

--- a/embedded/tbtree/snapshot.go
+++ b/embedded/tbtree/snapshot.go
@@ -53,7 +53,7 @@ func (s *Snapshot) Set(key, value []byte) error {
 	v := make([]byte, len(value))
 	copy(v, value)
 
-	nodes, depth, err := s.root.insertAt(k, v, s.ts)
+	nodes, depth, err := s.root.insertAt([]*KV{{K: k, V: v}}, s.ts)
 	if err != nil {
 		return err
 	}

--- a/embedded/tbtree/tbtree.go
+++ b/embedded/tbtree/tbtree.go
@@ -1825,6 +1825,7 @@ func (n *innerNode) updateOnInsertAt(kvs []*KV, ts uint64) (nodes []node, depth 
 		return nil, 0, err
 	}
 
+	currTs := n._ts // if split unexpectedly fails, changes will be rolled back
 	n._ts = ts
 
 	// count the number of children after insertion
@@ -1853,7 +1854,11 @@ func (n *innerNode) updateOnInsertAt(kvs []*KV, ts uint64) (nodes []node, depth 
 
 	n.nodes = ns
 
-	nodes, _ = n.split()
+	nodes, err = n.split()
+	if err != nil {
+		n._ts = currTs
+		return nil, 0, err
+	}
 
 	return nodes, depth + 1, nil
 }

--- a/embedded/tbtree/tbtree.go
+++ b/embedded/tbtree/tbtree.go
@@ -640,7 +640,7 @@ func OpenWith(path string, nLog, hLog, cLog appendable.Appendable, opts *Options
 	}
 
 	if validatedCLogEntry == nil {
-		t.root = &leafNode{t: t, mut: true}
+		t.root = &leafNode{t: t, mut: false}
 	} else {
 		t.root, err = t.readNodeAt(validatedCLogEntry.finalNLogSize - int64(validatedCLogEntry.rootNodeSize))
 		if err != nil {

--- a/embedded/tbtree/tbtree.go
+++ b/embedded/tbtree/tbtree.go
@@ -1829,14 +1829,26 @@ func (n *innerNode) updateOnInsertAt(sortedKVs []*KV, ts uint64) (nodes []node, 
 
 	n._ts = ts
 
-	ns := make([]node, 0)
+	nsSize := len(n.nodes)
+
+	for i := range n.nodes {
+		cs, ok := nodesPerChild[i]
+		if ok {
+			nsSize += len(cs) - 1
+		}
+	}
+
+	ns := make([]node, nsSize)
+	nsi := 0
 
 	for i, n := range n.nodes {
 		cs, ok := nodesPerChild[i]
 		if ok {
-			ns = append(ns, cs...)
+			copy(ns[nsi:], cs)
+			nsi += len(cs)
 		} else {
-			ns = append(ns, n)
+			ns[nsi] = n
+			nsi++
 		}
 	}
 

--- a/embedded/tbtree/tbtree.go
+++ b/embedded/tbtree/tbtree.go
@@ -640,7 +640,9 @@ func OpenWith(path string, nLog, hLog, cLog appendable.Appendable, opts *Options
 	}
 
 	if validatedCLogEntry == nil {
-		t.root = &leafNode{t: t, mut: false}
+		// even when starting with a fresh btree, it's better to make the changes in a copy of the node,
+		// so that you can rollback if necessary.
+		t.root = &leafNode{t: t}
 	} else {
 		t.root, err = t.readNodeAt(validatedCLogEntry.finalNLogSize - int64(validatedCLogEntry.rootNodeSize))
 		if err != nil {

--- a/embedded/tbtree/tbtree.go
+++ b/embedded/tbtree/tbtree.go
@@ -1827,7 +1827,6 @@ func (n *innerNode) updateOnInsertAt(kvs []*KV, ts uint64) (nodes []node, depth 
 		return nil, 0, err
 	}
 
-	currTs := n._ts // if split unexpectedly fails, changes will be rolled back
 	n._ts = ts
 
 	// count the number of children after insertion
@@ -1858,7 +1857,6 @@ func (n *innerNode) updateOnInsertAt(kvs []*KV, ts uint64) (nodes []node, depth 
 
 	nodes, err = n.split()
 	if err != nil {
-		n._ts = currTs
 		return nil, 0, err
 	}
 

--- a/embedded/tbtree/tbtree.go
+++ b/embedded/tbtree/tbtree.go
@@ -1811,7 +1811,7 @@ func (n *innerNode) updateOnInsertAt(kvs []*KV, ts uint64) (nodes []node, depth 
 			nodesMutex.Lock()
 			defer nodesMutex.Unlock()
 
-			if err != nil {
+			if cerr != nil {
 				// if any of its children fail to insert, insertion fails
 				err = cerr
 				return

--- a/embedded/tbtree/tbtree_test.go
+++ b/embedded/tbtree/tbtree_test.go
@@ -1392,7 +1392,7 @@ func BenchmarkRandomBulkInsertion(b *testing.B) {
 
 		for i := 0; i < kBulkCount; i++ {
 			for j := 0; j < kBulkSize; j++ {
-				k := make([]byte, 8)
+				k := make([]byte, 32)
 				v := make([]byte, 32)
 
 				rnd.Read(k)

--- a/pkg/database/database_test.go
+++ b/pkg/database/database_test.go
@@ -491,9 +491,6 @@ func TestSetGetAll(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint64(2), txhdr.Id)
 
-	err = db.CompactIndex()
-	require.NoError(t, err)
-
 	itList, err := db.GetAll(&schema.KeyListRequest{
 		Keys: [][]byte{
 			[]byte("Alberto"),

--- a/pkg/integration/client_test.go
+++ b/pkg/integration/client_test.go
@@ -923,6 +923,9 @@ func TestImmuClient_SetAll(t *testing.T) {
 	_, err = client.SetAll(ctx, setRequest)
 	require.NoError(t, err)
 
+	_, err = client.FlushIndex(ctx, 1, false)
+	require.NoError(t, err)
+
 	err = client.CompactIndex(ctx, &emptypb.Empty{})
 	require.NoError(t, err)
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -871,6 +871,9 @@ func testServerSetGetBatch(ctx context.Context, s *ImmuServer, t *testing.T) {
 		t.Fatalf("Nil index after Setbatch")
 	}
 
+	_, err = s.FlushIndex(ctx, &schema.FlushIndexRequest{CleanupPercentage: 1})
+	require.NoError(t, err)
+
 	_, err = s.CompactIndex(ctx, nil)
 	require.NoError(t, err)
 


### PR DESCRIPTION
This PR introduces optimizations in bulk insertions by following an optimistic concurrent approach.
KV pairs to be inserted are first distributed among corresponding nodes and insertion takes place at the same time, finally the new list of nodes is built up.

Signed-off-by: Jeronimo Irazabal <jeronimo.irazabal@gmail.com>