### PR TITLE
fix(embedded/ahtree): correct calculation of payload offset

### DIFF
--- a/embedded/ahtree/ahtree.go
+++ b/embedded/ahtree/ahtree.go
@@ -214,7 +214,7 @@ func OpenWith(pLog, dLog, cLog appendable.Appendable, opts *Options) (*AHtree, e
 	pOff := binary.BigEndian.Uint64(b[:])
 	pSize := binary.BigEndian.Uint32(b[offsetSize:])
 
-	t.pLogSize = int64(pOff) + int64(pSize)
+	t.pLogSize = int64(pOff) + int64(szSize+pSize)
 
 	pLogFileSize, err := pLog.Size()
 	if err != nil {
@@ -409,7 +409,7 @@ func (t *AHtree) ResetSize(newSize uint64) error {
 		pOff := binary.BigEndian.Uint64(b[:])
 		pSize := binary.BigEndian.Uint32(b[offsetSize:])
 
-		pLogSize = int64(pOff) + int64(pSize)
+		pLogSize = int64(pOff) + int64(szSize+pSize)
 
 		pLogFileSize, err := t.pLog.Size()
 		if err != nil {

--- a/embedded/ahtree/ahtree.go
+++ b/embedded/ahtree/ahtree.go
@@ -214,6 +214,10 @@ func OpenWith(pLog, dLog, cLog appendable.Appendable, opts *Options) (*AHtree, e
 	pOff := binary.BigEndian.Uint64(b[:])
 	pSize := binary.BigEndian.Uint32(b[offsetSize:])
 
+	// pOff denotes the latest payload
+	// pSize denotes the size of the latest payload
+	// as payloads are prefixed with the size when written into pLog
+	// pLogSize is calculated with the offset, the size description of the payload and the payload itself
 	t.pLogSize = int64(pOff) + int64(szSize+pSize)
 
 	pLogFileSize, err := pLog.Size()
@@ -409,6 +413,10 @@ func (t *AHtree) ResetSize(newSize uint64) error {
 		pOff := binary.BigEndian.Uint64(b[:])
 		pSize := binary.BigEndian.Uint32(b[offsetSize:])
 
+		// pOff denotes the latest payload
+		// pSize denotes the size of the latest payload
+		// as payloads are prefixed with the size when written into pLog
+		// pLogSize is calculated with the offset, the size description of the payload and the payload itself
 		pLogSize = int64(pOff) + int64(szSize+pSize)
 
 		pLogFileSize, err := t.pLog.Size()

--- a/embedded/appendable/multiapp/multi_app.go
+++ b/embedded/appendable/multiapp/multi_app.go
@@ -414,6 +414,16 @@ func (mf *MultiFileAppendable) SetOffset(off int64) error {
 		return ErrReadOnly
 	}
 
+	currOffset := mf.offset()
+
+	if off > currOffset {
+		return fmt.Errorf("%w: provided offset %d is bigger than current one %d", ErrIllegalArguments, off, currOffset)
+	}
+
+	if off == currOffset {
+		return nil
+	}
+
 	appID := appendableID(off, mf.fileSize)
 
 	if mf.currAppID != appID {


### PR DESCRIPTION
Signed-off-by: Jeronimo Irazabal <jeronimo.irazabal@gmail.com>

test(embedded/ahtree): include payload len into plog

Signed-off-by: Jeronimo Irazabal <jeronimo.irazabal@gmail.com>

fix(embedded/appendable): prevent moving forward when setting offset in multi-appendable

Signed-off-by: Jeronimo Irazabal <jeronimo.irazabal@gmail.com>

test(embedded/ahtree): unit test checking append after reopening

Signed-off-by: Jeronimo Irazabal <jeronimo.irazabal@gmail.com>