### PR TITLE
Extend immudb performance tests with immudb replication sync/async

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -53,9 +53,10 @@ jobs:
         id: performance
         run: |
           SECONDS=0
-          ./perf-test-suite $ARG_DURATION > perf-test-results.json
+          ./perf-test-suite $ARG_DURATION > perf-test-results-with-summaries.txt
           echo "duration=$SECONDS" >> $GITHUB_ENV
           echo "version=$(cat Makefile | grep '\<VERSION=' | awk -F= '{print $2}' | tr -d [\',])" >> $GITHUB_ENV
+          sed '/^{/,/^}/!d' perf-test-results-with-summaries.txt > perf-test-results.json
       - name: Upload test results
         uses: actions/upload-artifact@v3
         with:

--- a/test/performance-test-suite/pkg/benchmarks/writetxs/benchmark.go
+++ b/test/performance-test-suite/pkg/benchmarks/writetxs/benchmark.go
@@ -159,7 +159,7 @@ func (b *benchmark) Warmup() error {
 			return err
 		}
 
-		defer os.RemoveAll(primaryPath)
+		defer os.RemoveAll(replicaPath)
 
 		replicaServerOptions := server.
 			DefaultOptions().

--- a/test/performance-test-suite/pkg/benchmarks/writetxs/benchmark.go
+++ b/test/performance-test-suite/pkg/benchmarks/writetxs/benchmark.go
@@ -132,8 +132,8 @@ func (b *benchmark) Warmup() error {
 		return err
 	}
 
-	if b.cfg.Replica == "async" {
-		const replicaDirName = "async-replica-tx-test"
+	if b.cfg.Replica == "async" || b.cfg.Replica == "sync" {
+		replicaDirName := fmt.Sprintf("%s-replica-tx-test", b.cfg.Replica)
 
 		replicaOptions := server.
 			ReplicationOptions{}
@@ -141,29 +141,17 @@ func (b *benchmark) Warmup() error {
 		options2 := server.
 			DefaultOptions().
 			WithDir(replicaDirName).
-			WithLogFormat(logger.LogFormatJSON).
-			WithReplicationOptions(replicaOptions.WithIsReplica(true))
+			WithLogFormat(logger.LogFormatJSON)
 
-		b.replicaServer = servertest.NewBufconnServer(options2)
-		b.replicaServer.Server.Srv.WithLogger(logger.NewMemoryLoggerWithLevel(logger.LogDebug))
-
-		err = b.replicaServer.Start()
-		if err != nil {
-			return err
+		if b.cfg.Replica == "async" {
+			options2.
+				WithReplicationOptions(replicaOptions.WithIsReplica(true))
 		}
-	}
 
-	if b.cfg.Replica == "sync" {
-		const replicaDirName = "sync-replica-tx-test"
-
-		replicaOptions := server.
-			ReplicationOptions{}
-
-		options2 := server.
-			DefaultOptions().
-			WithDir(replicaDirName).
-			WithLogFormat(logger.LogFormatJSON).
-			WithReplicationOptions(replicaOptions.WithIsReplica(true).WithSyncReplication(true))
+		if b.cfg.Replica == "sync" {
+			options2.
+				WithReplicationOptions(replicaOptions.WithIsReplica(true).WithSyncReplication(true))
+		}
 
 		b.replicaServer = servertest.NewBufconnServer(options2)
 		b.replicaServer.Server.Srv.WithLogger(logger.NewMemoryLoggerWithLevel(logger.LogDebug))

--- a/test/performance-test-suite/pkg/runner/benchmarks.go
+++ b/test/performance-test-suite/pkg/runner/benchmarks.go
@@ -24,7 +24,7 @@ import (
 func getBenchmarksToRun() []benchmarks.Benchmark {
 	return []benchmarks.Benchmark{
 		writetxs.NewBenchmark(writetxs.Config{
-			Name:       "Write TX/s - single server",
+			Name:       "Write TX/s - no replicas",
 			Workers:    30,
 			BatchSize:  1,
 			KeySize:    32,
@@ -34,7 +34,7 @@ func getBenchmarksToRun() []benchmarks.Benchmark {
 		}),
 
 		writetxs.NewBenchmark(writetxs.Config{
-			Name:       "Write KV/s - single server",
+			Name:       "Write KV/s - no replicas",
 			Workers:    30,
 			BatchSize:  1000,
 			KeySize:    32,

--- a/test/performance-test-suite/pkg/runner/benchmarks.go
+++ b/test/performance-test-suite/pkg/runner/benchmarks.go
@@ -30,7 +30,7 @@ func getBenchmarksToRun() []benchmarks.Benchmark {
 			KeySize:    32,
 			ValueSize:  128,
 			AsyncWrite: true,
-			Replica:    false,
+			Replica:    "",
 		}),
 
 		writetxs.NewBenchmark(writetxs.Config{
@@ -40,7 +40,7 @@ func getBenchmarksToRun() []benchmarks.Benchmark {
 			KeySize:    32,
 			ValueSize:  128,
 			AsyncWrite: true,
-			Replica:    false,
+			Replica:    "",
 		}),
 
 		writetxs.NewBenchmark(writetxs.Config{
@@ -50,7 +50,7 @@ func getBenchmarksToRun() []benchmarks.Benchmark {
 			KeySize:    32,
 			ValueSize:  128,
 			AsyncWrite: true,
-			Replica:    true,
+			Replica:    "async",
 		}),
 
 		writetxs.NewBenchmark(writetxs.Config{
@@ -60,7 +60,27 @@ func getBenchmarksToRun() []benchmarks.Benchmark {
 			KeySize:    32,
 			ValueSize:  128,
 			AsyncWrite: true,
-			Replica:    true,
+			Replica:    "async",
+		}),
+
+		writetxs.NewBenchmark(writetxs.Config{
+			Name:       "Write TX/s - one sync replica",
+			Workers:    30,
+			BatchSize:  1,
+			KeySize:    32,
+			ValueSize:  128,
+			AsyncWrite: true,
+			Replica:    "sync",
+		}),
+
+		writetxs.NewBenchmark(writetxs.Config{
+			Name:       "Write KV/s - one sync replica",
+			Workers:    30,
+			BatchSize:  1000,
+			KeySize:    32,
+			ValueSize:  128,
+			AsyncWrite: true,
+			Replica:    "sync",
 		}),
 	}
 }

--- a/test/performance-test-suite/pkg/runner/benchmarks.go
+++ b/test/performance-test-suite/pkg/runner/benchmarks.go
@@ -24,21 +24,43 @@ import (
 func getBenchmarksToRun() []benchmarks.Benchmark {
 	return []benchmarks.Benchmark{
 		writetxs.NewBenchmark(writetxs.Config{
-			Name:       "Write TX/s",
+			Name:       "Write TX/s - single server",
 			Workers:    30,
 			BatchSize:  1,
 			KeySize:    32,
 			ValueSize:  128,
 			AsyncWrite: true,
+			Replica:    false,
 		}),
 
 		writetxs.NewBenchmark(writetxs.Config{
-			Name:       "Write KV/s",
+			Name:       "Write KV/s - single server",
 			Workers:    30,
 			BatchSize:  1000,
 			KeySize:    32,
 			ValueSize:  128,
 			AsyncWrite: true,
+			Replica:    false,
+		}),
+
+		writetxs.NewBenchmark(writetxs.Config{
+			Name:       "Write TX/s - one async replica",
+			Workers:    30,
+			BatchSize:  1,
+			KeySize:    32,
+			ValueSize:  128,
+			AsyncWrite: true,
+			Replica:    true,
+		}),
+
+		writetxs.NewBenchmark(writetxs.Config{
+			Name:       "Write KV/s - one async replica",
+			Workers:    30,
+			BatchSize:  1000,
+			KeySize:    32,
+			ValueSize:  128,
+			AsyncWrite: true,
+			Replica:    true,
 		}),
 	}
 }


### PR DESCRIPTION
- [x] async
- [x] sync

This is a summary of a sample result of the changed performance tests:

```sh
Write TX/s - no replicas
TX: 18810, KV: 18810, TX/s: 1880.98, KV/S: 1880.98, CPUTime: 3.86, VMM: 2.29G, RSS: 321.01M, Writes (bytes/calls): 14.30M/88987, Reads (bytes/calls): 90.11k/190709

Write KV/s - no replicas
TX: 3438, KV: 3438000, TX/s: 341.78, KV/S: 341777.54, CPUTime: 38.33, VMM: 3.92G, RSS: 1.61G, Writes (bytes/calls): 910.06M/106995, Reads (bytes/calls): 29.41M/120928

Write TX/s - one async replica
TX: 9240, KV: 9240, TX/s: 923.91, KV/S: 923.91, CPUTime: 6.27, VMM: 5.18G, RSS: 1.83G, Writes (bytes/calls): 63.80M/136470, Reads (bytes/calls): 1.86M/285687

Write KV/s - one async replica
TX: 756, KV: 756000, TX/s: 75.60, KV/S: 75596.01, CPUTime: 12.50, VMM: 6.52G, RSS: 3.35G, Writes (bytes/calls): 194.29M/30254, Reads (bytes/calls): 1.13M/111999

Write TX/s - one sync replica
TX: 1296, KV: 1296, TX/s: 129.60, KV/S: 129.60, CPUTime: 19.18, VMM: 9.34G, RSS: 5.35G, Writes (bytes/calls): 522.53M/169316, Reads (bytes/calls): 57.84M/539576

Write KV/s - one sync replica
TX: 268, KV: 268000, TX/s: 26.80, KV/S: 26798.07, CPUTime: 16.37, VMM: 10.26G, RSS: 5.64G, Writes (bytes/calls): 214.32M/110988, Reads (bytes/calls): 16.40M/482183
```