### PR TITLE
fix(pkg/database): skip eof error during scan

### DIFF
--- a/pkg/database/scan.go
+++ b/pkg/database/scan.go
@@ -18,7 +18,9 @@ package database
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 
 	"github.com/codenotary/immudb/embedded/store"
 	"github.com/codenotary/immudb/pkg/api/schema"
@@ -93,6 +95,10 @@ func (d *db) Scan(ctx context.Context, req *schema.ScanRequest) (*schema.Entries
 		e, err := d.getAtTx(key, valRef.Tx(), 0, snap, valRef.HC(), true)
 		if err == store.ErrKeyNotFound {
 			// ignore deleted ones (referenced key may have been deleted)
+			continue
+		}
+		if errors.Is(err, io.EOF) {
+			// ignore truncated values (referenced value may have been truncated)
 			continue
 		}
 		if err != nil {

--- a/pkg/database/scan_test.go
+++ b/pkg/database/scan_test.go
@@ -265,3 +265,91 @@ func TestStoreScanEndKey(t *testing.T) {
 		}
 	})
 }
+
+func TestStoreScanWithTruncation(t *testing.T) {
+	rootPath := t.TempDir()
+
+	fileSize := 12
+
+	options := DefaultOption().WithDBRootPath(rootPath).WithCorruptionChecker(false)
+	options.storeOpts.WithIndexOptions(options.storeOpts.IndexOpts.WithCompactionThld(2)).WithFileSize(fileSize)
+	options.storeOpts.MaxIOConcurrency = 1
+	options.storeOpts.MaxConcurrency = 500
+	options.storeOpts.VLogCacheSize = 0
+
+	db := makeDbWith(t, "db", options)
+
+	for i := 0; i < 10; i++ {
+		_, err := db.Set(
+			context.Background(),
+			&schema.SetRequest{
+				KVs: []*schema.KeyValue{{
+					Key:   []byte(fmt.Sprintf("prefix:suffix%d", i)),
+					Value: []byte(`item`),
+				}},
+			},
+		)
+		require.NoError(t, err)
+	}
+
+	deletePointTx := uint64(5)
+
+	t.Run("ensure data is truncated up to delete point", func(t *testing.T) {
+		hdr, err := db.st.ReadTxHeader(deletePointTx, false, false)
+		require.NoError(t, err)
+		c := NewVlogTruncator(db)
+		require.NoError(t, c.Truncate(context.Background(), hdr.ID))
+
+		for i := deletePointTx; i < 10; i++ {
+			tx := store.NewTx(db.st.MaxTxEntries(), db.st.MaxKeyLen())
+			err = db.st.ReadTx(i, false, tx)
+			require.NoError(t, err)
+			for _, e := range tx.Entries() {
+				_, err := db.st.ReadValue(e)
+				require.NoError(t, err)
+			}
+		}
+
+		for i := deletePointTx - 1; i > 0; i-- {
+			tx := store.NewTx(db.st.MaxTxEntries(), db.st.MaxKeyLen())
+			err = db.st.ReadTx(i, false, tx)
+			require.NoError(t, err)
+			for _, e := range tx.Entries() {
+				_, err := db.st.ReadValue(e)
+				require.Error(t, err)
+			}
+		}
+	})
+
+	t.Run("ensure scanning prefix works post data deletion", func(t *testing.T) {
+		scanOptions := schema.ScanRequest{
+			SeekKey: nil,
+			Prefix:  []byte(`prefix:`),
+			Limit:   0,
+			Desc:    false,
+			SinceTx: deletePointTx,
+		}
+
+		list, err := db.Scan(context.Background(), &scanOptions)
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, len(list.Entries), 6)
+		require.Equal(t, list.Entries[0].Key, []byte(`prefix:suffix3`))
+		require.Equal(t, list.Entries[1].Key, []byte(`prefix:suffix4`))
+		require.Equal(t, list.Entries[2].Key, []byte(`prefix:suffix5`))
+
+		scanOptions = schema.ScanRequest{
+			SeekKey: []byte(`prefix?`),
+			Prefix:  []byte(`prefix:`),
+			Limit:   0,
+			Desc:    true,
+			SinceTx: deletePointTx,
+		}
+
+		list, err = db.Scan(context.Background(), &scanOptions)
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, len(list.Entries), 6)
+		require.Equal(t, list.Entries[0].Key, []byte(`prefix:suffix9`))
+		require.Equal(t, list.Entries[1].Key, []byte(`prefix:suffix8`))
+		require.Equal(t, list.Entries[2].Key, []byte(`prefix:suffix7`))
+	})
+}

--- a/pkg/database/sorted_set.go
+++ b/pkg/database/sorted_set.go
@@ -19,7 +19,9 @@ package database
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
+	"io"
 	"math"
 
 	"github.com/codenotary/immudb/embedded/store"
@@ -209,6 +211,10 @@ func (d *db) ZScan(ctx context.Context, req *schema.ZScanRequest) (*schema.ZEntr
 		e, err := d.getAtTx(key, atTx, 1, snap, 0, true)
 		if err == store.ErrKeyNotFound {
 			// ignore deleted ones (referenced key may have been deleted)
+			continue
+		}
+		if errors.Is(err, io.EOF) {
+			// ignore truncated values (referenced value may have been truncated)
 			continue
 		}
 		if err != nil {


### PR DESCRIPTION
eof error, which is returned when data is truncated, should not block reading scanning all keys