### PR TITLE
support for unsafe MVCC mode

### DIFF
--- a/embedded/sql/engine.go
+++ b/embedded/sql/engine.go
@@ -195,7 +195,7 @@ func (e *Engine) NewTx(ctx context.Context, opts *TxOptions) (*SQLTx, error) {
 	// At least that requirement is at commit time,
 	// but it's set during tx initialization to simplify commit steps
 
-	if opts.unsafeMVCC && e.lastCatalogTxID > 0 {
+	if opts.UnsafeMVCC && e.lastCatalogTxID > 0 {
 		snapshotMustIncludeTxID = func(lastPrecommittedTxID uint64) uint64 {
 			// return the greatest value  e.lastCatalogTxID and opts.SnapshotMustIncludeTxID
 			if opts.SnapshotMustIncludeTxID == nil {
@@ -210,12 +210,17 @@ func (e *Engine) NewTx(ctx context.Context, opts *TxOptions) (*SQLTx, error) {
 
 			return e.lastCatalogTxID
 		}
+	} else {
+		snapshotMustIncludeTxID = func(lastPrecommittedTxID uint64) uint64 {
+			return lastPrecommittedTxID
+		}
 	}
 
 	txOpts := &store.TxOptions{
 		Mode:                    mode,
 		SnapshotMustIncludeTxID: snapshotMustIncludeTxID,
 		SnapshotRenewalPeriod:   opts.SnapshotRenewalPeriod,
+		UnsafeMVCC:              opts.UnsafeMVCC,
 	}
 
 	e.mutex.RLock()

--- a/embedded/sql/engine_test.go
+++ b/embedded/sql/engine_test.go
@@ -6169,6 +6169,9 @@ func BenchmarkInsertInto(b *testing.B) {
 		b.Fail()
 	}
 
+	// TODO: lastCatalogTxID automatically managed by the engine
+	engine.lastCatalogTxID = ctxs[0].txHeader.ID
+
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
@@ -6185,8 +6188,8 @@ func BenchmarkInsertInto(b *testing.B) {
 				for i := 0; i < txCount; i++ {
 					txOpts := DefaultTxOptions().
 						WithExplicitClose(true).
-						WithSnapshotRenewalPeriod(0).
-						WithSnapshotMustIncludeTxID(func(lastPrecommittedTxID uint64) uint64 { return ctxs[0].txHeader.ID })
+						WithUnsafeMVCC(true).
+						WithSnapshotMustIncludeTxID(func(lastPrecommittedTxID uint64) uint64 { return 0 })
 
 					tx, err := engine.NewTx(context.Background(), txOpts)
 					if err != nil {

--- a/embedded/sql/sql_tx_options.go
+++ b/embedded/sql/sql_tx_options.go
@@ -28,6 +28,7 @@ type TxOptions struct {
 	SnapshotMustIncludeTxID func(lastPrecommittedTxID uint64) uint64
 	SnapshotRenewalPeriod   time.Duration
 	ExplicitClose           bool
+	UnsafeMVCC              bool
 }
 
 func DefaultTxOptions() *TxOptions {
@@ -38,6 +39,7 @@ func DefaultTxOptions() *TxOptions {
 		SnapshotMustIncludeTxID: txOpts.SnapshotMustIncludeTxID,
 		SnapshotRenewalPeriod:   txOpts.SnapshotRenewalPeriod,
 		ExplicitClose:           false, // commit or rollback explicitly required
+		UnsafeMVCC:              false, // mvcc restricted to catalog changes
 	}
 }
 
@@ -66,5 +68,10 @@ func (opts *TxOptions) WithSnapshotRenewalPeriod(snapshotRenewalPeriod time.Dura
 
 func (opts *TxOptions) WithExplicitClose(explicitClose bool) *TxOptions {
 	opts.ExplicitClose = explicitClose
+	return opts
+}
+
+func (opts *TxOptions) WithUnsafeMVCC(unsafeMVCC bool) *TxOptions {
+	opts.UnsafeMVCC = unsafeMVCC
 	return opts
 }

--- a/embedded/sql/stmt.go
+++ b/embedded/sql/stmt.go
@@ -218,6 +218,8 @@ func (stmt *CreateDatabaseStmt) execAt(ctx context.Context, tx *SQLTx, params ma
 		return nil, err
 	}
 
+	tx.mutatedCatalog = true
+
 	return tx, nil
 }
 
@@ -345,6 +347,8 @@ func (stmt *CreateTableStmt) execAt(ctx context.Context, tx *SQLTx, params map[s
 		return nil, err
 	}
 
+	tx.mutatedCatalog = true
+
 	return tx, nil
 }
 
@@ -441,6 +445,8 @@ func (stmt *CreateIndexStmt) execAt(ctx context.Context, tx *SQLTx, params map[s
 		return nil, err
 	}
 
+	tx.mutatedCatalog = true
+
 	return tx, nil
 }
 
@@ -472,6 +478,8 @@ func (stmt *AddColumnStmt) execAt(ctx context.Context, tx *SQLTx, params map[str
 	if err != nil {
 		return nil, err
 	}
+
+	tx.mutatedCatalog = true
 
 	return tx, nil
 }
@@ -505,6 +513,8 @@ func (stmt *RenameColumnStmt) execAt(ctx context.Context, tx *SQLTx, params map[
 	if err != nil {
 		return nil, err
 	}
+
+	tx.mutatedCatalog = true
 
 	return tx, nil
 }

--- a/embedded/store/immustore.go
+++ b/embedded/store/immustore.go
@@ -1268,10 +1268,12 @@ func (s *ImmuStore) precommit(ctx context.Context, otx *OngoingTx, hdr *TxHeader
 	}
 
 	if otx.hasPreconditions() {
-		// Preconditions must be executed with up-to-date tree
-		err = s.WaitForIndexingUpto(ctx, currPrecomittedTxID)
-		if err != nil {
-			return nil, err
+		if !otx.unsafeMVCC {
+			// Preconditions must be executed with up-to-date tree
+			err = s.WaitForIndexingUpto(ctx, currPrecomittedTxID)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		err = otx.checkPreconditions(s)

--- a/embedded/store/ongoing_tx.go
+++ b/embedded/store/ongoing_tx.go
@@ -30,8 +30,9 @@ import (
 type OngoingTx struct {
 	st *ImmuStore
 
-	snap     *Snapshot
-	readOnly bool // MVCC validations are not needed for read-only transactions
+	snap       *Snapshot
+	readOnly   bool // MVCC validations are not needed for read-only transactions
+	unsafeMVCC bool
 
 	entries      []*EntrySpec
 	entriesByKey map[[sha256.Size]byte]int
@@ -92,6 +93,7 @@ func newOngoingTx(ctx context.Context, s *ImmuStore, opts *TxOptions) (*OngoingT
 		st:           s,
 		entriesByKey: make(map[[sha256.Size]byte]int),
 		ts:           time.Now(),
+		unsafeMVCC:   opts.UnsafeMVCC,
 	}
 
 	if opts.Mode == WriteOnlyTx {

--- a/embedded/store/ongoing_tx.go
+++ b/embedded/store/ongoing_tx.go
@@ -34,6 +34,8 @@ type OngoingTx struct {
 	readOnly   bool // MVCC validations are not needed for read-only transactions
 	unsafeMVCC bool
 
+	requireMVCCOnFollowingTxs bool
+
 	entries      []*EntrySpec
 	entriesByKey map[[sha256.Size]byte]int
 
@@ -418,6 +420,10 @@ func (tx *OngoingTx) NewKeyReader(spec KeyReaderSpec) (KeyReader, error) {
 	}
 
 	return newOngoingTxKeyReader(tx, spec)
+}
+
+func (tx *OngoingTx) RequireMVCCOnFollowingTxs(requireMVCCOnFollowingTxs bool) {
+	tx.requireMVCCOnFollowingTxs = requireMVCCOnFollowingTxs
 }
 
 func (tx *OngoingTx) Commit(ctx context.Context) (*TxHeader, error) {

--- a/embedded/store/ongoing_tx_options.go
+++ b/embedded/store/ongoing_tx_options.go
@@ -38,6 +38,9 @@ type TxOptions struct {
 	SnapshotMustIncludeTxID func(lastPrecommittedTxID uint64) uint64
 	// SnapshotRenewalPeriod determines for how long a snaphsot may reuse existent dumped root
 	SnapshotRenewalPeriod time.Duration
+
+	// MVCC does not wait for indexing to be up to date
+	UnsafeMVCC bool
 }
 
 func DefaultTxOptions() *TxOptions {
@@ -46,6 +49,7 @@ func DefaultTxOptions() *TxOptions {
 		SnapshotMustIncludeTxID: func(lastPrecommittedTxID uint64) uint64 {
 			return lastPrecommittedTxID
 		},
+		UnsafeMVCC: false,
 	}
 }
 
@@ -73,5 +77,10 @@ func (opts *TxOptions) WithSnapshotMustIncludeTxID(snapshotMustIncludeTxID func(
 
 func (opts *TxOptions) WithSnapshotRenewalPeriod(snapshotRenewalPeriod time.Duration) *TxOptions {
 	opts.SnapshotRenewalPeriod = snapshotRenewalPeriod
+	return opts
+}
+
+func (opts *TxOptions) WithUnsafeMVCC(unsafeMVCC bool) *TxOptions {
+	opts.UnsafeMVCC = unsafeMVCC
 	return opts
 }


### PR DESCRIPTION
depending on the use case, concurrency control may be relaxed toward performance i.e. if your application won't concurrently modify the same related data.