### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/embedded/appendable/remoteapp/remote_app_test.go
+++ b/embedded/appendable/remoteapp/remote_app_test.go
@@ -226,8 +226,7 @@ func TestWritePastFirstChunk(t *testing.T) {
 }
 
 func prepareLocalTestFiles(t *testing.T) string {
-	path, err := ioutil.TempDir(os.TempDir(), "testdata")
-	require.NoError(t, err)
+	path := t.TempDir()
 	mapp, err := multiapp.Open(path, multiapp.DefaultOptions().WithFileSize(10).WithFileExt("tst"))
 	require.NoError(t, err)
 
@@ -245,7 +244,6 @@ func prepareLocalTestFiles(t *testing.T) string {
 
 func TestRemoteAppUploadOnStartup(t *testing.T) {
 	path := prepareLocalTestFiles(t)
-	defer os.RemoveAll(path)
 
 	opts := DefaultOptions()
 	opts.WithFileExt("tst")
@@ -262,9 +260,7 @@ func TestRemoteAppUploadOnStartup(t *testing.T) {
 }
 
 func TestReopenOnCleanShutdownWhenEmpty(t *testing.T) {
-	path, err := ioutil.TempDir(os.TempDir(), "testdata")
-	require.NoError(t, err)
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 
 	mem := memory.Open()
 	opts := DefaultOptions()
@@ -295,9 +291,7 @@ func TestReopenOnCleanShutdownWhenEmpty(t *testing.T) {
 }
 
 func TestReopenFromRemoteStorageOnCleanShutdown(t *testing.T) {
-	path, err := ioutil.TempDir(os.TempDir(), "testdata")
-	require.NoError(t, err)
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 
 	mem := memory.Open()
 	opts := DefaultOptions()
@@ -343,9 +337,7 @@ func TestRemoteStorageMetrics(t *testing.T) {
 	mFailed := testutil.ToFloat64(metricsUploadFailed)
 	mSucceeded := testutil.ToFloat64(metricsUploadSucceeded)
 
-	path, err := ioutil.TempDir(os.TempDir(), "testdata")
-	require.NoError(t, err)
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 
 	mem := memory.Open()
 	opts := DefaultOptions()
@@ -451,9 +443,7 @@ func (r *remoteStorageMockingWrapper) ListEntries(ctx context.Context, path stri
 func TestRemoteStorageUploadRetry(t *testing.T) {
 	mRetries := testutil.ToFloat64(metricsUploadRetried)
 
-	path, err := ioutil.TempDir(os.TempDir(), "testdata")
-	require.NoError(t, err)
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 
 	// Injecting exactly one error in put, get and exists operations
 	var putErrInjected int32
@@ -498,9 +488,7 @@ func TestRemoteStorageUploadRetry(t *testing.T) {
 }
 
 func TestRemoteStorageUploadCancel(t *testing.T) {
-	path, err := ioutil.TempDir(os.TempDir(), "testdata")
-	require.NoError(t, err)
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 
 	for _, name := range []string{"Put", "Get", "Exists"} {
 		t.Run(name, func(t *testing.T) {
@@ -567,9 +555,7 @@ func TestRemoteStorageUploadCancel(t *testing.T) {
 }
 
 func TestRemoteStorageUploadCancelWhenThrottled(t *testing.T) {
-	path, err := ioutil.TempDir(os.TempDir(), "testdata")
-	require.NoError(t, err)
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 
 	// Injecting exactly one error in put, get and exists operations
 	mem := &remoteStorageMockingWrapper{
@@ -603,9 +589,7 @@ func TestRemoteStorageUploadCancelWhenThrottled(t *testing.T) {
 }
 
 func _TestRemoteStorageUploadUnrecoverableError(t *testing.T) {
-	path, err := ioutil.TempDir(os.TempDir(), "testdata")
-	require.NoError(t, err)
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 
 	mUploadFailed := testutil.ToFloat64(metricsUploadFailed)
 
@@ -659,9 +643,7 @@ type errReader struct {
 func (e errReader) Read([]byte) (int, error) { return 0, e.err }
 
 func _TestRemoteStorageDownloadRetry(t *testing.T) {
-	path, err := ioutil.TempDir(os.TempDir(), "testdata")
-	require.NoError(t, err)
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 
 	for _, errKind := range []string{"Open", "Read"} {
 		t.Run(errKind, func(t *testing.T) {
@@ -724,9 +706,7 @@ func _TestRemoteStorageDownloadRetry(t *testing.T) {
 }
 
 func TestRemoteStorageDownloadCancel(t *testing.T) {
-	path, err := ioutil.TempDir(os.TempDir(), "testdata")
-	require.NoError(t, err)
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 
 	for _, errKind := range []string{"Open", "Read"} {
 		t.Run(errKind, func(t *testing.T) {
@@ -802,9 +782,7 @@ func TestRemoteStorageDownloadCancel(t *testing.T) {
 }
 
 func TestRemoteStorageDownloadUnrecoverableError(t *testing.T) {
-	path, err := ioutil.TempDir(os.TempDir(), "testdata")
-	require.NoError(t, err)
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 
 	mDownloadFailed := testutil.ToFloat64(metricsDownloadFailed)
 
@@ -847,7 +825,6 @@ func TestRemoteStorageDownloadUnrecoverableError(t *testing.T) {
 
 func TestRemoteStorageOpenChunkWhenUploading(t *testing.T) {
 	path := prepareLocalTestFiles(t)
-	defer os.RemoveAll(path)
 
 	mem := &remoteStorageMockingWrapper{
 		wrapped: memory.Open(),
@@ -887,9 +864,7 @@ func TestRemoteStorageOpenChunkWhenUploading(t *testing.T) {
 }
 
 func TestRemoteStorageOpenInitialAppendableMissingRemoteChunk(t *testing.T) {
-	path, err := ioutil.TempDir(os.TempDir(), "testdata")
-	require.NoError(t, err)
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 
 	// Prepare test dataset
 	opts := DefaultOptions()
@@ -930,9 +905,7 @@ func TestRemoteStorageOpenInitialAppendableMissingRemoteChunk(t *testing.T) {
 }
 
 func TestRemoteStorageOpenInitialAppendableCorruptedLocalFile(t *testing.T) {
-	path, err := ioutil.TempDir(os.TempDir(), "testdata")
-	require.NoError(t, err)
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 
 	// Prepare test dataset
 	opts := DefaultOptions()

--- a/embedded/store/immustore_test.go
+++ b/embedded/store/immustore_test.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -996,9 +995,7 @@ func TestImmudbStoreIndexing(t *testing.T) {
 }
 
 func TestImmudbStoreRWTransactions(t *testing.T) {
-	dir, err := ioutil.TempDir("", "data_rwtx")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	opts := DefaultOptions().WithSynced(false).WithMaxConcurrency(1)
 	immuStore, err := Open(dir, opts)

--- a/pkg/client/cache/file_cache_test.go
+++ b/pkg/client/cache/file_cache_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/codenotary/immudb/pkg/api/schema"
@@ -12,21 +11,17 @@ import (
 )
 
 func TestNewFileCache(t *testing.T) {
-	dirname, err := ioutil.TempDir("", "example")
-	require.NoError(t, err)
-	defer os.RemoveAll(dirname)
+	dirname := t.TempDir()
 
 	fc := NewFileCache(dirname)
 	require.IsType(t, &fileCache{}, fc)
 }
 
 func TestFileCacheSetErrorNotLocked(t *testing.T) {
-	dirname, err := ioutil.TempDir("", "example")
-	require.NoError(t, err)
-	defer os.RemoveAll(dirname)
+	dirname := t.TempDir()
 
 	fc := NewFileCache(dirname)
-	err = fc.Set("uuid", "dbName", &schema.ImmutableState{
+	err := fc.Set("uuid", "dbName", &schema.ImmutableState{
 		TxId:      0,
 		TxHash:    []byte(`hash`),
 		Signature: nil,
@@ -35,12 +30,10 @@ func TestFileCacheSetErrorNotLocked(t *testing.T) {
 }
 
 func TestFileCacheSet(t *testing.T) {
-	dirname, err := ioutil.TempDir("", "example")
-	require.NoError(t, err)
-	defer os.RemoveAll(dirname)
+	dirname := t.TempDir()
 
 	fc := NewFileCache(dirname)
-	err = fc.Lock("uuid")
+	err := fc.Lock("uuid")
 	require.NoError(t, err)
 	defer fc.Unlock()
 
@@ -53,12 +46,10 @@ func TestFileCacheSet(t *testing.T) {
 }
 
 func TestFileCacheGet(t *testing.T) {
-	dirname, err := ioutil.TempDir("", "example")
-	require.NoError(t, err)
-	defer os.RemoveAll(dirname)
+	dirname := t.TempDir()
 
 	fc := NewFileCache(dirname)
-	err = fc.Lock("uuid")
+	err := fc.Lock("uuid")
 	require.NoError(t, err)
 	defer fc.Unlock()
 
@@ -76,24 +67,20 @@ func TestFileCacheGet(t *testing.T) {
 }
 
 func TestFileCacheGetFailNotLocked(t *testing.T) {
-	dirname, err := ioutil.TempDir("", "example")
-	require.NoError(t, err)
-	defer os.RemoveAll(dirname)
+	dirname := t.TempDir()
 
 	fc := NewFileCache(dirname)
-	_, err = fc.Get("uuid", "dbName")
+	_, err := fc.Get("uuid", "dbName")
 
 	require.ErrorIs(t, err, ErrCacheNotLocked)
 }
 
 func TestFileCacheGetSingleLineError(t *testing.T) {
-	dirname, err := ioutil.TempDir("", "example")
-	require.NoError(t, err)
-	defer os.RemoveAll(dirname)
+	dirname := t.TempDir()
 
 	dbName := "dbt"
 
-	err = ioutil.WriteFile(dirname+"/.state-test", []byte(dbName+":"), 0666)
+	err := ioutil.WriteFile(dirname+"/.state-test", []byte(dbName+":"), 0666)
 	require.NoError(t, err)
 
 	fc := NewFileCache(dirname)
@@ -106,13 +93,11 @@ func TestFileCacheGetSingleLineError(t *testing.T) {
 }
 
 func TestFileCacheGetRootUnableToDecodeErr(t *testing.T) {
-	dirname, err := ioutil.TempDir("", "example")
-	require.NoError(t, err)
-	defer os.RemoveAll(dirname)
+	dirname := t.TempDir()
 
 	dbName := "dbt"
 
-	err = ioutil.WriteFile(dirname+"/.state-test", []byte(dbName+":firstLine"), 0666)
+	err := ioutil.WriteFile(dirname+"/.state-test", []byte(dbName+":firstLine"), 0666)
 	require.NoError(t, err)
 
 	fc := NewFileCache(dirname)
@@ -125,13 +110,11 @@ func TestFileCacheGetRootUnableToDecodeErr(t *testing.T) {
 }
 
 func TestFileCacheGetRootUnmarshalErr(t *testing.T) {
-	dirname, err := ioutil.TempDir("", "example")
-	require.NoError(t, err)
-	defer os.RemoveAll(dirname)
+	dirname := t.TempDir()
 
 	dbName := "dbt"
 
-	err = ioutil.WriteFile(dirname+"/.state-test", []byte(dbName+":"+base64.StdEncoding.EncodeToString([]byte("wrong-content"))), 0666)
+	err := ioutil.WriteFile(dirname+"/.state-test", []byte(dbName+":"+base64.StdEncoding.EncodeToString([]byte("wrong-content"))), 0666)
 	require.NoError(t, err)
 
 	fc := NewFileCache(dirname)
@@ -144,13 +127,11 @@ func TestFileCacheGetRootUnmarshalErr(t *testing.T) {
 }
 
 func TestFileCacheGetEmptyFile(t *testing.T) {
-	dirname, err := ioutil.TempDir("", "example")
-	require.NoError(t, err)
-	defer os.RemoveAll(dirname)
+	dirname := t.TempDir()
 
 	dbName := "dbt"
 
-	err = ioutil.WriteFile(dirname+"/.state-test", []byte(""), 0666)
+	err := ioutil.WriteFile(dirname+"/.state-test", []byte(""), 0666)
 	require.NoError(t, err)
 
 	fc := NewFileCache(dirname)
@@ -163,12 +144,10 @@ func TestFileCacheGetEmptyFile(t *testing.T) {
 }
 
 func TestFileCacheOverwriteHash(t *testing.T) {
-	dirname, err := ioutil.TempDir("", "example")
-	require.NoError(t, err)
-	defer os.RemoveAll(dirname)
+	dirname := t.TempDir()
 
 	fc := NewFileCache(dirname)
-	err = fc.Lock("test")
+	err := fc.Lock("test")
 	require.NoError(t, err)
 	defer fc.Unlock()
 
@@ -188,12 +167,10 @@ func TestFileCacheOverwriteHash(t *testing.T) {
 }
 
 func TestFileCacheMultipleDatabases(t *testing.T) {
-	dirname, err := ioutil.TempDir("", "example")
-	require.NoError(t, err)
-	defer os.RemoveAll(dirname)
+	dirname := t.TempDir()
 
 	fc := NewFileCache(dirname)
-	err = fc.Lock("test")
+	err := fc.Lock("test")
 	require.NoError(t, err)
 	defer fc.Unlock()
 

--- a/pkg/client/cache/history_file_cache_test.go
+++ b/pkg/client/cache/history_file_cache_test.go
@@ -30,22 +30,18 @@ import (
 )
 
 func TestNewHistoryFileCache(t *testing.T) {
-	dir, err := ioutil.TempDir("", "example")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	fc := NewHistoryFileCache(dir)
-	defer os.RemoveAll(dir)
 	require.IsType(t, &historyFileCache{}, fc)
 }
 
 func TestNewHistoryFileCacheSet(t *testing.T) {
-	dir, err := ioutil.TempDir("", "example")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	fc := NewHistoryFileCache(dir)
-	defer os.RemoveAll(dir)
 
-	err = fc.Set("uuid", "dbName", &schema.ImmutableState{TxId: 1, TxHash: []byte{1}})
+	err := fc.Set("uuid", "dbName", &schema.ImmutableState{TxId: 1, TxHash: []byte{1}})
 	require.NoError(t, err)
 
 	err = fc.Set("uuid", "dbName", &schema.ImmutableState{TxId: 2, TxHash: []byte{2}})
@@ -60,11 +56,9 @@ func TestNewHistoryFileCacheSet(t *testing.T) {
 }
 
 func TestNewHistoryFileCacheGet(t *testing.T) {
-	dir, err := ioutil.TempDir("", "example")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	fc := NewHistoryFileCache(dir)
-	defer os.RemoveAll(dir)
 
 	root, err := fc.Get("uuid", "dbName")
 	require.NoError(t, err)
@@ -72,11 +66,9 @@ func TestNewHistoryFileCacheGet(t *testing.T) {
 }
 
 func TestNewHistoryFileCacheWalk(t *testing.T) {
-	dir, err := ioutil.TempDir("", "example")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	fc := NewHistoryFileCache(dir)
-	defer os.RemoveAll(dir)
 
 	iface, err := fc.Walk("uuid", "dbName", func(root *schema.ImmutableState) interface{} {
 		return nil
@@ -99,26 +91,22 @@ func TestNewHistoryFileCacheWalk(t *testing.T) {
 }
 
 func TestHistoryFileCache_SetError(t *testing.T) {
-	dir, err := ioutil.TempDir("", "example")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	fc := NewHistoryFileCache(dir)
-	defer os.RemoveAll(dir)
 
-	err = fc.Set("uuid", "dbName", nil)
+	err := fc.Set("uuid", "dbName", nil)
 	require.Error(t, err)
 }
 
 func TestHistoryFileCache_GetError(t *testing.T) {
-	dir, err := ioutil.TempDir("", "example")
-	require.NoError(t, err)
+	dir := t.TempDir()
 
 	fc := NewHistoryFileCache(dir)
-	defer os.RemoveAll(dir)
 
 	// create a dummy file so that the cache can't create the directory
 	// automatically
-	err = ioutil.WriteFile(filepath.Join(dir, "exists"), []byte("data"), 0644)
+	err := ioutil.WriteFile(filepath.Join(dir, "exists"), []byte("data"), 0644)
 	require.NoError(t, err)
 	_, err = fc.Get("exists", "dbName")
 	require.Error(t, err)
@@ -135,29 +123,23 @@ func TestHistoryFileCache_SetMissingFolder(t *testing.T) {
 }
 
 func TestHistoryFileCache_WalkFolderNotExistsCreated(t *testing.T) {
-	dir, err := ioutil.TempDir("", "history-cache")
-	require.NoError(t, err)
-
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	notExists := filepath.Join(dir, "not-exists")
 	fc := NewHistoryFileCache(notExists)
 
-	_, err = fc.Walk("uuid", "dbName", func(root *schema.ImmutableState) interface{} {
+	_, err := fc.Walk("uuid", "dbName", func(root *schema.ImmutableState) interface{} {
 		return nil
 	})
 	require.NoError(t, err)
 }
 
 func TestHistoryFileCache_getStatesFileInfosError(t *testing.T) {
-	dir, err := ioutil.TempDir("", "history-cache")
-	require.NoError(t, err)
-
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	notExists := filepath.Join(dir, "does-not-exist")
 	fc := &historyFileCache{dir: notExists}
-	_, err = fc.getStatesFileInfos(dir)
+	_, err := fc.getStatesFileInfos(dir)
 	require.NoError(t, err)
 }
 

--- a/pkg/integration/auditor_test.go
+++ b/pkg/integration/auditor_test.go
@@ -201,9 +201,7 @@ func TestDefaultAuditorRunOnDb(t *testing.T) {
 	require.NoError(t, err)
 	serviceClient := schema.NewImmuServiceClient(clientConn)
 
-	auditorDir, err := ioutil.TempDir("", "auditor_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(auditorDir)
+	auditorDir := t.TempDir()
 
 	da, err := auditor.DefaultAuditor(
 		time.Duration(0),
@@ -294,9 +292,7 @@ func TestRepeatedAuditorRunOnDb(t *testing.T) {
 		},
 	}
 
-	auditorDir, err := ioutil.TempDir("", "auditor_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(auditorDir)
+	auditorDir := t.TempDir()
 
 	da, err := auditor.DefaultAuditor(
 		time.Duration(0),
@@ -390,9 +386,7 @@ func testDefaultAuditorRunOnDbWithSignature(t *testing.T, pk *ecdsa.PublicKey) {
 	require.NoError(t, err)
 	serviceClient := schema.NewImmuServiceClient(clientConn)
 
-	auditorDir, err := ioutil.TempDir("", "auditor_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(auditorDir)
+	auditorDir := t.TempDir()
 
 	da, err := auditor.DefaultAuditor(
 		time.Duration(0),

--- a/pkg/integration/follower_replication_test.go
+++ b/pkg/integration/follower_replication_test.go
@@ -18,9 +18,7 @@ package integration
 
 import (
 	"context"
-	"io/ioutil"
 	"net"
-	"os"
 	"testing"
 	"time"
 
@@ -191,9 +189,7 @@ func TestReplication(t *testing.T) {
 
 func TestSystemDBAndDefaultDBReplication(t *testing.T) {
 	// init primary server
-	primaryDir, err := ioutil.TempDir("", "primary-data")
-	require.NoError(t, err)
-	defer os.RemoveAll(primaryDir)
+	primaryDir := t.TempDir()
 
 	primaryServerOpts := server.DefaultOptions().
 		WithMetricsServer(false).
@@ -204,7 +200,7 @@ func TestSystemDBAndDefaultDBReplication(t *testing.T) {
 
 	primaryServer := server.DefaultServer().WithOptions(primaryServerOpts).(*server.ImmuServer)
 
-	err = primaryServer.Initialize()
+	err := primaryServer.Initialize()
 	require.NoError(t, err)
 
 	go func() {
@@ -225,9 +221,7 @@ func TestSystemDBAndDefaultDBReplication(t *testing.T) {
 	defer primaryClient.CloseSession(context.Background())
 
 	// init replica server
-	replicaDir, err := ioutil.TempDir("", "replica-data")
-	require.NoError(t, err)
-	defer os.RemoveAll(replicaDir)
+	replicaDir := t.TempDir()
 
 	replicationOpts := &server.ReplicationOptions{
 		IsReplica:                    true,

--- a/pkg/integration/server_recovery_test.go
+++ b/pkg/integration/server_recovery_test.go
@@ -17,8 +17,6 @@ limitations under the License.
 package integration
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 	"time"
 
@@ -27,9 +25,7 @@ import (
 )
 
 func TestServerRecovertMode(t *testing.T) {
-	dir, err := ioutil.TempDir("", "integration_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	serverOptions := server.DefaultOptions().
 		WithDir(dir).
@@ -41,7 +37,7 @@ func TestServerRecovertMode(t *testing.T) {
 
 	s := server.DefaultServer().WithOptions(serverOptions).(*server.ImmuServer)
 
-	err = s.Initialize()
+	err := s.Initialize()
 	require.Equal(t, server.ErrAuthMustBeDisabled, err)
 
 	serverOptions = server.DefaultOptions().

--- a/pkg/pgsql/server/pgsql_integration_test.go
+++ b/pkg/pgsql/server/pgsql_integration_test.go
@@ -22,7 +22,6 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"sync"
@@ -39,14 +38,13 @@ import (
 )
 
 func TestPgsqlServer_SimpleQuery(t *testing.T) {
-	td, _ := ioutil.TempDir("", "_pgsql")
+	td := t.TempDir()
 	options := server.DefaultOptions().WithDir(td).WithPgsqlServer(true).WithPgsqlServerPort(0)
 	bs := servertest.NewBufconnServer(options)
 
 	bs.Start()
 	defer bs.Stop()
 
-	defer os.RemoveAll(td)
 	defer os.Remove(".state-")
 
 	bs.WaitForPgsqlListener()
@@ -70,14 +68,13 @@ func TestPgsqlServer_SimpleQuery(t *testing.T) {
 }
 
 func TestPgsqlServer_SimpleQueryBlob(t *testing.T) {
-	td, _ := ioutil.TempDir("", "_pgsql")
+	td := t.TempDir()
 	options := server.DefaultOptions().WithDir(td).WithPgsqlServer(true).WithPgsqlServerPort(0)
 	bs := servertest.NewBufconnServer(options)
 
 	bs.Start()
 	defer bs.Stop()
 
-	defer os.RemoveAll(td)
 	defer os.Remove(".state-")
 
 	bs.WaitForPgsqlListener()
@@ -107,14 +104,13 @@ func TestPgsqlServer_SimpleQueryBlob(t *testing.T) {
 }
 
 func TestPgsqlServer_SimpleQueryBool(t *testing.T) {
-	td, _ := ioutil.TempDir("", "_pgsql")
+	td := t.TempDir()
 	options := server.DefaultOptions().WithDir(td).WithPgsqlServer(true).WithPgsqlServerPort(0)
 	bs := servertest.NewBufconnServer(options)
 
 	bs.Start()
 	defer bs.Stop()
 
-	defer os.RemoveAll(td)
 	defer os.Remove(".state-")
 
 	bs.WaitForPgsqlListener()
@@ -139,14 +135,13 @@ func TestPgsqlServer_SimpleQueryBool(t *testing.T) {
 }
 
 func TestPgsqlServer_SimpleQueryExecError(t *testing.T) {
-	td, _ := ioutil.TempDir("", "_pgsql")
+	td := t.TempDir()
 	options := server.DefaultOptions().WithDir(td).WithPgsqlServer(true).WithPgsqlServerPort(0)
 	bs := servertest.NewBufconnServer(options)
 
 	bs.Start()
 	defer bs.Stop()
 
-	defer os.RemoveAll(td)
 	defer os.Remove(".state-")
 
 	bs.WaitForPgsqlListener()
@@ -159,14 +154,13 @@ func TestPgsqlServer_SimpleQueryExecError(t *testing.T) {
 }
 
 func TestPgsqlServer_SimpleQueryQueryError(t *testing.T) {
-	td, _ := ioutil.TempDir("", "_pgsql")
+	td := t.TempDir()
 	options := server.DefaultOptions().WithDir(td).WithPgsqlServer(true).WithPgsqlServerPort(0)
 	bs := servertest.NewBufconnServer(options)
 
 	bs.Start()
 	defer bs.Stop()
 
-	defer os.RemoveAll(td)
 	defer os.Remove(".state-")
 
 	bs.WaitForPgsqlListener()
@@ -179,14 +173,13 @@ func TestPgsqlServer_SimpleQueryQueryError(t *testing.T) {
 }
 
 func TestPgsqlServer_SimpleQueryQueryMissingDatabase(t *testing.T) {
-	td, _ := ioutil.TempDir("", "_pgsql")
+	td := t.TempDir()
 	options := server.DefaultOptions().WithDir(td).WithPgsqlServer(true).WithPgsqlServerPort(0)
 	bs := servertest.NewBufconnServer(options)
 
 	bs.Start()
 	defer bs.Stop()
 
-	defer os.RemoveAll(td)
 	defer os.Remove(".state-")
 
 	bs.WaitForPgsqlListener()
@@ -199,14 +192,13 @@ func TestPgsqlServer_SimpleQueryQueryMissingDatabase(t *testing.T) {
 }
 
 func TestPgsqlServer_SimpleQueryQueryDatabaseNotExists(t *testing.T) {
-	td, _ := ioutil.TempDir("", "_pgsql")
+	td := t.TempDir()
 	options := server.DefaultOptions().WithDir(td).WithPgsqlServer(true).WithPgsqlServerPort(0)
 	bs := servertest.NewBufconnServer(options)
 
 	bs.Start()
 	defer bs.Stop()
 
-	defer os.RemoveAll(td)
 	defer os.Remove(".state-")
 
 	bs.WaitForPgsqlListener()
@@ -219,14 +211,13 @@ func TestPgsqlServer_SimpleQueryQueryDatabaseNotExists(t *testing.T) {
 }
 
 func TestPgsqlServer_SimpleQueryQueryMissingUsername(t *testing.T) {
-	td, _ := ioutil.TempDir("", "_pgsql")
+	td := t.TempDir()
 	options := server.DefaultOptions().WithDir(td).WithPgsqlServer(true).WithPgsqlServerPort(0)
 	bs := servertest.NewBufconnServer(options)
 
 	bs.Start()
 	defer bs.Stop()
 
-	defer os.RemoveAll(td)
 	defer os.Remove(".state-")
 
 	bs.WaitForPgsqlListener()
@@ -239,14 +230,13 @@ func TestPgsqlServer_SimpleQueryQueryMissingUsername(t *testing.T) {
 }
 
 func TestPgsqlServer_SimpleQueryQueryMissingPassword(t *testing.T) {
-	td, _ := ioutil.TempDir("", "_pgsql")
+	td := t.TempDir()
 	options := server.DefaultOptions().WithDir(td).WithPgsqlServer(true).WithPgsqlServerPort(0)
 	bs := servertest.NewBufconnServer(options)
 
 	bs.Start()
 	defer bs.Stop()
 
-	defer os.RemoveAll(td)
 	defer os.Remove(".state-")
 
 	bs.WaitForPgsqlListener()
@@ -259,13 +249,12 @@ func TestPgsqlServer_SimpleQueryQueryMissingPassword(t *testing.T) {
 }
 
 func TestPgsqlServer_SimpleQueryQueryClosedConnError(t *testing.T) {
-	td, _ := ioutil.TempDir("", "_pgsql")
+	td := t.TempDir()
 	options := server.DefaultOptions().WithDir(td).WithPgsqlServer(true).WithPgsqlServerPort(0)
 	bs := servertest.NewBufconnServer(options)
 
 	bs.Start()
 
-	defer os.RemoveAll(td)
 	defer os.Remove(".state-")
 
 	bs.WaitForPgsqlListener()
@@ -279,14 +268,13 @@ func TestPgsqlServer_SimpleQueryQueryClosedConnError(t *testing.T) {
 }
 
 func TestPgsqlServer_SimpleQueryTerminate(t *testing.T) {
-	td, _ := ioutil.TempDir("", "_pgsql")
+	td := t.TempDir()
 	options := server.DefaultOptions().WithDir(td).WithPgsqlServer(true).WithPgsqlServerPort(0)
 	bs := servertest.NewBufconnServer(options)
 
 	bs.Start()
 	defer bs.Stop()
 
-	defer os.RemoveAll(td)
 	defer os.Remove(".state-")
 
 	bs.WaitForPgsqlListener()
@@ -313,14 +301,13 @@ func TestPgsqlServer_SimpleQueryTerminate(t *testing.T) {
 }
 
 func TestPgsqlServer_SimpleQueryQueryEmptyQueryMessage(t *testing.T) {
-	td, _ := ioutil.TempDir("", "_pgsql")
+	td := t.TempDir()
 	options := server.DefaultOptions().WithDir(td).WithPgsqlServer(true).WithPgsqlServerPort(0)
 	bs := servertest.NewBufconnServer(options)
 
 	bs.Start()
 	defer bs.Stop()
 
-	defer os.RemoveAll(td)
 	defer os.Remove(".state-")
 
 	bs.WaitForPgsqlListener()
@@ -344,14 +331,13 @@ func TestPgsqlServer_SimpleQueryQueryEmptyQueryMessage(t *testing.T) {
 }
 
 func TestPgsqlServer_SimpleQueryQueryCreateOrUseDatabaseNotSupported(t *testing.T) {
-	td, _ := ioutil.TempDir("", "_pgsql")
+	td := t.TempDir()
 	options := server.DefaultOptions().WithDir(td).WithPgsqlServer(true).WithPgsqlServerPort(0)
 	bs := servertest.NewBufconnServer(options)
 
 	bs.Start()
 	defer bs.Stop()
 
-	defer os.RemoveAll(td)
 	defer os.Remove(".state-")
 
 	bs.WaitForPgsqlListener()
@@ -367,14 +353,13 @@ func TestPgsqlServer_SimpleQueryQueryCreateOrUseDatabaseNotSupported(t *testing.
 }
 
 func TestPgsqlServer_SimpleQueryQueryExecError(t *testing.T) {
-	td, _ := ioutil.TempDir("", "_pgsql")
+	td := t.TempDir()
 	options := server.DefaultOptions().WithDir(td).WithPgsqlServer(true).WithPgsqlServerPort(0)
 	bs := servertest.NewBufconnServer(options)
 
 	bs.Start()
 	defer bs.Stop()
 
-	defer os.RemoveAll(td)
 	defer os.Remove(".state-")
 
 	bs.WaitForPgsqlListener()
@@ -392,7 +377,7 @@ func TestPgsqlServer_SimpleQueryQueryExecError(t *testing.T) {
 }
 
 func TestPgsqlServer_SimpleQueryQuerySSLConn(t *testing.T) {
-	td, _ := ioutil.TempDir("", "_pgsql")
+	td := t.TempDir()
 
 	certPem := []byte(`-----BEGIN CERTIFICATE-----
 MIIBhTCCASugAwIBAgIQIRi6zePL6mKjOipn+dNuaTAKBggqhkjOPQQDAjASMRAw
@@ -421,7 +406,6 @@ EKTcWGekdmdDPsHloRNtsiCa697B2O9IFA==
 	bs.Start()
 	defer bs.Stop()
 
-	defer os.RemoveAll(td)
 	defer os.Remove(".state-")
 
 	bs.WaitForPgsqlListener()
@@ -435,14 +419,13 @@ EKTcWGekdmdDPsHloRNtsiCa697B2O9IFA==
 }
 
 func TestPgsqlServer_SSLNotEnabled(t *testing.T) {
-	td, _ := ioutil.TempDir("", "_pgsql")
+	td := t.TempDir()
 	options := server.DefaultOptions().WithDir(td).WithPgsqlServer(true).WithPgsqlServerPort(0)
 	bs := servertest.NewBufconnServer(options)
 
 	bs.Start()
 	defer bs.Stop()
 
-	defer os.RemoveAll(td)
 	defer os.Remove(".state-")
 
 	bs.WaitForPgsqlListener()
@@ -457,14 +440,13 @@ func TestPgsqlServer_SSLNotEnabled(t *testing.T) {
 }
 
 func _TestPgsqlServer_SimpleQueryAsynch(t *testing.T) {
-	td, _ := ioutil.TempDir("", "_pgsql")
+	td := t.TempDir()
 	options := server.DefaultOptions().WithDir(td).WithPgsqlServer(true).WithPgsqlServerPort(0)
 	bs := servertest.NewBufconnServer(options)
 
 	bs.Start()
 	defer bs.Stop()
 
-	defer os.RemoveAll(td)
 	defer os.Remove(".state-")
 
 	bs.WaitForPgsqlListener()
@@ -498,14 +480,13 @@ func _TestPgsqlServer_SimpleQueryAsynch(t *testing.T) {
 }
 
 func TestPgsqlServer_VersionStatement(t *testing.T) {
-	td, _ := ioutil.TempDir("", "_pgsql")
+	td := t.TempDir()
 	options := server.DefaultOptions().WithDir(td).WithPgsqlServer(true).WithPgsqlServerPort(0)
 	bs := servertest.NewBufconnServer(options)
 
 	bs.Start()
 	defer bs.Stop()
 
-	defer os.RemoveAll(td)
 	defer os.Remove(".state-")
 
 	bs.WaitForPgsqlListener()
@@ -520,14 +501,13 @@ func TestPgsqlServer_VersionStatement(t *testing.T) {
 }
 
 func TestPgsqlServerSetStatement(t *testing.T) {
-	td, _ := ioutil.TempDir("", "_pgsql")
+	td := t.TempDir()
 	options := server.DefaultOptions().WithDir(td).WithPgsqlServer(true).WithPgsqlServerPort(0)
 	bs := servertest.NewBufconnServer(options)
 
 	bs.Start()
 	defer bs.Stop()
 
-	defer os.RemoveAll(td)
 	defer os.Remove(".state-")
 
 	bs.WaitForPgsqlListener()
@@ -540,14 +520,13 @@ func TestPgsqlServerSetStatement(t *testing.T) {
 }
 
 func TestPgsqlServer_SimpleQueryNilValues(t *testing.T) {
-	td, _ := ioutil.TempDir("", "_pgsql")
+	td := t.TempDir()
 	options := server.DefaultOptions().WithDir(td).WithPgsqlServer(true).WithPgsqlServerPort(0)
 	bs := servertest.NewBufconnServer(options)
 
 	bs.Start()
 	defer bs.Stop()
 
-	defer os.RemoveAll(td)
 	defer os.Remove(".state-")
 
 	bs.WaitForPgsqlListener()
@@ -579,14 +558,13 @@ func getRandomTableName() string {
 }
 
 func TestPgsqlServer_ExtendedQueryPG(t *testing.T) {
-	td, _ := ioutil.TempDir("", "_pgsql")
+	td := t.TempDir()
 	options := server.DefaultOptions().WithDir(td).WithPgsqlServer(true).WithPgsqlServerPort(0)
 	bs := servertest.NewBufconnServer(options)
 
 	bs.Start()
 	defer bs.Stop()
 
-	defer os.RemoveAll(td)
 	defer os.Remove(".state-")
 
 	bs.WaitForPgsqlListener()
@@ -610,14 +588,13 @@ func TestPgsqlServer_ExtendedQueryPG(t *testing.T) {
 }
 
 func TestPgsqlServer_ExtendedQueryPGxNamedStatements(t *testing.T) {
-	td, _ := ioutil.TempDir("", "_pgsql")
+	td := t.TempDir()
 	options := server.DefaultOptions().WithDir(td).WithPgsqlServer(true).WithPgsqlServerPort(0)
 	bs := servertest.NewBufconnServer(options)
 
 	bs.Start()
 	defer bs.Stop()
 
-	defer os.RemoveAll(td)
 	defer os.Remove(".state-")
 
 	bs.WaitForPgsqlListener()
@@ -644,14 +621,13 @@ func TestPgsqlServer_ExtendedQueryPGxNamedStatements(t *testing.T) {
 }
 
 func TestPgsqlServer_ExtendedQueryPGxMultiFieldsPreparedStatements(t *testing.T) {
-	td, _ := ioutil.TempDir("", "_pgsql")
+	td := t.TempDir()
 	options := server.DefaultOptions().WithDir(td).WithPgsqlServer(true).WithPgsqlServerPort(0)
 	bs := servertest.NewBufconnServer(options)
 
 	bs.Start()
 	defer bs.Stop()
 
-	defer os.RemoveAll(td)
 	defer os.Remove(".state-")
 
 	bs.WaitForPgsqlListener()
@@ -688,14 +664,13 @@ func TestPgsqlServer_ExtendedQueryPGxMultiFieldsPreparedStatements(t *testing.T)
 }
 
 func TestPgsqlServer_ExtendedQueryPGMultiFieldsPreparedStatements(t *testing.T) {
-	td, _ := ioutil.TempDir("", "_pgsql")
+	td := t.TempDir()
 	options := server.DefaultOptions().WithDir(td).WithPgsqlServer(true).WithPgsqlServerPort(0)
 	bs := servertest.NewBufconnServer(options)
 
 	bs.Start()
 	defer bs.Stop()
 
-	defer os.RemoveAll(td)
 	defer os.Remove(".state-")
 
 	bs.WaitForPgsqlListener()
@@ -730,14 +705,13 @@ func TestPgsqlServer_ExtendedQueryPGMultiFieldsPreparedStatements(t *testing.T) 
 }
 
 func TestPgsqlServer_ExtendedQueryPGMultiFieldsPreparedInsert(t *testing.T) {
-	td, _ := ioutil.TempDir("", "_pgsql")
+	td := t.TempDir()
 	options := server.DefaultOptions().WithDir(td).WithPgsqlServer(true).WithPgsqlServerPort(0)
 	bs := servertest.NewBufconnServer(options)
 
 	bs.Start()
 	defer bs.Stop()
 
-	defer os.RemoveAll(td)
 	defer os.Remove(".state-")
 
 	bs.WaitForPgsqlListener()
@@ -772,14 +746,13 @@ func TestPgsqlServer_ExtendedQueryPGMultiFieldsPreparedInsert(t *testing.T) {
 }
 
 func TestPgsqlServer_ExtendedQueryPGxMultiInsertStatements(t *testing.T) {
-	td, _ := ioutil.TempDir("", "_pgsql")
+	td := t.TempDir()
 	options := server.DefaultOptions().WithDir(td).WithPgsqlServer(true).WithPgsqlServerPort(0)
 	bs := servertest.NewBufconnServer(options)
 
 	bs.Start()
 	defer bs.Stop()
 
-	defer os.RemoveAll(td)
 	defer os.Remove(".state-")
 
 	bs.WaitForPgsqlListener()
@@ -806,14 +779,13 @@ func TestPgsqlServer_ExtendedQueryPGxMultiInsertStatements(t *testing.T) {
 }
 
 func TestPgsqlServer_ExtendedQueryPGMultiFieldsPreparedMultiInsertError(t *testing.T) {
-	td, _ := ioutil.TempDir("", "_pgsql")
+	td := t.TempDir()
 	options := server.DefaultOptions().WithDir(td).WithPgsqlServer(true).WithPgsqlServerPort(0)
 	bs := servertest.NewBufconnServer(options)
 
 	bs.Start()
 	defer bs.Stop()
 
-	defer os.RemoveAll(td)
 	defer os.Remove(".state-")
 
 	bs.WaitForPgsqlListener()

--- a/pkg/replication/replicator_test.go
+++ b/pkg/replication/replicator_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package replication
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -28,11 +27,9 @@ import (
 )
 
 func TestReplication(t *testing.T) {
-	path, err := ioutil.TempDir(os.TempDir(), "replication_data")
-	require.NoError(t, err)
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 
-	_, err = NewTxReplicator(xid.New(), nil, nil, nil)
+	_, err := NewTxReplicator(xid.New(), nil, nil, nil)
 	require.ErrorIs(t, err, ErrIllegalArguments)
 
 	rOpts := DefaultOptions().

--- a/pkg/server/db_options_test.go
+++ b/pkg/server/db_options_test.go
@@ -17,8 +17,6 @@ limitations under the License.
 package server
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/codenotary/immudb/pkg/replication"
@@ -26,9 +24,7 @@ import (
 )
 
 func TestDefaultOptions(t *testing.T) {
-	dir, err := ioutil.TempDir("", "server_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	s, closer := testServer(DefaultOptions().WithDir(dir))
 	defer closer()
@@ -42,9 +38,7 @@ func TestDefaultOptions(t *testing.T) {
 }
 
 func TestReplicaOptions(t *testing.T) {
-	dir, err := ioutil.TempDir("", "server_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	s, closer := testServer(DefaultOptions().WithDir(dir))
 	defer closer()
@@ -70,9 +64,7 @@ func TestReplicaOptions(t *testing.T) {
 }
 
 func TestPrimaryOptions(t *testing.T) {
-	dir, err := ioutil.TempDir("", "server_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	s, closer := testServer(DefaultOptions().WithDir(dir))
 	defer closer()

--- a/pkg/server/db_runtime_test.go
+++ b/pkg/server/db_runtime_test.go
@@ -19,8 +19,6 @@ package server
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/codenotary/immudb/pkg/api/schema"
@@ -32,9 +30,7 @@ import (
 )
 
 func TestServerDatabaseRuntime(t *testing.T) {
-	dir, err := ioutil.TempDir("", "server_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	opts := DefaultOptions().WithDir(dir)
 
@@ -144,9 +140,7 @@ func TestServerDatabaseRuntime(t *testing.T) {
 }
 
 func TestServerDatabaseRuntimeEdgeCases(t *testing.T) {
-	dir, err := ioutil.TempDir("", "server_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	opts := DefaultOptions().WithDir(dir)
 

--- a/pkg/server/remote_storage_test.go
+++ b/pkg/server/remote_storage_test.go
@@ -90,9 +90,7 @@ func (r *remoteStorageMockingWrapper) ListEntries(ctx context.Context, path stri
 }
 
 func TestCreateRemoteStorage(t *testing.T) {
-	dir, err := ioutil.TempDir("", "server_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	opts := DefaultOptions().WithDir(dir)
 
@@ -139,9 +137,7 @@ func storeData(t *testing.T, s remotestorage.Storage, name string, data []byte) 
 }
 
 func TestInitializeRemoteStorageNoRemoteStorage(t *testing.T) {
-	dir, err := ioutil.TempDir("", "server_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	opts := DefaultOptions().WithDir(dir)
 
@@ -149,14 +145,12 @@ func TestInitializeRemoteStorageNoRemoteStorage(t *testing.T) {
 
 	s.WithOptions(opts)
 
-	err = s.initializeRemoteStorage(nil)
+	err := s.initializeRemoteStorage(nil)
 	require.NoError(t, err)
 }
 
 func TestInitializeRemoteStorageEmptyRemoteStorage(t *testing.T) {
-	dir, err := ioutil.TempDir("", "server_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	opts := DefaultOptions().WithDir(dir)
 
@@ -164,14 +158,12 @@ func TestInitializeRemoteStorageEmptyRemoteStorage(t *testing.T) {
 
 	s.WithOptions(opts)
 
-	err = s.initializeRemoteStorage(memory.Open())
+	err := s.initializeRemoteStorage(memory.Open())
 	require.NoError(t, err)
 }
 
 func TestInitializeRemoteStorageEmptyRemoteStorageErrorOnExists(t *testing.T) {
-	dir, err := ioutil.TempDir("", "server_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	opts := DefaultOptions().WithDir(dir)
 
@@ -187,14 +179,12 @@ func TestInitializeRemoteStorageEmptyRemoteStorageErrorOnExists(t *testing.T) {
 		},
 	}
 
-	err = s.initializeRemoteStorage(mem)
+	err := s.initializeRemoteStorage(mem)
 	require.True(t, errors.Is(err, injectedErr))
 }
 
 func TestInitializeRemoteStorageEmptyRemoteStorageErrorOnListEntries(t *testing.T) {
-	dir, err := ioutil.TempDir("", "server_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	opts := DefaultOptions().WithDir(dir)
 
@@ -210,14 +200,12 @@ func TestInitializeRemoteStorageEmptyRemoteStorageErrorOnListEntries(t *testing.
 		},
 	}
 
-	err = s.initializeRemoteStorage(mem)
+	err := s.initializeRemoteStorage(mem)
 	require.True(t, errors.Is(err, injectedErr))
 }
 
 func TestInitializeRemoteStorageDownloadIdentifier(t *testing.T) {
-	dir, err := ioutil.TempDir("", "server_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	opts := DefaultOptions().WithDir(dir)
 
@@ -228,7 +216,7 @@ func TestInitializeRemoteStorageDownloadIdentifier(t *testing.T) {
 	m := memory.Open()
 	storeData(t, m, "immudb.identifier", []byte{1, 2, 3, 4, 5})
 
-	err = s.initializeRemoteStorage(m)
+	err := s.initializeRemoteStorage(m)
 	require.NoError(t, err)
 
 	uuidFilename := filepath.Join(dir, "immudb.identifier")
@@ -241,9 +229,7 @@ func TestInitializeRemoteStorageDownloadIdentifier(t *testing.T) {
 }
 
 func TestInitializeRemoteStorageDownloadIdentifierErrorOnGet(t *testing.T) {
-	dir, err := ioutil.TempDir("", "server_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	opts := DefaultOptions().WithDir(dir)
 
@@ -261,7 +247,7 @@ func TestInitializeRemoteStorageDownloadIdentifierErrorOnGet(t *testing.T) {
 
 	storeData(t, m, "immudb.identifier", []byte{1, 2, 3, 4, 5})
 
-	err = s.initializeRemoteStorage(m)
+	err := s.initializeRemoteStorage(m)
 	require.True(t, errors.Is(err, injectedErr))
 }
 
@@ -284,9 +270,7 @@ func (e errReader) Read([]byte) (int, error) {
 }
 
 func TestInitializeRemoteStorageDownloadIdentifierErrorOnRead(t *testing.T) {
-	dir, err := ioutil.TempDir("", "server_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	opts := DefaultOptions().WithDir(dir)
 
@@ -304,14 +288,12 @@ func TestInitializeRemoteStorageDownloadIdentifierErrorOnRead(t *testing.T) {
 
 	storeData(t, m, "immudb.identifier", []byte{1, 2, 3, 4, 5})
 
-	err = s.initializeRemoteStorage(m)
+	err := s.initializeRemoteStorage(m)
 	require.True(t, errors.Is(err, injectedErr))
 }
 
 func TestInitializeRemoteStorageIdentifierMismatch(t *testing.T) {
-	dir, err := ioutil.TempDir("", "server_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	opts := DefaultOptions().WithDir(dir)
 
@@ -322,7 +304,7 @@ func TestInitializeRemoteStorageIdentifierMismatch(t *testing.T) {
 	m := memory.Open()
 	storeData(t, m, "immudb.identifier", []byte{1, 2, 3, 4, 5})
 
-	_, err = getOrSetUUID(dir, dir)
+	_, err := getOrSetUUID(dir, dir)
 	require.NoError(t, err)
 
 	err = s.initializeRemoteStorage(m)
@@ -330,9 +312,7 @@ func TestInitializeRemoteStorageIdentifierMismatch(t *testing.T) {
 }
 
 func TestInitializeRemoteStorageCreateLocalDirs(t *testing.T) {
-	dir, err := ioutil.TempDir("", "server_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	opts := DefaultOptions().WithDir(dir)
 
@@ -346,7 +326,7 @@ func TestInitializeRemoteStorageCreateLocalDirs(t *testing.T) {
 	storeData(t, m, "dir2/file3", []byte{1, 2, 3})
 	storeData(t, m, "dir3/file4", []byte{1, 2, 3})
 
-	err = s.initializeRemoteStorage(m)
+	err := s.initializeRemoteStorage(m)
 	require.NoError(t, err)
 
 	require.DirExists(t, filepath.Join(dir, "dir1"))
@@ -355,9 +335,7 @@ func TestInitializeRemoteStorageCreateLocalDirs(t *testing.T) {
 }
 
 func TestInitializeRemoteStorageCreateLocalDirsError(t *testing.T) {
-	dir, err := ioutil.TempDir("", "server_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	opts := DefaultOptions().WithDir(dir)
 
@@ -371,7 +349,7 @@ func TestInitializeRemoteStorageCreateLocalDirsError(t *testing.T) {
 	storeData(t, m, "dir2/file3", []byte{1, 2, 3})
 	storeData(t, m, "dir3/file4", []byte{1, 2, 3})
 
-	err = ioutil.WriteFile(filepath.Join(dir, "dir3"), []byte{}, 0777)
+	err := ioutil.WriteFile(filepath.Join(dir, "dir3"), []byte{}, 0777)
 	require.NoError(t, err)
 
 	err = s.initializeRemoteStorage(m)
@@ -379,9 +357,7 @@ func TestInitializeRemoteStorageCreateLocalDirsError(t *testing.T) {
 }
 
 func TestUpdateRemoteUUID(t *testing.T) {
-	dir, err := ioutil.TempDir("", "server_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	opts := DefaultOptions().WithDir(dir)
 
@@ -411,9 +387,7 @@ func TestUpdateRemoteUUID(t *testing.T) {
 }
 
 func TestStoreOptionsForDBWithRemoteStorage(t *testing.T) {
-	dir, err := ioutil.TempDir("", "server_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	opts := DefaultOptions().WithDir(dir)
 
@@ -461,9 +435,7 @@ func TestStoreOptionsForDBWithRemoteStorage(t *testing.T) {
 }
 
 func TestRemoteStorageUsedForNewDB(t *testing.T) {
-	dir, err := ioutil.TempDir("", "server_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	s := DefaultServer()
 
@@ -473,7 +445,7 @@ func TestRemoteStorageUsedForNewDB(t *testing.T) {
 		WithListener(bufconn.Listen(1024 * 1024)),
 	)
 
-	err = s.Initialize()
+	err := s.Initialize()
 	require.NoError(t, err)
 
 	m := memory.Open()

--- a/pkg/server/service_test.go
+++ b/pkg/server/service_test.go
@@ -17,8 +17,6 @@ limitations under the License.
 package server
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 	"time"
 
@@ -31,9 +29,7 @@ func TestService(t *testing.T) {
 	bufSize := 1024 * 1024
 	l := bufconn.Listen(bufSize)
 
-	dir, err := ioutil.TempDir("", "server_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	options := DefaultOptions().
 		WithDir(dir).
@@ -44,7 +40,7 @@ func TestService(t *testing.T) {
 
 	server := DefaultServer().WithOptions(options).(*ImmuServer)
 
-	err = server.Initialize()
+	err := server.Initialize()
 	require.NoError(t, err)
 	srvc := &Service{
 		ImmuServerIf: server,

--- a/pkg/server/sessions/internal/transactions/transactions_test.go
+++ b/pkg/server/sessions/internal/transactions/transactions_test.go
@@ -18,7 +18,6 @@ package transactions
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -29,9 +28,7 @@ import (
 )
 
 func TestNewTx(t *testing.T) {
-	path, err := ioutil.TempDir(os.TempDir(), "tx_session_data")
-	require.NoError(t, err)
-	defer os.RemoveAll(path)
+	path := t.TempDir()
 
 	db, err := database.NewDB("db1", nil, database.DefaultOption().WithDBRootPath(path), logger.NewSimpleLogger("logger", os.Stdout))
 	require.NoError(t, err)

--- a/pkg/server/sever_current_state_test.go
+++ b/pkg/server/sever_current_state_test.go
@@ -18,8 +18,6 @@ package server
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/codenotary/immudb/pkg/api/schema"
@@ -29,9 +27,7 @@ import (
 )
 
 func TestServerCurrentStateSigned(t *testing.T) {
-	dir, err := ioutil.TempDir("", "server_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	s := DefaultServer()
 

--- a/pkg/server/sql_test.go
+++ b/pkg/server/sql_test.go
@@ -18,8 +18,6 @@ package server
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/codenotary/immudb/embedded/sql"
@@ -31,9 +29,7 @@ import (
 )
 
 func TestSQLInteraction(t *testing.T) {
-	dir, err := ioutil.TempDir("", "server_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	serverOptions := DefaultOptions().
 		WithDir(dir).
@@ -47,7 +43,7 @@ func TestSQLInteraction(t *testing.T) {
 
 	ctx := context.Background()
 
-	_, err = s.ListTables(ctx, &emptypb.Empty{})
+	_, err := s.ListTables(ctx, &emptypb.Empty{})
 	require.Error(t, err)
 
 	_, err = s.SQLExec(ctx, nil)
@@ -114,9 +110,7 @@ func TestSQLInteraction(t *testing.T) {
 }
 
 func TestSQLExecResult(t *testing.T) {
-	dir, err := ioutil.TempDir("", "server_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	serverOptions := DefaultOptions().
 		WithDir(dir).
@@ -151,9 +145,7 @@ func TestSQLExecResult(t *testing.T) {
 }
 
 func TestSQLExecCreateDatabase(t *testing.T) {
-	dir, err := ioutil.TempDir("", "server_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	serverOptions := DefaultOptions().
 		WithDir(dir).

--- a/pkg/server/stream_replication_test.go
+++ b/pkg/server/stream_replication_test.go
@@ -19,8 +19,6 @@ package server
 import (
 	"context"
 	"errors"
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/codenotary/immudb/pkg/api/schema"
@@ -31,9 +29,7 @@ import (
 )
 
 func TestExportTxEdgeCases(t *testing.T) {
-	dir, err := ioutil.TempDir("", "server_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	serverOptions := DefaultOptions().
 		WithDir(dir).
@@ -44,7 +40,7 @@ func TestExportTxEdgeCases(t *testing.T) {
 
 	s.Initialize()
 
-	err = s.ExportTx(nil, nil)
+	err := s.ExportTx(nil, nil)
 	require.Equal(t, ErrIllegalArguments, err)
 
 	err = s.ExportTx(&schema.ExportTxRequest{Tx: 1}, &immuServiceExportTxServer{})
@@ -69,9 +65,7 @@ func TestExportTxEdgeCases(t *testing.T) {
 }
 
 func TestReplicateTxEdgeCases(t *testing.T) {
-	dir, err := ioutil.TempDir("", "server_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	serverOptions := DefaultOptions().
 		WithDir(dir).
@@ -82,7 +76,7 @@ func TestReplicateTxEdgeCases(t *testing.T) {
 
 	s.Initialize()
 
-	err = s.ReplicateTx(nil)
+	err := s.ReplicateTx(nil)
 	require.Equal(t, ErrIllegalArguments, err)
 
 	err = s.ReplicateTx(&immuServiceReplicateTxServer{ctx: context.Background()})

--- a/pkg/server/stream_test.go
+++ b/pkg/server/stream_test.go
@@ -2,8 +2,6 @@ package server
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/codenotary/immudb/pkg/api/schema"
@@ -12,15 +10,13 @@ import (
 )
 
 func TestImmuServer_StreamGetDbError(t *testing.T) {
-	dir, err := ioutil.TempDir("", "server_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	s := DefaultServer()
 
 	s.WithOptions(DefaultOptions().WithDir(dir))
 
-	err = s.StreamSet(&StreamServerMock{})
+	err := s.StreamSet(&StreamServerMock{})
 	require.Error(t, err)
 	err = s.StreamGet(nil, &StreamServerMock{})
 	require.Error(t, err)

--- a/pkg/server/transaction_test.go
+++ b/pkg/server/transaction_test.go
@@ -2,8 +2,6 @@ package server
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/codenotary/immudb/pkg/api/schema"
@@ -12,15 +10,13 @@ import (
 )
 
 func TestImmuServer_Transaction(t *testing.T) {
-	dir, err := ioutil.TempDir("", "server_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	s := DefaultServer()
 
 	s.WithOptions(DefaultOptions().WithDir(dir).WithMaintenance(true))
 
-	_, err = s.NewTx(context.Background(), nil)
+	_, err := s.NewTx(context.Background(), nil)
 	require.ErrorIs(t, err, ErrIllegalArguments)
 
 	_, err = s.NewTx(context.Background(), &schema.NewTxRequest{Mode: schema.TxMode_ReadWrite})

--- a/pkg/server/types_test.go
+++ b/pkg/server/types_test.go
@@ -17,8 +17,6 @@ limitations under the License.
 package server
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/codenotary/immudb/pkg/database"
@@ -27,9 +25,7 @@ import (
 )
 
 func TestWithLogger(t *testing.T) {
-	dir, err := ioutil.TempDir("", "server_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	logger := &mockLogger{}
 
@@ -42,9 +38,7 @@ func TestWithLogger(t *testing.T) {
 }
 
 func TestWithStreamServiceFactory(t *testing.T) {
-	dir, err := ioutil.TempDir("", "server_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	streamServiceFactory := stream.NewStreamServiceFactory(4096)
 
@@ -57,9 +51,7 @@ func TestWithStreamServiceFactory(t *testing.T) {
 }
 
 func TestWithDbList(t *testing.T) {
-	dir, err := ioutil.TempDir("", "server_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	dbList := database.NewDatabaseList()
 

--- a/pkg/server/user_test.go
+++ b/pkg/server/user_test.go
@@ -18,8 +18,6 @@ package server
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/codenotary/immudb/pkg/api/schema"
@@ -31,9 +29,7 @@ import (
 )
 
 func TestServerLogin(t *testing.T) {
-	dir, err := ioutil.TempDir("", "server_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	serverOptions := DefaultOptions().
 		WithDir(dir).
@@ -59,9 +55,7 @@ func TestServerLogin(t *testing.T) {
 }
 
 func TestServerLogout(t *testing.T) {
-	dir, err := ioutil.TempDir("", "server_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	serverOptions := DefaultOptions().
 		WithDir(dir).
@@ -72,7 +66,7 @@ func TestServerLogout(t *testing.T) {
 
 	s.Initialize()
 
-	_, err = s.Logout(context.Background(), &emptypb.Empty{})
+	_, err := s.Logout(context.Background(), &emptypb.Empty{})
 	if err == nil || err.Error() != ErrNotLoggedIn.Message() {
 		t.Fatalf("Logout expected error, got %v", err)
 	}
@@ -92,9 +86,7 @@ func TestServerLogout(t *testing.T) {
 }
 
 func TestServerLoginLogoutWithAuthDisabled(t *testing.T) {
-	dir, err := ioutil.TempDir("", "server_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	serverOptions := DefaultOptions().
 		WithDir(dir).
@@ -105,15 +97,13 @@ func TestServerLoginLogoutWithAuthDisabled(t *testing.T) {
 
 	s.Initialize()
 
-	_, err = s.Logout(context.Background(), &emptypb.Empty{})
+	_, err := s.Logout(context.Background(), &emptypb.Empty{})
 	require.NotNil(t, err)
 	require.Equal(t, ErrAuthDisabled, err.Error())
 }
 
 func TestServerListUsersAdmin(t *testing.T) {
-	dir, err := ioutil.TempDir("", "server_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	serverOptions := DefaultOptions().
 		WithDir(dir).
@@ -229,9 +219,7 @@ func TestServerListUsersAdmin(t *testing.T) {
 }
 
 func TestServerUsermanagement(t *testing.T) {
-	dir, err := ioutil.TempDir("", "server_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	serverOptions := DefaultOptions().
 		WithDir(dir).

--- a/pkg/server/webserver_test.go
+++ b/pkg/server/webserver_test.go
@@ -18,9 +18,7 @@ package server
 
 import (
 	"crypto/tls"
-	"io/ioutil"
 	"net/http"
-	"os"
 	"testing"
 	"time"
 
@@ -28,9 +26,7 @@ import (
 )
 
 func TestStartWebServerHTTP(t *testing.T) {
-	dir, err := ioutil.TempDir("", "server_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	options := DefaultOptions().WithDir(dir)
 	server := DefaultServer().WithOptions(options).(*ImmuServer)
@@ -58,9 +54,7 @@ func TestStartWebServerHTTP(t *testing.T) {
 }
 
 func TestStartWebServerHTTPS(t *testing.T) {
-	dir, err := ioutil.TempDir("", "server_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	options := DefaultOptions().WithDir(dir)
 	server := DefaultServer().WithOptions(options).(*ImmuServer)

--- a/pkg/streamutils/files_test.go
+++ b/pkg/streamutils/files_test.go
@@ -1,19 +1,19 @@
 package streamutils
 
 import (
-	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestStreamUtilsFiles(t *testing.T) {
-	tmpdir, err := ioutil.TempDir(os.TempDir(), "streamutils")
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	// stat will fail
-	_, err = GetKeyValuesFromFiles(filepath.Join(tmpdir, "non-existant"))
+	_, err := GetKeyValuesFromFiles(filepath.Join(tmpdir, "non-existant"))
 	require.Error(t, err)
 
 	unreadable := filepath.Join(tmpdir, "dir")


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	require.NoError(t, err)
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```