### PR TITLE
chore(embedded/sql): singledb sql engine

### DIFF
--- a/cmd/immuclient/command/currentstatus_test.go
+++ b/cmd/immuclient/command/currentstatus_test.go
@@ -19,6 +19,7 @@ package immuclient
 import (
 	"bytes"
 	"io/ioutil"
+	"strings"
 	"testing"
 
 	"github.com/codenotary/immudb/pkg/client"
@@ -74,5 +75,5 @@ func TestCurrentState(t *testing.T) {
 	require.NoError(t, err)
 	rsp := string(msg)
 
-	require.Contains(t, rsp, "txID:")
+	require.True(t, strings.Contains(rsp, "is empty") || strings.Contains(rsp, "txID:"))
 }

--- a/embedded/sql/aggregated_values.go
+++ b/embedded/sql/aggregated_values.go
@@ -73,11 +73,11 @@ func (v *CountValue) updateWith(val TypedValue) error {
 
 // ValueExp
 
-func (v *CountValue) inferType(cols map[string]ColDescriptor, params map[string]SQLValueType, implicitDB, implicitTable string) (SQLValueType, error) {
+func (v *CountValue) inferType(cols map[string]ColDescriptor, params map[string]SQLValueType, implicitTable string) (SQLValueType, error) {
 	return IntegerType, nil
 }
 
-func (v *CountValue) requiresType(t SQLValueType, cols map[string]ColDescriptor, params map[string]SQLValueType, implicitDB, implicitTable string) error {
+func (v *CountValue) requiresType(t SQLValueType, cols map[string]ColDescriptor, params map[string]SQLValueType, implicitTable string) error {
 	if t != IntegerType {
 		return ErrNotComparableValues
 	}
@@ -92,11 +92,11 @@ func (v *CountValue) substitute(params map[string]interface{}) (ValueExp, error)
 	return nil, ErrUnexpected
 }
 
-func (v *CountValue) reduce(tx *SQLTx, row *Row, implicitDB, implicitTable string) (TypedValue, error) {
+func (v *CountValue) reduce(tx *SQLTx, row *Row, implicitTable string) (TypedValue, error) {
 	return nil, ErrUnexpected
 }
 
-func (v *CountValue) reduceSelectors(row *Row, implicitDB, implicitTable string) ValueExp {
+func (v *CountValue) reduceSelectors(row *Row, implicitTable string) ValueExp {
 	return nil
 }
 
@@ -165,11 +165,11 @@ func (v *SumValue) updateWith(val TypedValue) error {
 
 // ValueExp
 
-func (v *SumValue) inferType(cols map[string]ColDescriptor, params map[string]SQLValueType, implicitDB, implicitTable string) (SQLValueType, error) {
+func (v *SumValue) inferType(cols map[string]ColDescriptor, params map[string]SQLValueType, implicitTable string) (SQLValueType, error) {
 	return IntegerType, nil
 }
 
-func (v *SumValue) requiresType(t SQLValueType, cols map[string]ColDescriptor, params map[string]SQLValueType, implicitDB, implicitTable string) error {
+func (v *SumValue) requiresType(t SQLValueType, cols map[string]ColDescriptor, params map[string]SQLValueType, implicitTable string) error {
 	if t != IntegerType {
 		return ErrNotComparableValues
 	}
@@ -184,11 +184,11 @@ func (v *SumValue) substitute(params map[string]interface{}) (ValueExp, error) {
 	return nil, ErrUnexpected
 }
 
-func (v *SumValue) reduce(tx *SQLTx, row *Row, implicitDB, implicitTable string) (TypedValue, error) {
+func (v *SumValue) reduce(tx *SQLTx, row *Row, implicitTable string) (TypedValue, error) {
 	return nil, ErrUnexpected
 }
 
-func (v *SumValue) reduceSelectors(row *Row, implicitDB, implicitTable string) ValueExp {
+func (v *SumValue) reduceSelectors(row *Row, implicitTable string) ValueExp {
 	return v
 }
 
@@ -255,7 +255,7 @@ func (v *MinValue) updateWith(val TypedValue) error {
 
 // ValueExp
 
-func (v *MinValue) inferType(cols map[string]ColDescriptor, params map[string]SQLValueType, implicitDB, implicitTable string) (SQLValueType, error) {
+func (v *MinValue) inferType(cols map[string]ColDescriptor, params map[string]SQLValueType, implicitTable string) (SQLValueType, error) {
 	if v.val.IsNull() {
 		return AnyType, ErrUnexpected
 	}
@@ -263,7 +263,7 @@ func (v *MinValue) inferType(cols map[string]ColDescriptor, params map[string]SQ
 	return v.val.Type(), nil
 }
 
-func (v *MinValue) requiresType(t SQLValueType, cols map[string]ColDescriptor, params map[string]SQLValueType, implicitDB, implicitTable string) error {
+func (v *MinValue) requiresType(t SQLValueType, cols map[string]ColDescriptor, params map[string]SQLValueType, implicitTable string) error {
 	if v.val.IsNull() {
 		return ErrUnexpected
 	}
@@ -283,11 +283,11 @@ func (v *MinValue) substitute(params map[string]interface{}) (ValueExp, error) {
 	return nil, ErrUnexpected
 }
 
-func (v *MinValue) reduce(tx *SQLTx, row *Row, implicitDB, implicitTable string) (TypedValue, error) {
+func (v *MinValue) reduce(tx *SQLTx, row *Row, implicitTable string) (TypedValue, error) {
 	return nil, ErrUnexpected
 }
 
-func (v *MinValue) reduceSelectors(row *Row, implicitDB, implicitTable string) ValueExp {
+func (v *MinValue) reduceSelectors(row *Row, implicitTable string) ValueExp {
 	return nil
 }
 
@@ -354,7 +354,7 @@ func (v *MaxValue) updateWith(val TypedValue) error {
 
 // ValueExp
 
-func (v *MaxValue) inferType(cols map[string]ColDescriptor, params map[string]SQLValueType, implicitDB, implicitTable string) (SQLValueType, error) {
+func (v *MaxValue) inferType(cols map[string]ColDescriptor, params map[string]SQLValueType, implicitTable string) (SQLValueType, error) {
 	if v.val.IsNull() {
 		return AnyType, ErrUnexpected
 	}
@@ -362,7 +362,7 @@ func (v *MaxValue) inferType(cols map[string]ColDescriptor, params map[string]SQ
 	return v.val.Type(), nil
 }
 
-func (v *MaxValue) requiresType(t SQLValueType, cols map[string]ColDescriptor, params map[string]SQLValueType, implicitDB, implicitTable string) error {
+func (v *MaxValue) requiresType(t SQLValueType, cols map[string]ColDescriptor, params map[string]SQLValueType, implicitTable string) error {
 	if v.val.IsNull() {
 		return ErrUnexpected
 	}
@@ -382,11 +382,11 @@ func (v *MaxValue) substitute(params map[string]interface{}) (ValueExp, error) {
 	return nil, ErrUnexpected
 }
 
-func (v *MaxValue) reduce(tx *SQLTx, row *Row, implicitDB, implicitTable string) (TypedValue, error) {
+func (v *MaxValue) reduce(tx *SQLTx, row *Row, implicitTable string) (TypedValue, error) {
 	return nil, ErrUnexpected
 }
 
-func (v *MaxValue) reduceSelectors(row *Row, implicitDB, implicitTable string) ValueExp {
+func (v *MaxValue) reduceSelectors(row *Row, implicitTable string) ValueExp {
 	return nil
 }
 
@@ -470,11 +470,11 @@ func (v *AVGValue) updateWith(val TypedValue) error {
 
 // ValueExp
 
-func (v *AVGValue) inferType(cols map[string]ColDescriptor, params map[string]SQLValueType, implicitDB, implicitTable string) (SQLValueType, error) {
+func (v *AVGValue) inferType(cols map[string]ColDescriptor, params map[string]SQLValueType, implicitTable string) (SQLValueType, error) {
 	return IntegerType, nil
 }
 
-func (v *AVGValue) requiresType(t SQLValueType, cols map[string]ColDescriptor, params map[string]SQLValueType, implicitDB, implicitTable string) error {
+func (v *AVGValue) requiresType(t SQLValueType, cols map[string]ColDescriptor, params map[string]SQLValueType, implicitTable string) error {
 	if t != IntegerType {
 		return ErrNotComparableValues
 	}
@@ -490,11 +490,11 @@ func (v *AVGValue) substitute(params map[string]interface{}) (ValueExp, error) {
 	return nil, ErrUnexpected
 }
 
-func (v *AVGValue) reduce(tx *SQLTx, row *Row, implicitDB, implicitTable string) (TypedValue, error) {
+func (v *AVGValue) reduce(tx *SQLTx, row *Row, implicitTable string) (TypedValue, error) {
 	return nil, ErrUnexpected
 }
 
-func (v *AVGValue) reduceSelectors(row *Row, implicitDB, implicitTable string) ValueExp {
+func (v *AVGValue) reduceSelectors(row *Row, implicitTable string) ValueExp {
 	return nil
 }
 

--- a/embedded/sql/aggregated_values_test.go
+++ b/embedded/sql/aggregated_values_test.go
@@ -53,14 +53,14 @@ func TestCountValue(t *testing.T) {
 
 	// ValueExp
 
-	sqlt, err := cval.inferType(nil, nil, "db1", "table1")
+	sqlt, err := cval.inferType(nil, nil, "table1")
 	require.NoError(t, err)
 	require.Equal(t, IntegerType, sqlt)
 
-	err = cval.requiresType(IntegerType, nil, nil, "db1", "table1")
+	err = cval.requiresType(IntegerType, nil, nil, "table1")
 	require.NoError(t, err)
 
-	err = cval.requiresType(BooleanType, nil, nil, "db1", "table1")
+	err = cval.requiresType(BooleanType, nil, nil, "table1")
 	require.ErrorIs(t, err, ErrNotComparableValues)
 
 	_, err = cval.jointColumnTo(nil, "table1")
@@ -69,10 +69,10 @@ func TestCountValue(t *testing.T) {
 	_, err = cval.substitute(nil)
 	require.ErrorIs(t, err, ErrUnexpected)
 
-	_, err = cval.reduce(nil, nil, "db1", "table1")
+	_, err = cval.reduce(nil, nil, "table1")
 	require.ErrorIs(t, err, ErrUnexpected)
 
-	require.Nil(t, cval.reduceSelectors(nil, "db1", "table1"))
+	require.Nil(t, cval.reduceSelectors(nil, "table1"))
 
 	require.False(t, cval.isConstant())
 
@@ -116,14 +116,14 @@ func TestSumValue(t *testing.T) {
 
 	// ValueExp
 
-	sqlt, err := cval.inferType(nil, nil, "db1", "table1")
+	sqlt, err := cval.inferType(nil, nil, "table1")
 	require.NoError(t, err)
 	require.Equal(t, IntegerType, sqlt)
 
-	err = cval.requiresType(IntegerType, nil, nil, "db1", "table1")
+	err = cval.requiresType(IntegerType, nil, nil, "table1")
 	require.NoError(t, err)
 
-	err = cval.requiresType(BooleanType, nil, nil, "db1", "table1")
+	err = cval.requiresType(BooleanType, nil, nil, "table1")
 	require.ErrorIs(t, err, ErrNotComparableValues)
 
 	_, err = cval.jointColumnTo(nil, "table1")
@@ -132,10 +132,10 @@ func TestSumValue(t *testing.T) {
 	_, err = cval.substitute(nil)
 	require.ErrorIs(t, err, ErrUnexpected)
 
-	_, err = cval.reduce(nil, nil, "db1", "table1")
+	_, err = cval.reduce(nil, nil, "table1")
 	require.ErrorIs(t, err, ErrUnexpected)
 
-	require.Equal(t, cval, cval.reduceSelectors(nil, "db1", "table1"))
+	require.Equal(t, cval, cval.reduceSelectors(nil, "table1"))
 
 	require.False(t, cval.isConstant())
 
@@ -151,10 +151,10 @@ func TestMinValue(t *testing.T) {
 	require.True(t, cval.ColBounded())
 	require.True(t, cval.IsNull())
 
-	_, err := cval.inferType(nil, nil, "db1", "table1")
+	_, err := cval.inferType(nil, nil, "table1")
 	require.ErrorIs(t, err, ErrUnexpected)
 
-	err = cval.requiresType(IntegerType, nil, nil, "db1", "table1")
+	err = cval.requiresType(IntegerType, nil, nil, "table1")
 	require.ErrorIs(t, err, ErrUnexpected)
 
 	err = cval.updateWith(&Integer{val: 10})
@@ -185,14 +185,14 @@ func TestMinValue(t *testing.T) {
 
 	// ValueExp
 
-	sqlt, err := cval.inferType(nil, nil, "db1", "table1")
+	sqlt, err := cval.inferType(nil, nil, "table1")
 	require.NoError(t, err)
 	require.Equal(t, IntegerType, sqlt)
 
-	err = cval.requiresType(IntegerType, nil, nil, "db1", "table1")
+	err = cval.requiresType(IntegerType, nil, nil, "table1")
 	require.NoError(t, err)
 
-	err = cval.requiresType(BooleanType, nil, nil, "db1", "table1")
+	err = cval.requiresType(BooleanType, nil, nil, "table1")
 	require.ErrorIs(t, err, ErrNotComparableValues)
 
 	_, err = cval.jointColumnTo(nil, "table1")
@@ -201,10 +201,10 @@ func TestMinValue(t *testing.T) {
 	_, err = cval.substitute(nil)
 	require.ErrorIs(t, err, ErrUnexpected)
 
-	_, err = cval.reduce(nil, nil, "db1", "table1")
+	_, err = cval.reduce(nil, nil, "table1")
 	require.ErrorIs(t, err, ErrUnexpected)
 
-	require.Nil(t, cval.reduceSelectors(nil, "db1", "table1"))
+	require.Nil(t, cval.reduceSelectors(nil, "table1"))
 
 	require.False(t, cval.isConstant())
 
@@ -220,10 +220,10 @@ func TestMaxValue(t *testing.T) {
 	require.True(t, cval.ColBounded())
 	require.True(t, cval.IsNull())
 
-	_, err := cval.inferType(nil, nil, "db1", "table1")
+	_, err := cval.inferType(nil, nil, "table1")
 	require.ErrorIs(t, err, ErrUnexpected)
 
-	err = cval.requiresType(IntegerType, nil, nil, "db1", "table1")
+	err = cval.requiresType(IntegerType, nil, nil, "table1")
 	require.ErrorIs(t, err, ErrUnexpected)
 
 	err = cval.updateWith(&Integer{val: 10})
@@ -254,14 +254,14 @@ func TestMaxValue(t *testing.T) {
 
 	// ValueExp
 
-	sqlt, err := cval.inferType(nil, nil, "db1", "table1")
+	sqlt, err := cval.inferType(nil, nil, "table1")
 	require.NoError(t, err)
 	require.Equal(t, IntegerType, sqlt)
 
-	err = cval.requiresType(IntegerType, nil, nil, "db1", "table1")
+	err = cval.requiresType(IntegerType, nil, nil, "table1")
 	require.NoError(t, err)
 
-	err = cval.requiresType(BooleanType, nil, nil, "db1", "table1")
+	err = cval.requiresType(BooleanType, nil, nil, "table1")
 	require.ErrorIs(t, err, ErrNotComparableValues)
 
 	_, err = cval.jointColumnTo(nil, "table1")
@@ -270,10 +270,10 @@ func TestMaxValue(t *testing.T) {
 	_, err = cval.substitute(nil)
 	require.ErrorIs(t, err, ErrUnexpected)
 
-	_, err = cval.reduce(nil, nil, "db1", "table1")
+	_, err = cval.reduce(nil, nil, "table1")
 	require.ErrorIs(t, err, ErrUnexpected)
 
-	require.Nil(t, cval.reduceSelectors(nil, "db1", "table1"))
+	require.Nil(t, cval.reduceSelectors(nil, "table1"))
 
 	require.False(t, cval.isConstant())
 
@@ -317,14 +317,14 @@ func TestAVGValue(t *testing.T) {
 
 	// ValueExp
 
-	sqlt, err := cval.inferType(nil, nil, "db1", "table1")
+	sqlt, err := cval.inferType(nil, nil, "table1")
 	require.NoError(t, err)
 	require.Equal(t, IntegerType, sqlt)
 
-	err = cval.requiresType(IntegerType, nil, nil, "db1", "table1")
+	err = cval.requiresType(IntegerType, nil, nil, "table1")
 	require.NoError(t, err)
 
-	err = cval.requiresType(BooleanType, nil, nil, "db1", "table1")
+	err = cval.requiresType(BooleanType, nil, nil, "table1")
 	require.ErrorIs(t, err, ErrNotComparableValues)
 
 	_, err = cval.jointColumnTo(nil, "table1")
@@ -333,10 +333,10 @@ func TestAVGValue(t *testing.T) {
 	_, err = cval.substitute(nil)
 	require.ErrorIs(t, err, ErrUnexpected)
 
-	_, err = cval.reduce(nil, nil, "db1", "table1")
+	_, err = cval.reduce(nil, nil, "table1")
 	require.ErrorIs(t, err, ErrUnexpected)
 
-	require.Nil(t, cval.reduceSelectors(nil, "db1", "table1"))
+	require.Nil(t, cval.reduceSelectors(nil, "table1"))
 
 	require.False(t, cval.isConstant())
 

--- a/embedded/sql/catalog_test.go
+++ b/embedded/sql/catalog_test.go
@@ -23,65 +23,31 @@ import (
 )
 
 func TestFromEmptyCatalog(t *testing.T) {
-	catalog := newCatalog()
+	db := newCatalog(nil)
 
-	dbs := catalog.Databases()
-	require.Empty(t, dbs)
+	_, err := db.GetTableByName("table1")
+	require.ErrorIs(t, err, ErrTableDoesNotExist)
 
-	exists := catalog.ExistDatabase("db1")
-	require.False(t, exists)
-
-	_, err := catalog.GetDatabaseByID(1)
-	require.Equal(t, ErrDatabaseDoesNotExist, err)
-
-	_, err = catalog.GetDatabaseByName("db1")
-	require.Equal(t, ErrDatabaseDoesNotExist, err)
-
-	_, err = catalog.GetTableByName("db1", "table1")
-	require.Equal(t, ErrDatabaseDoesNotExist, err)
-
-	db, err := catalog.newDatabase(2, "db1")
-	require.NoError(t, err)
-	require.NotNil(t, db)
-	require.Equal(t, uint32(2), db.id)
-	require.Equal(t, "db1", db.Name())
-	require.Empty(t, db.GetTables())
-
-	dbs = catalog.Databases()
-	require.NotNil(t, db)
-	require.Len(t, dbs, 1)
-	require.Equal(t, "db1", dbs[0].Name())
-
-	db1, err := catalog.GetDatabaseByID(2)
-	require.NoError(t, err)
-	require.Equal(t, db.name, db1.name)
-
-	_, err = catalog.GetDatabaseByName("db1")
-	require.NoError(t, err)
-
-	_, err = catalog.newDatabase(2, "db1")
-	require.Equal(t, ErrDatabaseAlreadyExists, err)
-
-	exists = db.ExistTable("table1")
+	exists := db.ExistTable("table1")
 	require.False(t, exists)
 
 	_, err = db.GetTableByID(1)
-	require.Equal(t, ErrTableDoesNotExist, err)
+	require.ErrorIs(t, err, ErrTableDoesNotExist)
 
 	_, err = db.GetTableByName("table1")
 	require.ErrorIs(t, err, ErrTableDoesNotExist)
 
 	_, err = db.newTable("", nil)
-	require.Equal(t, ErrIllegalArguments, err)
+	require.ErrorIs(t, err, ErrIllegalArguments)
 
 	_, err = db.newTable("table1", nil)
-	require.Equal(t, ErrIllegalArguments, err)
+	require.ErrorIs(t, err, ErrIllegalArguments)
 
 	_, err = db.newTable("table1", []*ColSpec{})
-	require.Equal(t, ErrIllegalArguments, err)
+	require.ErrorIs(t, err, ErrIllegalArguments)
 
 	_, err = db.newTable("table1", []*ColSpec{{colName: "id", colType: IntegerType}, {colName: "id", colType: IntegerType}})
-	require.Equal(t, ErrDuplicatedColumn, err)
+	require.ErrorIs(t, err, ErrDuplicatedColumn)
 
 	table, err := db.newTable("table1", []*ColSpec{{colName: "id", colType: IntegerType}, {colName: "title", colType: IntegerType}})
 	require.NoError(t, err)
@@ -102,7 +68,7 @@ func TestFromEmptyCatalog(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = db.GetTableByID(2)
-	require.Equal(t, ErrTableDoesNotExist, err)
+	require.ErrorIs(t, err, ErrTableDoesNotExist)
 
 	_, err = db.newTable("table1", []*ColSpec{{colName: "id", colType: IntegerType}, {colName: "title", colType: IntegerType}})
 	require.ErrorIs(t, err, ErrTableAlreadyExists)
@@ -129,7 +95,7 @@ func TestFromEmptyCatalog(t *testing.T) {
 	require.Equal(t, c.Name(), "title")
 
 	_, err = table.GetColumnByID(3)
-	require.Equal(t, ErrColumnDoesNotExist, err)
+	require.ErrorIs(t, err, ErrColumnDoesNotExist)
 
 	_, err = table.newIndex(true, nil)
 	require.ErrorIs(t, err, ErrIllegalArguments)

--- a/embedded/sql/cond_row_reader.go
+++ b/embedded/sql/cond_row_reader.go
@@ -42,10 +42,6 @@ func (cr *conditionalRowReader) Tx() *SQLTx {
 	return cr.rowReader.Tx()
 }
 
-func (cr *conditionalRowReader) Database() string {
-	return cr.rowReader.Database()
-}
-
 func (cr *conditionalRowReader) TableAlias() string {
 	return cr.rowReader.TableAlias()
 }
@@ -81,7 +77,7 @@ func (cr *conditionalRowReader) InferParameters(ctx context.Context, params map[
 		return err
 	}
 
-	_, err = cr.condition.inferType(cols, params, cr.Database(), cr.TableAlias())
+	_, err = cr.condition.inferType(cols, params, cr.TableAlias())
 
 	return err
 }
@@ -98,7 +94,7 @@ func (cr *conditionalRowReader) Read(ctx context.Context) (*Row, error) {
 			return nil, fmt.Errorf("%w: when evaluating WHERE clause", err)
 		}
 
-		r, err := cond.reduce(cr.Tx(), row, cr.rowReader.Database(), cr.rowReader.TableAlias())
+		r, err := cond.reduce(cr.Tx(), row, cr.rowReader.TableAlias())
 		if err != nil {
 			return nil, fmt.Errorf("%w: when evaluating WHERE clause", err)
 		}

--- a/embedded/sql/distinct_row_reader.go
+++ b/embedded/sql/distinct_row_reader.go
@@ -49,10 +49,6 @@ func (dr *distinctRowReader) Tx() *SQLTx {
 	return dr.rowReader.Tx()
 }
 
-func (dr *distinctRowReader) Database() string {
-	return dr.rowReader.Database()
-}
-
 func (dr *distinctRowReader) TableAlias() string {
 	return dr.rowReader.TableAlias()
 }

--- a/embedded/sql/distinct_row_reader_test.go
+++ b/embedded/sql/distinct_row_reader_test.go
@@ -34,8 +34,6 @@ func TestDistinctRowReader(t *testing.T) {
 
 	rowReader, err := newDistinctRowReader(context.Background(), dummyr)
 	require.NoError(t, err)
-
-	require.Equal(t, dummyr.Database(), rowReader.Database())
 	require.Equal(t, dummyr.TableAlias(), rowReader.TableAlias())
 	require.Equal(t, dummyr.OrderBy(), rowReader.OrderBy())
 	require.Equal(t, dummyr.ScanSpecs(), rowReader.ScanSpecs())

--- a/embedded/sql/engine_test.go
+++ b/embedded/sql/engine_test.go
@@ -5709,7 +5709,7 @@ func TestSingleDBCatalogQueries(t *testing.T) {
 
 		row, err := r.Read(context.Background())
 		require.NoError(t, err)
-		require.Equal(t, "mytable2", row.ValuesBySelector["(db1.tables.name)"].RawValue())
+		require.Equal(t, "mytable2", row.ValuesBySelector["(tables.name)"].RawValue())
 
 		_, err = r.Read(context.Background())
 		require.ErrorIs(t, err, ErrNoMoreRows)

--- a/embedded/sql/grouped_row_reader_test.go
+++ b/embedded/sql/grouped_row_reader_test.go
@@ -37,10 +37,7 @@ func TestGroupedRowReader(t *testing.T) {
 	tx, err := engine.NewTx(context.Background(), DefaultTxOptions())
 	require.NoError(t, err)
 
-	db, err := tx.catalog.newDatabase(1, "db1")
-	require.NoError(t, err)
-
-	table, err := db.newTable("table1", []*ColSpec{{colName: "id", colType: IntegerType}})
+	table, err := tx.catalog.newTable("table1", []*ColSpec{{colName: "id", colType: IntegerType}})
 	require.NoError(t, err)
 
 	index, err := table.newIndex(true, []uint32{1})

--- a/embedded/sql/joint_row_reader.go
+++ b/embedded/sql/joint_row_reader.go
@@ -61,10 +61,6 @@ func (jointr *jointRowReader) Tx() *SQLTx {
 	return jointr.rowReader.Tx()
 }
 
-func (jointr *jointRowReader) Database() string {
-	return jointr.rowReader.Database()
-}
-
 func (jointr *jointRowReader) TableAlias() string {
 	return jointr.rowReader.TableAlias()
 }
@@ -167,7 +163,7 @@ func (jointr *jointRowReader) InferParameters(ctx context.Context, params map[st
 			return err
 		}
 
-		_, err = join.cond.inferType(cols, params, jointr.Database(), jointr.TableAlias())
+		_, err = join.cond.inferType(cols, params, jointr.TableAlias())
 		if err != nil {
 			return err
 		}
@@ -233,7 +229,7 @@ func (jointr *jointRowReader) Read(ctx context.Context) (row *Row, err error) {
 
 			jointq := &SelectStmt{
 				ds:      jspec.ds,
-				where:   jspec.cond.reduceSelectors(row, jointr.Database(), jointr.TableAlias()),
+				where:   jspec.cond.reduceSelectors(row, jointr.TableAlias()),
 				indexOn: jspec.indexOn,
 			}
 

--- a/embedded/sql/joint_row_reader_test.go
+++ b/embedded/sql/joint_row_reader_test.go
@@ -38,13 +38,7 @@ func TestJointRowReader(t *testing.T) {
 	tx, err := engine.NewTx(context.Background(), DefaultTxOptions())
 	require.NoError(t, err)
 
-	db, err := tx.catalog.newDatabase(1, "db1")
-	require.NoError(t, err)
-
-	err = tx.useDatabase("db1")
-	require.NoError(t, err)
-
-	table, err := db.newTable("table1", []*ColSpec{{colName: "id", colType: IntegerType}, {colName: "number", colType: IntegerType}})
+	table, err := tx.catalog.newTable("table1", []*ColSpec{{colName: "id", colType: IntegerType}, {colName: "number", colType: IntegerType}})
 	require.NoError(t, err)
 
 	index, err := table.newIndex(true, []uint32{1})

--- a/embedded/sql/limit_row_reader.go
+++ b/embedded/sql/limit_row_reader.go
@@ -40,10 +40,6 @@ func (lr *limitRowReader) Tx() *SQLTx {
 	return lr.rowReader.Tx()
 }
 
-func (lr *limitRowReader) Database() string {
-	return lr.rowReader.Database()
-}
-
 func (lr *limitRowReader) TableAlias() string {
 	return lr.rowReader.TableAlias()
 }

--- a/embedded/sql/limit_row_reader_test.go
+++ b/embedded/sql/limit_row_reader_test.go
@@ -27,8 +27,6 @@ func TestLimitRowReader(t *testing.T) {
 	dummyr := &dummyRowReader{failReturningColumns: false}
 
 	rowReader := newLimitRowReader(dummyr, 1)
-
-	require.Equal(t, dummyr.Database(), rowReader.Database())
 	require.Equal(t, dummyr.TableAlias(), rowReader.TableAlias())
 	require.Equal(t, dummyr.OrderBy(), rowReader.OrderBy())
 	require.Equal(t, dummyr.ScanSpecs(), rowReader.ScanSpecs())

--- a/embedded/sql/offset_row_reader.go
+++ b/embedded/sql/offset_row_reader.go
@@ -40,10 +40,6 @@ func (r *offsetRowReader) Tx() *SQLTx {
 	return r.rowReader.Tx()
 }
 
-func (r *offsetRowReader) Database() string {
-	return r.rowReader.Database()
-}
-
 func (r *offsetRowReader) TableAlias() string {
 	return r.rowReader.TableAlias()
 }

--- a/embedded/sql/offset_row_reader_test.go
+++ b/embedded/sql/offset_row_reader_test.go
@@ -27,8 +27,6 @@ func TestOffsetRowReader(t *testing.T) {
 	dummyr := &dummyRowReader{failReturningColumns: false}
 
 	rowReader := newOffsetRowReader(dummyr, 1)
-
-	require.Equal(t, dummyr.Database(), rowReader.Database())
 	require.Equal(t, dummyr.TableAlias(), rowReader.TableAlias())
 	require.Equal(t, dummyr.OrderBy(), rowReader.OrderBy())
 	require.Equal(t, dummyr.ScanSpecs(), rowReader.ScanSpecs())

--- a/embedded/sql/options.go
+++ b/embedded/sql/options.go
@@ -28,6 +28,8 @@ type Options struct {
 	prefix        []byte
 	distinctLimit int
 	autocommit    bool
+
+	multidbHandler MultiDBHandler
 }
 
 func DefaultOptions() *Options {
@@ -60,5 +62,10 @@ func (opts *Options) WithDistinctLimit(distinctLimit int) *Options {
 
 func (opts *Options) WithAutocommit(autocommit bool) *Options {
 	opts.autocommit = autocommit
+	return opts
+}
+
+func (opts *Options) WithMultiDBHandler(multidbHandler MultiDBHandler) *Options {
+	opts.multidbHandler = multidbHandler
 	return opts
 }

--- a/embedded/sql/proj_row_reader.go
+++ b/embedded/sql/proj_row_reader.go
@@ -39,7 +39,6 @@ func newProjectedRowReader(ctx context.Context, rowReader RowReader, tableAlias 
 
 		for _, col := range cols {
 			sel := &ColSelector{
-				db:    col.Database,
 				table: col.Table,
 				col:   col.Column,
 			}
@@ -60,10 +59,6 @@ func (pr *projectedRowReader) onClose(callback func()) {
 
 func (pr *projectedRowReader) Tx() *SQLTx {
 	return pr.rowReader.Tx()
-}
-
-func (pr *projectedRowReader) Database() string {
-	return pr.rowReader.Database()
 }
 
 func (pr *projectedRowReader) TableAlias() string {
@@ -91,10 +86,9 @@ func (pr *projectedRowReader) Columns(ctx context.Context) ([]ColDescriptor, err
 	colsByPos := make([]ColDescriptor, len(pr.selectors))
 
 	for i, sel := range pr.selectors {
-		aggFn, db, table, col := sel.resolve(pr.rowReader.Database(), pr.rowReader.TableAlias())
+		aggFn, table, col := sel.resolve(pr.rowReader.TableAlias())
 
 		if pr.tableAlias != "" {
-			db = pr.Database()
 			table = pr.tableAlias
 		}
 
@@ -111,10 +105,9 @@ func (pr *projectedRowReader) Columns(ctx context.Context) ([]ColDescriptor, err
 		}
 
 		colsByPos[i] = ColDescriptor{
-			AggFn:    aggFn,
-			Database: db,
-			Table:    table,
-			Column:   col,
+			AggFn:  aggFn,
+			Table:  table,
+			Column: col,
 		}
 
 		encSel := colsByPos[i].Selector()
@@ -134,9 +127,9 @@ func (pr *projectedRowReader) colsBySelector(ctx context.Context) (map[string]Co
 	colDescriptors := make(map[string]ColDescriptor, len(pr.selectors))
 
 	for i, sel := range pr.selectors {
-		aggFn, db, table, col := sel.resolve(pr.rowReader.Database(), pr.rowReader.TableAlias())
+		aggFn, table, col := sel.resolve(pr.rowReader.TableAlias())
 
-		encSel := EncodeSelector(aggFn, db, table, col)
+		encSel := EncodeSelector(aggFn, table, col)
 
 		colDesc, ok := dsColDescriptors[encSel]
 		if !ok {
@@ -144,7 +137,6 @@ func (pr *projectedRowReader) colsBySelector(ctx context.Context) (map[string]Co
 		}
 
 		if pr.tableAlias != "" {
-			db = pr.Database()
 			table = pr.tableAlias
 		}
 
@@ -161,11 +153,10 @@ func (pr *projectedRowReader) colsBySelector(ctx context.Context) (map[string]Co
 		}
 
 		des := ColDescriptor{
-			AggFn:    aggFn,
-			Database: db,
-			Table:    table,
-			Column:   col,
-			Type:     colDesc.Type,
+			AggFn:  aggFn,
+			Table:  table,
+			Column: col,
+			Type:   colDesc.Type,
 		}
 
 		colDescriptors[des.Selector()] = des
@@ -194,9 +185,9 @@ func (pr *projectedRowReader) Read(ctx context.Context) (*Row, error) {
 	}
 
 	for i, sel := range pr.selectors {
-		aggFn, db, table, col := sel.resolve(pr.rowReader.Database(), pr.rowReader.TableAlias())
+		aggFn, table, col := sel.resolve(pr.rowReader.TableAlias())
 
-		encSel := EncodeSelector(aggFn, db, table, col)
+		encSel := EncodeSelector(aggFn, table, col)
 
 		val, ok := row.ValuesBySelector[encSel]
 		if !ok {
@@ -204,7 +195,6 @@ func (pr *projectedRowReader) Read(ctx context.Context) (*Row, error) {
 		}
 
 		if pr.tableAlias != "" {
-			db = pr.Database()
 			table = pr.tableAlias
 		}
 
@@ -221,7 +211,7 @@ func (pr *projectedRowReader) Read(ctx context.Context) (*Row, error) {
 		}
 
 		prow.ValuesByPosition[i] = val
-		prow.ValuesBySelector[EncodeSelector(aggFn, db, table, col)] = val
+		prow.ValuesBySelector[EncodeSelector(aggFn, table, col)] = val
 	}
 
 	return prow, nil

--- a/embedded/sql/row_reader_test.go
+++ b/embedded/sql/row_reader_test.go
@@ -24,12 +24,8 @@ import (
 
 func TestKeyReaderSpecFromCornerCases(t *testing.T) {
 	prefix := []byte("key.prefix.")
-	db := &Database{
-		id: 1,
-	}
 	table := &Table{
 		id: 2,
-		db: db,
 	}
 	index := &Index{
 		table: table,

--- a/embedded/sql/sql_grammar.y
+++ b/embedded/sql/sql_grammar.y
@@ -568,7 +568,7 @@ selector:
 |
     AGGREGATE_FUNC '(' col ')'
     {
-        $$ = &AggColSelector{aggFn: $1, db: $3.db, table: $3.table, col: $3.col}
+        $$ = &AggColSelector{aggFn: $1, table: $3.table, col: $3.col}
     }
 
 col:

--- a/embedded/sql/sql_parser.go
+++ b/embedded/sql/sql_parser.go
@@ -1206,7 +1206,7 @@ yydefault:
 	case 82:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		{
-			yyVAL.sel = &AggColSelector{aggFn: yyDollar[1].aggFn, db: yyDollar[3].col.db, table: yyDollar[3].col.table, col: yyDollar[3].col.col}
+			yyVAL.sel = &AggColSelector{aggFn: yyDollar[1].aggFn, table: yyDollar[3].col.table, col: yyDollar[3].col.col}
 		}
 	case 83:
 		yyDollar = yyS[yypt-1 : yypt+1]

--- a/embedded/sql/sql_tx.go
+++ b/embedded/sql/sql_tx.go
@@ -32,8 +32,7 @@ type SQLTx struct {
 
 	tx *store.OngoingTx
 
-	currentDB *Database
-	catalog   *Catalog // in-mem catalog
+	catalog *Catalog // in-mem catalog
 
 	mutatedCatalog bool // set when a DDL stmt was executed within the current tx
 
@@ -63,21 +62,6 @@ func (sqlTx *SQLTx) RequireExplicitClose() error {
 	sqlTx.opts.ExplicitClose = true
 
 	return nil
-}
-
-func (sqlTx *SQLTx) useDatabase(dbName string) error {
-	db, err := sqlTx.catalog.GetDatabaseByName(dbName)
-	if err != nil {
-		return err
-	}
-
-	sqlTx.currentDB = db
-
-	return nil
-}
-
-func (sqlTx *SQLTx) Database() *Database {
-	return sqlTx.currentDB
 }
 
 func (sqlTx *SQLTx) Timestamp() time.Time {

--- a/embedded/sql/stmt_test.go
+++ b/embedded/sql/stmt_test.go
@@ -27,13 +27,13 @@ import (
 
 func TestRequiresTypeColSelectorsValueExp(t *testing.T) {
 	cols := make(map[string]ColDescriptor)
-	cols["(db1.mytable.id)"] = ColDescriptor{Type: IntegerType}
-	cols["(db1.mytable.ts)"] = ColDescriptor{Type: TimestampType}
-	cols["(db1.mytable.title)"] = ColDescriptor{Type: VarcharType}
-	cols["(db1.mytable.active)"] = ColDescriptor{Type: BooleanType}
-	cols["(db1.mytable.payload)"] = ColDescriptor{Type: BLOBType}
-	cols["COUNT(db1.mytable.*)"] = ColDescriptor{Type: IntegerType}
-	cols["(db1.mytable.ft)"] = ColDescriptor{Type: Float64Type}
+	cols["(mytable.id)"] = ColDescriptor{Type: IntegerType}
+	cols["(mytable.ts)"] = ColDescriptor{Type: TimestampType}
+	cols["(mytable.title)"] = ColDescriptor{Type: VarcharType}
+	cols["(mytable.active)"] = ColDescriptor{Type: BooleanType}
+	cols["(mytable.payload)"] = ColDescriptor{Type: BLOBType}
+	cols["COUNT(mytable.*)"] = ColDescriptor{Type: IntegerType}
+	cols["(mytable.ft)"] = ColDescriptor{Type: Float64Type}
 
 	params := make(map[string]SQLValueType)
 
@@ -41,124 +41,110 @@ func TestRequiresTypeColSelectorsValueExp(t *testing.T) {
 		exp           ValueExp
 		cols          map[string]ColDescriptor
 		params        map[string]SQLValueType
-		implicitDB    string
 		implicitTable string
 		requiredType  SQLValueType
 		expectedError error
 	}{
 		{
-			exp:           &ColSelector{db: "db1", table: "mytable", col: "id"},
+			exp:           &ColSelector{table: "mytable", col: "id"},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  IntegerType,
 			expectedError: nil,
 		},
 		{
-			exp:           &ColSelector{db: "db1", table: "mytable", col: "id1"},
+			exp:           &ColSelector{table: "mytable", col: "id1"},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  IntegerType,
 			expectedError: ErrColumnDoesNotExist,
 		},
 		{
-			exp:           &ColSelector{db: "db1", table: "mytable", col: "id"},
+			exp:           &ColSelector{table: "mytable", col: "id"},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  BooleanType,
 			expectedError: ErrInvalidTypes,
 		},
 		{
-			exp:           &ColSelector{db: "db1", table: "mytable", col: "ts"},
+			exp:           &ColSelector{table: "mytable", col: "ts"},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  TimestampType,
 			expectedError: nil,
 		},
 		{
-			exp:           &ColSelector{db: "db1", table: "mytable", col: "ts"},
+			exp:           &ColSelector{table: "mytable", col: "ts"},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  BooleanType,
 			expectedError: ErrInvalidTypes,
 		},
 		{
-			exp:           &AggColSelector{aggFn: "COUNT", db: "db1", table: "mytable", col: "*"},
+			exp:           &AggColSelector{aggFn: "COUNT", table: "mytable", col: "*"},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  IntegerType,
 			expectedError: nil,
 		},
 		{
-			exp:           &AggColSelector{aggFn: "COUNT", db: "db1", table: "mytable", col: "*"},
+			exp:           &AggColSelector{aggFn: "COUNT", table: "mytable", col: "*"},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  VarcharType,
 			expectedError: ErrInvalidTypes,
 		},
 		{
-			exp:           &AggColSelector{aggFn: "MIN", db: "db1", table: "mytable", col: "title"},
+			exp:           &AggColSelector{aggFn: "MIN", table: "mytable", col: "title"},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  VarcharType,
 			expectedError: nil,
 		},
 		{
-			exp:           &AggColSelector{aggFn: "MIN", db: "db1", table: "mytable", col: "title1"},
+			exp:           &AggColSelector{aggFn: "MIN", table: "mytable", col: "title1"},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  VarcharType,
 			expectedError: ErrColumnDoesNotExist,
 		},
 		{
-			exp:           &AggColSelector{aggFn: "SUM", db: "db1", table: "mytable", col: "id"},
+			exp:           &AggColSelector{aggFn: "SUM", table: "mytable", col: "id"},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  IntegerType,
 			expectedError: nil,
 		},
 		{
-			exp:           &AggColSelector{aggFn: "SUM", db: "db1", table: "mytable", col: "title"},
+			exp:           &AggColSelector{aggFn: "SUM", table: "mytable", col: "title"},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  IntegerType,
 			expectedError: ErrInvalidTypes,
 		},
 		{
-			exp:           &AggColSelector{aggFn: "SUM", db: "db1", table: "mytable", col: "ft"},
+			exp:           &AggColSelector{aggFn: "SUM", table: "mytable", col: "ft"},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  Float64Type,
 			expectedError: nil,
 		},
 		{
-			exp:           &AggColSelector{aggFn: "SUM", db: "db1", table: "mytable", col: "ft"},
+			exp:           &AggColSelector{aggFn: "SUM", table: "mytable", col: "ft"},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  BooleanType,
 			expectedError: ErrInvalidTypes,
@@ -166,11 +152,11 @@ func TestRequiresTypeColSelectorsValueExp(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		err := tc.exp.requiresType(tc.requiredType, tc.cols, tc.params, tc.implicitDB, tc.implicitTable)
+		err := tc.exp.requiresType(tc.requiredType, tc.cols, tc.params, tc.implicitTable)
 		require.ErrorIs(t, err, tc.expectedError, fmt.Sprintf("failed on iteration %d", i))
 
 		if tc.expectedError == nil {
-			it, err := tc.exp.inferType(tc.cols, params, tc.implicitDB, tc.implicitTable)
+			it, err := tc.exp.inferType(tc.cols, params, tc.implicitTable)
 			require.NoError(t, err)
 			require.Equal(t, tc.requiredType, it)
 		}
@@ -179,12 +165,12 @@ func TestRequiresTypeColSelectorsValueExp(t *testing.T) {
 
 func TestRequiresTypeNumExpValueExp(t *testing.T) {
 	cols := make(map[string]ColDescriptor)
-	cols["(db1.mytable.id)"] = ColDescriptor{Type: IntegerType}
-	cols["(db1.mytable.title)"] = ColDescriptor{Type: VarcharType}
-	cols["(db1.mytable.active)"] = ColDescriptor{Type: BooleanType}
-	cols["(db1.mytable.payload)"] = ColDescriptor{Type: BLOBType}
-	cols["COUNT(db1.mytable.*)"] = ColDescriptor{Type: IntegerType}
-	cols["(db1.mytable.ft)"] = ColDescriptor{Type: Float64Type}
+	cols["(mytable.id)"] = ColDescriptor{Type: IntegerType}
+	cols["(mytable.title)"] = ColDescriptor{Type: VarcharType}
+	cols["(mytable.active)"] = ColDescriptor{Type: BooleanType}
+	cols["(mytable.payload)"] = ColDescriptor{Type: BLOBType}
+	cols["COUNT(mytable.*)"] = ColDescriptor{Type: IntegerType}
+	cols["(mytable.ft)"] = ColDescriptor{Type: Float64Type}
 
 	params := make(map[string]SQLValueType)
 
@@ -192,7 +178,6 @@ func TestRequiresTypeNumExpValueExp(t *testing.T) {
 		exp           ValueExp
 		cols          map[string]ColDescriptor
 		params        map[string]SQLValueType
-		implicitDB    string
 		implicitTable string
 		requiredType  SQLValueType
 		expectedError error
@@ -201,7 +186,6 @@ func TestRequiresTypeNumExpValueExp(t *testing.T) {
 			exp:           &NumExp{op: ADDOP, left: &Integer{val: 0}, right: &Integer{val: 0}},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  IntegerType,
 			expectedError: nil,
@@ -210,7 +194,6 @@ func TestRequiresTypeNumExpValueExp(t *testing.T) {
 			exp:           &NumExp{op: ADDOP, left: &Integer{val: 0}, right: &Integer{val: 0}},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  BooleanType,
 			expectedError: ErrInvalidTypes,
@@ -219,7 +202,6 @@ func TestRequiresTypeNumExpValueExp(t *testing.T) {
 			exp:           &NumExp{op: ADDOP, left: &Bool{val: true}, right: &Integer{val: 0}},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  IntegerType,
 			expectedError: ErrInvalidTypes,
@@ -228,7 +210,6 @@ func TestRequiresTypeNumExpValueExp(t *testing.T) {
 			exp:           &NumExp{op: ADDOP, left: &Integer{val: 0}, right: &Bool{val: true}},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  IntegerType,
 			expectedError: ErrInvalidTypes,
@@ -237,7 +218,6 @@ func TestRequiresTypeNumExpValueExp(t *testing.T) {
 			exp:           &NumExp{op: ADDOP, left: &Integer{val: 0}, right: &Bool{val: true}},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  Float64Type,
 			expectedError: ErrInvalidTypes,
@@ -245,11 +225,11 @@ func TestRequiresTypeNumExpValueExp(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		err := tc.exp.requiresType(tc.requiredType, tc.cols, tc.params, tc.implicitDB, tc.implicitTable)
+		err := tc.exp.requiresType(tc.requiredType, tc.cols, tc.params, tc.implicitTable)
 		require.ErrorIs(t, err, tc.expectedError, fmt.Sprintf("failed on iteration %d", i))
 
 		if tc.expectedError == nil {
-			it, err := tc.exp.inferType(tc.cols, params, tc.implicitDB, tc.implicitTable)
+			it, err := tc.exp.inferType(tc.cols, params, tc.implicitTable)
 			require.NoError(t, err)
 			require.Equal(t, tc.requiredType, it)
 		}
@@ -258,12 +238,12 @@ func TestRequiresTypeNumExpValueExp(t *testing.T) {
 
 func TestRequiresTypeSimpleValueExp(t *testing.T) {
 	cols := make(map[string]ColDescriptor)
-	cols["(db1.mytable.id)"] = ColDescriptor{Type: IntegerType}
-	cols["(db1.mytable.title)"] = ColDescriptor{Type: VarcharType}
-	cols["(db1.mytable.active)"] = ColDescriptor{Type: BooleanType}
-	cols["(db1.mytable.payload)"] = ColDescriptor{Type: BLOBType}
-	cols["COUNT(db1.mytable.*)"] = ColDescriptor{Type: IntegerType}
-	cols["(db1.mytable.ft)"] = ColDescriptor{Type: Float64Type}
+	cols["(mytable.id)"] = ColDescriptor{Type: IntegerType}
+	cols["(mytable.title)"] = ColDescriptor{Type: VarcharType}
+	cols["(mytable.active)"] = ColDescriptor{Type: BooleanType}
+	cols["(mytable.payload)"] = ColDescriptor{Type: BLOBType}
+	cols["COUNT(mytable.*)"] = ColDescriptor{Type: IntegerType}
+	cols["(mytable.ft)"] = ColDescriptor{Type: Float64Type}
 
 	params := make(map[string]SQLValueType)
 
@@ -271,7 +251,6 @@ func TestRequiresTypeSimpleValueExp(t *testing.T) {
 		exp           ValueExp
 		cols          map[string]ColDescriptor
 		params        map[string]SQLValueType
-		implicitDB    string
 		implicitTable string
 		requiredType  SQLValueType
 		expectedError error
@@ -280,7 +259,6 @@ func TestRequiresTypeSimpleValueExp(t *testing.T) {
 			exp:           &NullValue{t: AnyType},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  VarcharType,
 			expectedError: nil,
@@ -289,7 +267,6 @@ func TestRequiresTypeSimpleValueExp(t *testing.T) {
 			exp:           &NullValue{t: VarcharType},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  VarcharType,
 			expectedError: nil,
@@ -298,7 +275,6 @@ func TestRequiresTypeSimpleValueExp(t *testing.T) {
 			exp:           &NullValue{t: BooleanType},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  VarcharType,
 			expectedError: ErrInvalidTypes,
@@ -307,7 +283,6 @@ func TestRequiresTypeSimpleValueExp(t *testing.T) {
 			exp:           &Integer{},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  IntegerType,
 			expectedError: nil,
@@ -316,7 +291,6 @@ func TestRequiresTypeSimpleValueExp(t *testing.T) {
 			exp:           &Integer{},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  VarcharType,
 			expectedError: ErrInvalidTypes,
@@ -325,7 +299,6 @@ func TestRequiresTypeSimpleValueExp(t *testing.T) {
 			exp:           &Varchar{},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  VarcharType,
 			expectedError: nil,
@@ -334,7 +307,6 @@ func TestRequiresTypeSimpleValueExp(t *testing.T) {
 			exp:           &Varchar{},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  BooleanType,
 			expectedError: ErrInvalidTypes,
@@ -343,7 +315,6 @@ func TestRequiresTypeSimpleValueExp(t *testing.T) {
 			exp:           &Bool{},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  BooleanType,
 			expectedError: nil,
@@ -352,7 +323,6 @@ func TestRequiresTypeSimpleValueExp(t *testing.T) {
 			exp:           &Bool{},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  IntegerType,
 			expectedError: ErrInvalidTypes,
@@ -361,7 +331,6 @@ func TestRequiresTypeSimpleValueExp(t *testing.T) {
 			exp:           &Blob{},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  BLOBType,
 			expectedError: nil,
@@ -370,7 +339,6 @@ func TestRequiresTypeSimpleValueExp(t *testing.T) {
 			exp:           &Blob{},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  IntegerType,
 			expectedError: ErrInvalidTypes,
@@ -379,7 +347,6 @@ func TestRequiresTypeSimpleValueExp(t *testing.T) {
 			exp:           &NotBoolExp{exp: &Bool{val: true}},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  BooleanType,
 			expectedError: nil,
@@ -388,7 +355,6 @@ func TestRequiresTypeSimpleValueExp(t *testing.T) {
 			exp:           &NotBoolExp{exp: &Bool{val: true}},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  IntegerType,
 			expectedError: ErrInvalidTypes,
@@ -397,7 +363,6 @@ func TestRequiresTypeSimpleValueExp(t *testing.T) {
 			exp:           &NotBoolExp{exp: &Varchar{val: "abc"}},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  BooleanType,
 			expectedError: ErrInvalidTypes,
@@ -406,7 +371,6 @@ func TestRequiresTypeSimpleValueExp(t *testing.T) {
 			exp:           &LikeBoolExp{val: &ColSelector{col: "col1"}, pattern: &Varchar{val: ""}},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  BooleanType,
 			expectedError: nil,
@@ -415,7 +379,6 @@ func TestRequiresTypeSimpleValueExp(t *testing.T) {
 			exp:           &LikeBoolExp{val: &ColSelector{col: "col1"}, pattern: &Varchar{val: ""}},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  VarcharType,
 			expectedError: ErrInvalidTypes,
@@ -424,7 +387,6 @@ func TestRequiresTypeSimpleValueExp(t *testing.T) {
 			exp:           &LikeBoolExp{},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  VarcharType,
 			expectedError: ErrInvalidCondition,
@@ -433,7 +395,6 @@ func TestRequiresTypeSimpleValueExp(t *testing.T) {
 			exp:           &LikeBoolExp{val: &ColSelector{col: "ft"}, pattern: &Varchar{val: ""}},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  Float64Type,
 			expectedError: ErrInvalidTypes,
@@ -441,11 +402,11 @@ func TestRequiresTypeSimpleValueExp(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		err := tc.exp.requiresType(tc.requiredType, tc.cols, tc.params, tc.implicitDB, tc.implicitTable)
+		err := tc.exp.requiresType(tc.requiredType, tc.cols, tc.params, tc.implicitTable)
 		require.ErrorIs(t, err, tc.expectedError, fmt.Sprintf("failed on iteration %d", i))
 
 		if tc.expectedError == nil {
-			it, err := tc.exp.inferType(tc.cols, params, tc.implicitDB, tc.implicitTable)
+			it, err := tc.exp.inferType(tc.cols, params, tc.implicitTable)
 			require.NoError(t, err)
 			require.Equal(t, tc.requiredType, it)
 		}
@@ -454,12 +415,12 @@ func TestRequiresTypeSimpleValueExp(t *testing.T) {
 
 func TestRequiresTypeSysFnValueExp(t *testing.T) {
 	cols := make(map[string]ColDescriptor)
-	cols["(db1.mytable.id)"] = ColDescriptor{Type: IntegerType}
-	cols["(db1.mytable.title)"] = ColDescriptor{Type: VarcharType}
-	cols["(db1.mytable.active)"] = ColDescriptor{Type: BooleanType}
-	cols["(db1.mytable.payload)"] = ColDescriptor{Type: BLOBType}
-	cols["COUNT(db1.mytable.*)"] = ColDescriptor{Type: IntegerType}
-	cols["(db1.mytable.ft)"] = ColDescriptor{Type: Float64Type}
+	cols["(mytable.id)"] = ColDescriptor{Type: IntegerType}
+	cols["(mytable.title)"] = ColDescriptor{Type: VarcharType}
+	cols["(mytable.active)"] = ColDescriptor{Type: BooleanType}
+	cols["(mytable.payload)"] = ColDescriptor{Type: BLOBType}
+	cols["COUNT(mytable.*)"] = ColDescriptor{Type: IntegerType}
+	cols["(mytable.ft)"] = ColDescriptor{Type: Float64Type}
 
 	params := make(map[string]SQLValueType)
 
@@ -467,7 +428,6 @@ func TestRequiresTypeSysFnValueExp(t *testing.T) {
 		exp           ValueExp
 		cols          map[string]ColDescriptor
 		params        map[string]SQLValueType
-		implicitDB    string
 		implicitTable string
 		requiredType  SQLValueType
 		expectedError error
@@ -476,7 +436,6 @@ func TestRequiresTypeSysFnValueExp(t *testing.T) {
 			exp:           &FnCall{fn: "NOW"},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  TimestampType,
 			expectedError: nil,
@@ -485,7 +444,6 @@ func TestRequiresTypeSysFnValueExp(t *testing.T) {
 			exp:           &FnCall{fn: "NOW"},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  BooleanType,
 			expectedError: ErrInvalidTypes,
@@ -494,7 +452,6 @@ func TestRequiresTypeSysFnValueExp(t *testing.T) {
 			exp:           &FnCall{fn: "LOWER"},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  VarcharType,
 			expectedError: ErrIllegalArguments,
@@ -503,7 +460,6 @@ func TestRequiresTypeSysFnValueExp(t *testing.T) {
 			exp:           &FnCall{fn: "LOWER"},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  Float64Type,
 			expectedError: ErrIllegalArguments,
@@ -511,11 +467,11 @@ func TestRequiresTypeSysFnValueExp(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		err := tc.exp.requiresType(tc.requiredType, tc.cols, tc.params, tc.implicitDB, tc.implicitTable)
+		err := tc.exp.requiresType(tc.requiredType, tc.cols, tc.params, tc.implicitTable)
 		require.ErrorIs(t, err, tc.expectedError, fmt.Sprintf("failed on iteration %d", i))
 
 		if tc.expectedError == nil {
-			it, err := tc.exp.inferType(tc.cols, params, tc.implicitDB, tc.implicitTable)
+			it, err := tc.exp.inferType(tc.cols, params, tc.implicitTable)
 			require.NoError(t, err)
 			require.Equal(t, tc.requiredType, it)
 		}
@@ -524,12 +480,12 @@ func TestRequiresTypeSysFnValueExp(t *testing.T) {
 
 func TestRequiresTypeBinValueExp(t *testing.T) {
 	cols := make(map[string]ColDescriptor)
-	cols["(db1.mytable.id)"] = ColDescriptor{Type: IntegerType}
-	cols["(db1.mytable.title)"] = ColDescriptor{Type: VarcharType}
-	cols["(db1.mytable.active)"] = ColDescriptor{Type: BooleanType}
-	cols["(db1.mytable.payload)"] = ColDescriptor{Type: BLOBType}
-	cols["COUNT(db1.mytable.*)"] = ColDescriptor{Type: IntegerType}
-	cols["(db1.mytable.ft)"] = ColDescriptor{Type: Float64Type}
+	cols["(mytable.id)"] = ColDescriptor{Type: IntegerType}
+	cols["(mytable.title)"] = ColDescriptor{Type: VarcharType}
+	cols["(mytable.active)"] = ColDescriptor{Type: BooleanType}
+	cols["(mytable.payload)"] = ColDescriptor{Type: BLOBType}
+	cols["COUNT(mytable.*)"] = ColDescriptor{Type: IntegerType}
+	cols["(mytable.ft)"] = ColDescriptor{Type: Float64Type}
 
 	params := make(map[string]SQLValueType)
 
@@ -537,7 +493,6 @@ func TestRequiresTypeBinValueExp(t *testing.T) {
 		exp           ValueExp
 		cols          map[string]ColDescriptor
 		params        map[string]SQLValueType
-		implicitDB    string
 		implicitTable string
 		requiredType  SQLValueType
 		expectedError error
@@ -546,7 +501,6 @@ func TestRequiresTypeBinValueExp(t *testing.T) {
 			exp:           &BinBoolExp{op: AND, left: &Bool{val: true}, right: &Bool{val: false}},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  BooleanType,
 			expectedError: nil,
@@ -555,7 +509,6 @@ func TestRequiresTypeBinValueExp(t *testing.T) {
 			exp:           &BinBoolExp{op: AND, left: &Bool{val: true}, right: &Bool{val: false}},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  IntegerType,
 			expectedError: ErrInvalidTypes,
@@ -564,7 +517,6 @@ func TestRequiresTypeBinValueExp(t *testing.T) {
 			exp:           &BinBoolExp{op: AND, left: &Integer{val: 1}, right: &Bool{val: false}},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  IntegerType,
 			expectedError: ErrInvalidTypes,
@@ -573,7 +525,6 @@ func TestRequiresTypeBinValueExp(t *testing.T) {
 			exp:           &BinBoolExp{op: AND, left: &Bool{val: false}, right: &Integer{val: 1}},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  IntegerType,
 			expectedError: ErrInvalidTypes,
@@ -582,7 +533,6 @@ func TestRequiresTypeBinValueExp(t *testing.T) {
 			exp:           &CmpBoolExp{op: LE, left: &Integer{val: 1}, right: &Integer{val: 1}},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  BooleanType,
 			expectedError: nil,
@@ -591,7 +541,6 @@ func TestRequiresTypeBinValueExp(t *testing.T) {
 			exp:           &CmpBoolExp{op: LE, left: &Integer{val: 1}, right: &Integer{val: 1}},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  IntegerType,
 			expectedError: ErrInvalidTypes,
@@ -600,7 +549,6 @@ func TestRequiresTypeBinValueExp(t *testing.T) {
 			exp:           &CmpBoolExp{op: LE, left: &Integer{val: 1}, right: &Bool{val: false}},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  BooleanType,
 			expectedError: ErrInvalidTypes,
@@ -609,7 +557,6 @@ func TestRequiresTypeBinValueExp(t *testing.T) {
 			exp:           &CmpBoolExp{op: LE, left: &Bool{val: false}, right: &Integer{val: 1}},
 			cols:          cols,
 			params:        params,
-			implicitDB:    "db1",
 			implicitTable: "mytable",
 			requiredType:  BooleanType,
 			expectedError: ErrInvalidTypes,
@@ -617,11 +564,11 @@ func TestRequiresTypeBinValueExp(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		err := tc.exp.requiresType(tc.requiredType, tc.cols, tc.params, tc.implicitDB, tc.implicitTable)
+		err := tc.exp.requiresType(tc.requiredType, tc.cols, tc.params, tc.implicitTable)
 		require.ErrorIs(t, err, tc.expectedError, fmt.Sprintf("failed on iteration %d", i))
 
 		if tc.expectedError == nil {
-			it, err := tc.exp.inferType(tc.cols, params, tc.implicitDB, tc.implicitTable)
+			it, err := tc.exp.inferType(tc.cols, params, tc.implicitTable)
 			require.NoError(t, err)
 			require.Equal(t, tc.requiredType, it)
 		}
@@ -631,20 +578,20 @@ func TestRequiresTypeBinValueExp(t *testing.T) {
 func TestYetUnsupportedExistsBoolExp(t *testing.T) {
 	exp := &ExistsBoolExp{}
 
-	_, err := exp.inferType(nil, nil, "", "")
+	_, err := exp.inferType(nil, nil, "")
 	require.Error(t, err)
 
-	err = exp.requiresType(BooleanType, nil, nil, "", "")
+	err = exp.requiresType(BooleanType, nil, nil, "")
 	require.Error(t, err)
 
 	rexp, err := exp.substitute(nil)
 	require.NoError(t, err)
 	require.Equal(t, exp, rexp)
 
-	_, err = exp.reduce(nil, nil, "", "")
+	_, err = exp.reduce(nil, nil, "")
 	require.Error(t, err)
 
-	require.Equal(t, exp, exp.reduceSelectors(nil, "", ""))
+	require.Equal(t, exp, exp.reduceSelectors(nil, ""))
 
 	require.False(t, exp.isConstant())
 
@@ -654,20 +601,20 @@ func TestYetUnsupportedExistsBoolExp(t *testing.T) {
 func TestYetUnsupportedInSubQueryExp(t *testing.T) {
 	exp := &InSubQueryExp{}
 
-	_, err := exp.inferType(nil, nil, "", "")
+	_, err := exp.inferType(nil, nil, "")
 	require.ErrorIs(t, err, ErrNoSupported)
 
-	err = exp.requiresType(BooleanType, nil, nil, "", "")
+	err = exp.requiresType(BooleanType, nil, nil, "")
 	require.ErrorIs(t, err, ErrNoSupported)
 
 	rexp, err := exp.substitute(nil)
 	require.NoError(t, err)
 	require.Equal(t, exp, rexp)
 
-	_, err = exp.reduce(nil, nil, "", "")
+	_, err = exp.reduce(nil, nil, "")
 	require.ErrorIs(t, err, ErrNoSupported)
 
-	require.Equal(t, exp, exp.reduceSelectors(nil, "", ""))
+	require.Equal(t, exp, exp.reduceSelectors(nil, ""))
 
 	require.False(t, exp.isConstant())
 
@@ -677,39 +624,39 @@ func TestYetUnsupportedInSubQueryExp(t *testing.T) {
 func TestLikeBoolExpEdgeCases(t *testing.T) {
 	exp := &LikeBoolExp{}
 
-	_, err := exp.inferType(nil, nil, "", "")
+	_, err := exp.inferType(nil, nil, "")
 	require.ErrorIs(t, err, ErrInvalidCondition)
 
-	err = exp.requiresType(BooleanType, nil, nil, "", "")
+	err = exp.requiresType(BooleanType, nil, nil, "")
 	require.ErrorIs(t, err, ErrInvalidCondition)
 
 	_, err = exp.substitute(nil)
 	require.ErrorIs(t, err, ErrInvalidCondition)
 
-	_, err = exp.reduce(nil, nil, "", "")
+	_, err = exp.reduce(nil, nil, "")
 	require.ErrorIs(t, err, ErrInvalidCondition)
 
-	require.Equal(t, exp, exp.reduceSelectors(nil, "", ""))
+	require.Equal(t, exp, exp.reduceSelectors(nil, ""))
 	require.False(t, exp.isConstant())
 	require.Nil(t, exp.selectorRanges(nil, "", nil, nil))
 
 	t.Run("like expression with invalid types", func(t *testing.T) {
 		exp := &LikeBoolExp{val: &ColSelector{col: "col1"}, pattern: &Integer{}}
 
-		_, err = exp.inferType(nil, nil, "", "")
+		_, err = exp.inferType(nil, nil, "")
 		require.ErrorIs(t, err, ErrInvalidTypes)
 
-		err = exp.requiresType(BooleanType, nil, nil, "", "")
+		err = exp.requiresType(BooleanType, nil, nil, "")
 		require.ErrorIs(t, err, ErrInvalidTypes)
 
 		v := &NullValue{}
 
 		row := &Row{
 			ValuesByPosition: []TypedValue{v},
-			ValuesBySelector: map[string]TypedValue{"(db1.table1.col1)": v},
+			ValuesBySelector: map[string]TypedValue{"(table1.col1)": v},
 		}
 
-		_, err = exp.reduce(nil, row, "db1", "table1")
+		_, err = exp.reduce(nil, row, "table1")
 		require.ErrorIs(t, err, ErrInvalidTypes)
 	})
 
@@ -811,21 +758,21 @@ func TestTimestmapType(t *testing.T) {
 		require.Equal(t, -1, cmp)
 	})
 
-	it, err := ts.inferType(map[string]ColDescriptor{}, map[string]string{}, "", "")
+	it, err := ts.inferType(map[string]ColDescriptor{}, map[string]string{}, "")
 	require.NoError(t, err)
 	require.Equal(t, TimestampType, it)
 
-	err = ts.requiresType(TimestampType, map[string]ColDescriptor{}, map[string]string{}, "", "")
+	err = ts.requiresType(TimestampType, map[string]ColDescriptor{}, map[string]string{}, "")
 	require.NoError(t, err)
 
-	err = ts.requiresType(IntegerType, map[string]ColDescriptor{}, map[string]string{}, "", "")
+	err = ts.requiresType(IntegerType, map[string]ColDescriptor{}, map[string]string{}, "")
 	require.ErrorIs(t, err, ErrInvalidTypes)
 
 	v, err := ts.substitute(map[string]interface{}{})
 	require.NoError(t, err)
 	require.Equal(t, ts, v)
 
-	v = ts.reduceSelectors(&Row{}, "", "")
+	v = ts.reduceSelectors(&Row{}, "")
 	require.Equal(t, ts, v)
 
 	err = ts.selectorRanges(&Table{}, "", map[string]interface{}{}, map[uint32]*typedValueRange{})
@@ -995,21 +942,21 @@ func TestFloat64Type(t *testing.T) {
 		require.Equal(t, -1, cmp)
 	})
 
-	it, err := ts.inferType(map[string]ColDescriptor{}, map[string]string{}, "", "")
+	it, err := ts.inferType(map[string]ColDescriptor{}, map[string]string{}, "")
 	require.NoError(t, err)
 	require.Equal(t, Float64Type, it)
 
-	err = ts.requiresType(Float64Type, map[string]ColDescriptor{}, map[string]string{}, "", "")
+	err = ts.requiresType(Float64Type, map[string]ColDescriptor{}, map[string]string{}, "")
 	require.NoError(t, err)
 
-	err = ts.requiresType(IntegerType, map[string]ColDescriptor{}, map[string]string{}, "", "")
+	err = ts.requiresType(IntegerType, map[string]ColDescriptor{}, map[string]string{}, "")
 	require.ErrorIs(t, err, ErrInvalidTypes)
 
 	v, err := ts.substitute(map[string]interface{}{})
 	require.NoError(t, err)
 	require.Equal(t, ts, v)
 
-	v = ts.reduceSelectors(&Row{}, "", "")
+	v = ts.reduceSelectors(&Row{}, "")
 	require.Equal(t, ts, v)
 
 	err = ts.selectorRanges(&Table{}, "", map[string]interface{}{}, map[uint32]*typedValueRange{})

--- a/embedded/sql/union_row_reader.go
+++ b/embedded/sql/union_row_reader.go
@@ -73,10 +73,6 @@ func (ur *unionRowReader) Tx() *SQLTx {
 	return ur.rowReaders[0].Tx()
 }
 
-func (ur *unionRowReader) Database() string {
-	return ur.rowReaders[0].Database()
-}
-
 func (ur *unionRowReader) TableAlias() string {
 	return ""
 }

--- a/embedded/sql/union_row_reader_test.go
+++ b/embedded/sql/union_row_reader_test.go
@@ -46,9 +46,6 @@ func TestUnionRowReader(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, rowReader)
 
-	require.NotNil(t, rowReader.Database())
-	require.Equal(t, "db1", rowReader.Database())
-
 	require.Equal(t, "", rowReader.TableAlias())
 
 	require.Nil(t, rowReader.OrderBy())

--- a/embedded/sql/values_row_reader.go
+++ b/embedded/sql/values_row_reader.go
@@ -26,7 +26,6 @@ type valuesRowReader struct {
 	colsByPos []ColDescriptor
 	colsBySel map[string]ColDescriptor
 
-	dbAlias    string
 	tableAlias string
 
 	values [][]ValueExp
@@ -38,13 +37,9 @@ type valuesRowReader struct {
 	closed          bool
 }
 
-func newValuesRowReader(tx *SQLTx, params map[string]interface{}, cols []ColDescriptor, dbAlias, tableAlias string, values [][]ValueExp) (*valuesRowReader, error) {
+func newValuesRowReader(tx *SQLTx, params map[string]interface{}, cols []ColDescriptor, tableAlias string, values [][]ValueExp) (*valuesRowReader, error) {
 	if len(cols) == 0 {
 		return nil, fmt.Errorf("%w: empty column list", ErrIllegalArguments)
-	}
-
-	if dbAlias == "" {
-		return nil, fmt.Errorf("%w: db alias is mandatory", ErrIllegalArguments)
 	}
 
 	if tableAlias == "" {
@@ -55,15 +50,14 @@ func newValuesRowReader(tx *SQLTx, params map[string]interface{}, cols []ColDesc
 	colsBySel := make(map[string]ColDescriptor, len(cols))
 
 	for i, c := range cols {
-		if c.AggFn != "" || c.Database != "" || c.Table != "" {
+		if c.AggFn != "" || c.Table != "" {
 			return nil, fmt.Errorf("%w: only column name may be specified", ErrIllegalArguments)
 		}
 
 		col := ColDescriptor{
-			Database: dbAlias,
-			Table:    tableAlias,
-			Column:   c.Column,
-			Type:     c.Type,
+			Table:  tableAlias,
+			Column: c.Column,
+			Type:   c.Type,
 		}
 
 		colsByPos[i] = col
@@ -81,7 +75,6 @@ func newValuesRowReader(tx *SQLTx, params map[string]interface{}, cols []ColDesc
 		params:     params,
 		colsByPos:  colsByPos,
 		colsBySel:  colsBySel,
-		dbAlias:    dbAlias,
 		tableAlias: tableAlias,
 		values:     values,
 	}, nil
@@ -93,14 +86,6 @@ func (vr *valuesRowReader) onClose(callback func()) {
 
 func (vr *valuesRowReader) Tx() *SQLTx {
 	return vr.tx
-}
-
-func (vr *valuesRowReader) Database() string {
-	if vr.dbAlias == "" {
-		return vr.tx.currentDB.name
-	}
-
-	return vr.dbAlias
 }
 
 func (vr *valuesRowReader) TableAlias() string {
@@ -130,7 +115,7 @@ func (vr *valuesRowReader) colsBySelector(ctx context.Context) (map[string]ColDe
 func (vr *valuesRowReader) InferParameters(ctx context.Context, params map[string]SQLValueType) error {
 	for _, vs := range vr.values {
 		for _, v := range vs {
-			v.inferType(vr.colsBySel, params, vr.dbAlias, vr.tableAlias)
+			v.inferType(vr.colsBySel, params, vr.tableAlias)
 		}
 	}
 	return nil
@@ -152,12 +137,12 @@ func (vr *valuesRowReader) Read(ctx context.Context) (*Row, error) {
 			return nil, err
 		}
 
-		rv, err := sv.reduce(vr.tx, nil, vr.dbAlias, vr.tableAlias)
+		rv, err := sv.reduce(vr.tx, nil, vr.tableAlias)
 		if err != nil {
 			return nil, err
 		}
 
-		err = rv.requiresType(vr.colsByPos[i].Type, vr.colsBySel, nil, vr.dbAlias, vr.tableAlias)
+		err = rv.requiresType(vr.colsByPos[i].Type, vr.colsBySel, nil, vr.tableAlias)
 		if err != nil {
 			return nil, err
 		}

--- a/embedded/sql/values_row_reader_test.go
+++ b/embedded/sql/values_row_reader_test.go
@@ -24,23 +24,23 @@ import (
 )
 
 func TestValuesRowReader(t *testing.T) {
-	_, err := newValuesRowReader(nil, nil, nil, "", "", nil)
+	_, err := newValuesRowReader(nil, nil, nil, "", nil)
 	require.ErrorIs(t, err, ErrIllegalArguments)
 
 	cols := []ColDescriptor{
 		{Column: "col1"},
 	}
 
-	_, err = newValuesRowReader(nil, nil, cols, "", "", nil)
+	_, err = newValuesRowReader(nil, nil, cols, "", nil)
 	require.ErrorIs(t, err, ErrIllegalArguments)
 
-	_, err = newValuesRowReader(nil, nil, cols, "db1", "", nil)
+	_, err = newValuesRowReader(nil, nil, cols, "", nil)
 	require.ErrorIs(t, err, ErrIllegalArguments)
 
-	_, err = newValuesRowReader(nil, nil, cols, "db1", "table1", nil)
+	_, err = newValuesRowReader(nil, nil, cols, "table1", nil)
 	require.NoError(t, err)
 
-	_, err = newValuesRowReader(nil, nil, cols, "db1", "table1",
+	_, err = newValuesRowReader(nil, nil, cols, "table1",
 		[][]ValueExp{
 			{
 				&Bool{val: true},
@@ -52,7 +52,7 @@ func TestValuesRowReader(t *testing.T) {
 	_, err = newValuesRowReader(nil, nil,
 		[]ColDescriptor{
 			{Table: "table1", Column: "col1"},
-		}, "", "", nil)
+		}, "", nil)
 	require.ErrorIs(t, err, ErrIllegalArguments)
 
 	values := [][]ValueExp{
@@ -65,10 +65,8 @@ func TestValuesRowReader(t *testing.T) {
 		"param1": 1,
 	}
 
-	rowReader, err := newValuesRowReader(nil, params, cols, "db1", "table1", values)
+	rowReader, err := newValuesRowReader(nil, params, cols, "table1", values)
 	require.NoError(t, err)
-
-	require.Equal(t, "db1", rowReader.Database())
 	require.Nil(t, rowReader.OrderBy())
 	require.Nil(t, rowReader.ScanSpecs())
 

--- a/pkg/database/all_ops_test.go
+++ b/pkg/database/all_ops_test.go
@@ -153,7 +153,7 @@ func TestSetBatch(t *testing.T) {
 
 		txhdr, err := db.Set(context.Background(), &schema.SetRequest{KVs: kvList})
 		require.NoError(t, err)
-		require.Equal(t, uint64(b+2), txhdr.Id)
+		require.Equal(t, uint64(b+1), txhdr.Id)
 
 		for i := 0; i < batchSize; i++ {
 			key := []byte(strconv.FormatUint(uint64(i), 10))
@@ -161,7 +161,7 @@ func TestSetBatch(t *testing.T) {
 			entry, err := db.Get(context.Background(), &schema.KeyRequest{Key: key, SinceTx: txhdr.Id})
 			require.NoError(t, err)
 			require.Equal(t, value, entry.Value)
-			require.Equal(t, uint64(b+2), entry.Tx)
+			require.Equal(t, uint64(b+1), entry.Tx)
 
 			vitem, err := db.VerifiableGet(context.Background(), &schema.VerifiableGetRequest{KeyRequest: &schema.KeyRequest{Key: key}}) //no prev root
 			require.NoError(t, err)
@@ -272,7 +272,7 @@ func TestExecAllOps(t *testing.T) {
 
 		idx, err := db.ExecAll(context.Background(), &schema.ExecAllRequest{Operations: atomicOps})
 		require.NoError(t, err)
-		require.Equal(t, uint64(b+2), idx.Id)
+		require.Equal(t, uint64(b+1), idx.Id)
 	}
 
 	zScanOpt := &schema.ZScanRequest{
@@ -332,7 +332,7 @@ func TestExecAllOpsZAddOnMixedAlreadyPersitedNotPersistedItems(t *testing.T) {
 
 	index, err := db.ExecAll(context.Background(), aOps)
 	require.NoError(t, err)
-	require.Equal(t, uint64(3), index.Id)
+	require.Equal(t, uint64(2), index.Id)
 
 	list, err := db.ZScan(context.Background(), &schema.ZScanRequest{
 		Set:     []byte(`mySet`),
@@ -639,7 +639,7 @@ func TestStore_ExecAllOpsConcurrent(t *testing.T) {
 
 		zList, err := db.ZScan(context.Background(), &schema.ZScanRequest{
 			Set:     []byte(set),
-			SinceTx: 11,
+			SinceTx: 10,
 		})
 		require.NoError(t, err)
 		require.Len(t, zList.Entries, 10)

--- a/pkg/database/database_test.go
+++ b/pkg/database/database_test.go
@@ -2196,7 +2196,7 @@ func Test_database_truncate(t *testing.T) {
 	require.NoError(t, err)
 	require.LessOrEqual(t, time.Unix(hdr.Ts, 0), queryTime)
 
-	err = c.Truncate(context.Background(), hdr.ID)
+	err = c.TruncateUptoTx(context.Background(), hdr.ID)
 	require.NoError(t, err)
 
 	for i := hdr.ID; i <= 20; i++ {

--- a/pkg/database/database_test.go
+++ b/pkg/database/database_test.go
@@ -2170,7 +2170,7 @@ db := makeDb(t)
 func Test_database_truncate(t *testing.T) {
 	options := DefaultOption().WithDBRootPath(t.TempDir())
 	options.storeOpts.WithIndexOptions(options.storeOpts.IndexOpts.WithCompactionThld(2)).
-		WithFileSize(16).
+		WithFileSize(8).
 		WithVLogCacheSize(0)
 
 	db := makeDbWith(t, "db", options)

--- a/pkg/database/database_test.go
+++ b/pkg/database/database_test.go
@@ -2170,14 +2170,14 @@ db := makeDb(t)
 func Test_database_truncate(t *testing.T) {
 	options := DefaultOption().WithDBRootPath(t.TempDir())
 	options.storeOpts.WithIndexOptions(options.storeOpts.IndexOpts.WithCompactionThld(2)).
-		WithFileSize(6).
+		WithFileSize(16).
 		WithVLogCacheSize(0)
 
 	db := makeDbWith(t, "db", options)
 
 	var queryTime time.Time
 
-	for i := 2; i <= 20; i++ {
+	for i := 0; i <= 20; i++ {
 		kv := &schema.KeyValue{
 			Key:   []byte(fmt.Sprintf("key_%d", i)),
 			Value: []byte(fmt.Sprintf("val_%d", i)),

--- a/pkg/database/database_test.go
+++ b/pkg/database/database_test.go
@@ -112,7 +112,7 @@ func TestDefaultDbCreation(t *testing.T) {
 
 	n, err := db.Size()
 	require.NoError(t, err)
-	require.Equal(t, uint64(1), n)
+	require.Zero(t, n)
 
 	_, err = db.Count(context.Background(), nil)
 	require.Error(t, err)
@@ -228,12 +228,12 @@ func TestDbSetGet(t *testing.T) {
 	for i, kv := range kvs[:1] {
 		txhdr, err := db.Set(context.Background(), &schema.SetRequest{KVs: []*schema.KeyValue{kv}})
 		require.NoError(t, err)
-		require.Equal(t, uint64(i+2), txhdr.Id)
+		require.Equal(t, uint64(i+1), txhdr.Id)
 
 		if i == 0 {
 			alh := schema.TxHeaderFromProto(txhdr).Alh()
 			copy(trustedAlh[:], alh[:])
-			trustedIndex = 2
+			trustedIndex = 1
 		}
 
 		keyReq := &schema.KeyRequest{Key: kv.Key, SinceTx: txhdr.Id}
@@ -385,13 +385,13 @@ func TestCurrentState(t *testing.T) {
 	for ind, val := range kvs {
 		txhdr, err := db.Set(context.Background(), &schema.SetRequest{KVs: []*schema.KeyValue{{Key: val.Key, Value: val.Value}}})
 		require.NoError(t, err)
-		require.Equal(t, uint64(ind+2), txhdr.Id)
+		require.Equal(t, uint64(ind+1), txhdr.Id)
 
 		time.Sleep(1 * time.Second)
 
 		state, err := db.CurrentState()
 		require.NoError(t, err)
-		require.Equal(t, uint64(ind+2), state.TxId)
+		require.Equal(t, uint64(ind+1), state.TxId)
 	}
 }
 
@@ -413,7 +413,7 @@ func TestSafeSetGet(t *testing.T) {
 				},
 			},
 		},
-		ProveSinceTx: 2,
+		ProveSinceTx: 1,
 	})
 	require.Equal(t, ErrIllegalState, err)
 
@@ -465,7 +465,7 @@ func TestSafeSetGet(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		require.Equal(t, uint64(ind+2), vit.Entry.Tx)
+		require.Equal(t, uint64(ind+1), vit.Entry.Tx)
 	}
 }
 
@@ -489,7 +489,7 @@ func TestSetGetAll(t *testing.T) {
 
 	txhdr, err := db.Set(context.Background(), &schema.SetRequest{KVs: kvs})
 	require.NoError(t, err)
-	require.Equal(t, uint64(2), txhdr.Id)
+	require.Equal(t, uint64(1), txhdr.Id)
 
 	itList, err := db.GetAll(context.Background(), &schema.KeyListRequest{
 		Keys: [][]byte{

--- a/pkg/database/reference_test.go
+++ b/pkg/database/reference_test.go
@@ -70,7 +70,7 @@ func TestStoreReference(t *testing.T) {
 	}
 	txhdr, err = db.SetReference(context.Background(), refOpts)
 	require.NoError(t, err)
-	require.Equal(t, uint64(3), txhdr.Id)
+	require.Equal(t, uint64(2), txhdr.Id)
 
 	keyReq := &schema.KeyRequest{Key: []byte(`myTag`), SinceTx: txhdr.Id}
 
@@ -171,7 +171,7 @@ func TestStoreReferenceAsyncCommit(t *testing.T) {
 
 		ref, err := db.SetReference(context.Background(), refOpts)
 		require.NoError(t, err, "n=%d", n)
-		require.Equal(t, n+2+2, ref.Id, "n=%d", n)
+		require.Equal(t, n+1+2, ref.Id, "n=%d", n)
 	}
 
 	for n := uint64(0); n <= 64; n++ {
@@ -215,7 +215,7 @@ func TestStoreMultipleReferenceOnSameKey(t *testing.T) {
 
 	reference1, err := db.SetReference(context.Background(), refOpts1)
 	require.NoError(t, err)
-	require.Exactly(t, uint64(4), reference1.Id)
+	require.Exactly(t, uint64(3), reference1.Id)
 	require.NotEmptyf(t, reference1, "Should not be empty")
 
 	refOpts2 := &schema.ReferenceRequest{
@@ -226,7 +226,7 @@ func TestStoreMultipleReferenceOnSameKey(t *testing.T) {
 	}
 	reference2, err := db.SetReference(context.Background(), refOpts2)
 	require.NoError(t, err)
-	require.Exactly(t, uint64(5), reference2.Id)
+	require.Exactly(t, uint64(4), reference2.Id)
 	require.NotEmptyf(t, reference2, "Should not be empty")
 
 	refOpts3 := &schema.ReferenceRequest{
@@ -237,7 +237,7 @@ func TestStoreMultipleReferenceOnSameKey(t *testing.T) {
 	}
 	reference3, err := db.SetReference(context.Background(), refOpts3)
 	require.NoError(t, err)
-	require.Exactly(t, uint64(6), reference3.Id)
+	require.Exactly(t, uint64(5), reference3.Id)
 	require.NotEmptyf(t, reference3, "Should not be empty")
 
 	firstTagRet, err := db.Get(context.Background(), &schema.KeyRequest{Key: []byte(`myTag1`), SinceTx: reference3.Id})

--- a/pkg/database/sorted_set_test.go
+++ b/pkg/database/sorted_set_test.go
@@ -43,7 +43,7 @@ func TestStoreIndexExists(t *testing.T) {
 
 	reference1, err1 := db.ZAdd(context.Background(), zaddOpts1)
 	require.NoError(t, err1)
-	require.Exactly(t, uint64(5), reference1.Id)
+	require.Exactly(t, uint64(4), reference1.Id)
 	require.NotEmptyf(t, reference1, "Should not be empty")
 
 	zaddOpts2 := &schema.ZAddRequest{
@@ -54,7 +54,7 @@ func TestStoreIndexExists(t *testing.T) {
 
 	reference2, err2 := db.ZAdd(context.Background(), zaddOpts2)
 	require.NoError(t, err2)
-	require.Exactly(t, uint64(6), reference2.Id)
+	require.Exactly(t, uint64(5), reference2.Id)
 	require.NotEmptyf(t, reference2, "Should not be empty")
 
 	zaddOpts2 = &schema.ZAddRequest{
@@ -75,7 +75,7 @@ func TestStoreIndexExists(t *testing.T) {
 
 	reference3, err3 := db.ZAdd(context.Background(), zaddOpts3)
 	require.NoError(t, err3)
-	require.Exactly(t, uint64(7), reference3.Id)
+	require.Exactly(t, uint64(6), reference3.Id)
 	require.NotEmptyf(t, reference3, "Should not be empty")
 
 	zscanOpts := &schema.ZScanRequest{
@@ -147,7 +147,7 @@ func TestStoreIndexEqualKeys(t *testing.T) {
 
 	reference1, err1 := db.ZAdd(context.Background(), zaddOpts1)
 	require.NoError(t, err1)
-	require.Exactly(t, uint64(6), reference1.Id)
+	require.Exactly(t, uint64(5), reference1.Id)
 	require.NotEmptyf(t, reference1, "Should not be empty")
 
 	zaddOpts2 := &schema.ZAddRequest{
@@ -160,7 +160,7 @@ func TestStoreIndexEqualKeys(t *testing.T) {
 
 	reference2, err2 := db.ZAdd(context.Background(), zaddOpts2)
 	require.NoError(t, err2)
-	require.Exactly(t, uint64(7), reference2.Id)
+	require.Exactly(t, uint64(6), reference2.Id)
 	require.NotEmptyf(t, reference2, "Should not be empty")
 
 	zaddOpts3 := &schema.ZAddRequest{
@@ -173,7 +173,7 @@ func TestStoreIndexEqualKeys(t *testing.T) {
 
 	reference3, err3 := db.ZAdd(context.Background(), zaddOpts3)
 	require.NoError(t, err3)
-	require.Exactly(t, uint64(8), reference3.Id)
+	require.Exactly(t, uint64(7), reference3.Id)
 	require.NotEmptyf(t, reference3, "Should not be empty")
 
 	zscanOpts1 := &schema.ZScanRequest{
@@ -210,7 +210,7 @@ func TestStoreIndexEqualKeysEqualScores(t *testing.T) {
 	reference1, err1 := db.ZAdd(context.Background(), zaddOpts1)
 
 	require.NoError(t, err1)
-	require.Exactly(t, uint64(5), reference1.Id)
+	require.Exactly(t, uint64(4), reference1.Id)
 	require.NotEmptyf(t, reference1, "Should not be empty")
 
 	zaddOpts2 := &schema.ZAddRequest{
@@ -224,7 +224,7 @@ func TestStoreIndexEqualKeysEqualScores(t *testing.T) {
 	reference2, err2 := db.ZAdd(context.Background(), zaddOpts2)
 
 	require.NoError(t, err2)
-	require.Exactly(t, uint64(6), reference2.Id)
+	require.Exactly(t, uint64(5), reference2.Id)
 	require.NotEmptyf(t, reference2, "Should not be empty")
 
 	zaddOpts3 := &schema.ZAddRequest{
@@ -238,7 +238,7 @@ func TestStoreIndexEqualKeysEqualScores(t *testing.T) {
 	reference3, err3 := db.ZAdd(context.Background(), zaddOpts3)
 
 	require.NoError(t, err3)
-	require.Exactly(t, uint64(7), reference3.Id)
+	require.Exactly(t, uint64(6), reference3.Id)
 	require.NotEmptyf(t, reference3, "Should not be empty")
 
 	zscanOpts1 := &schema.ZScanRequest{
@@ -604,7 +604,7 @@ func TestStoreZScanOnZAddIndexReference(t *testing.T) {
 
 	reference1, err1 := db.ZAdd(context.Background(), zaddOpts1)
 	require.NoError(t, err1)
-	require.Exactly(t, uint64(5), reference1.Id)
+	require.Exactly(t, uint64(4), reference1.Id)
 	require.NotEmptyf(t, reference1, "Should not be empty")
 
 	zaddOpts2 := &schema.ZAddRequest{
@@ -617,7 +617,7 @@ func TestStoreZScanOnZAddIndexReference(t *testing.T) {
 
 	reference2, err2 := db.ZAdd(context.Background(), zaddOpts2)
 	require.NoError(t, err2)
-	require.Exactly(t, uint64(6), reference2.Id)
+	require.Exactly(t, uint64(5), reference2.Id)
 	require.NotEmptyf(t, reference2, "Should not be empty")
 
 	zaddOpts3 := &schema.ZAddRequest{
@@ -630,7 +630,7 @@ func TestStoreZScanOnZAddIndexReference(t *testing.T) {
 
 	reference3, err3 := db.ZAdd(context.Background(), zaddOpts3)
 	require.NoError(t, err3)
-	require.Exactly(t, uint64(7), reference3.Id)
+	require.Exactly(t, uint64(6), reference3.Id)
 	require.NotEmptyf(t, reference3, "Should not be empty")
 
 	zscanOpts1 := &schema.ZScanRequest{
@@ -658,7 +658,7 @@ func TestStoreVerifiableZAdd(t *testing.T) {
 
 	_, err = db.VerifiableZAdd(context.Background(), &schema.VerifiableZAddRequest{
 		ZAddRequest:  nil,
-		ProveSinceTx: i1.Id + 1,
+		ProveSinceTx: i1.Id,
 	})
 	require.Equal(t, store.ErrIllegalArguments, err)
 
@@ -681,7 +681,7 @@ func TestStoreVerifiableZAdd(t *testing.T) {
 		ProveSinceTx: i1.Id,
 	})
 	require.NoError(t, err)
-	require.Equal(t, uint64(3), vtx.Tx.Header.Id)
+	require.Equal(t, uint64(2), vtx.Tx.Header.Id)
 
 	ekv := EncodeZAdd(req.Set, req.Score, EncodeKey(req.Key), req.AtTx)
 	require.Equal(t, ekv.Key, vtx.Tx.Entries[0].Key)

--- a/pkg/database/truncator.go
+++ b/pkg/database/truncator.go
@@ -40,9 +40,9 @@ type Truncator interface {
 	//  * Returns nil TxHeader, and an error.
 	Plan(ctx context.Context, truncationUntil time.Time) (*store.TxHeader, error)
 
-	// Truncate runs truncation against the relevant appendable logs. Must
+	// TruncateUptoTx runs truncation against the relevant appendable logs. Must
 	// be called after result of Plan().
-	Truncate(ctx context.Context, txID uint64) error
+	TruncateUptoTx(ctx context.Context, txID uint64) error
 }
 
 func NewVlogTruncator(d DB) Truncator {
@@ -109,8 +109,8 @@ func (v *vlogTruncator) commitCatalog(ctx context.Context, txID uint64) (*store.
 	return tx.Commit(ctx)
 }
 
-// Truncate runs truncation against the relevant appendable logs upto the specified transaction offset.
-func (v *vlogTruncator) Truncate(ctx context.Context, txID uint64) error {
+// TruncateUpTo runs truncation against the relevant appendable logs upto the specified transaction offset.
+func (v *vlogTruncator) TruncateUptoTx(ctx context.Context, txID uint64) error {
 	defer func(t time.Time) {
 		v.metrics.ran.Inc()
 		v.metrics.duration.Observe(time.Since(t).Seconds())

--- a/pkg/database/truncator_test.go
+++ b/pkg/database/truncator_test.go
@@ -97,7 +97,7 @@ func Test_vlogCompactor_WithMultipleIO(t *testing.T) {
 
 	c := NewVlogTruncator(db)
 
-	require.NoError(t, c.Truncate(context.Background(), hdr.ID))
+	require.NoError(t, c.TruncateUptoTx(context.Background(), hdr.ID))
 
 	for i := deletePointTx; i < 20; i++ {
 		tx := store.NewTx(db.st.MaxTxEntries(), db.st.MaxKeyLen())
@@ -142,7 +142,7 @@ func Test_vlogCompactor_WithSingleIO(t *testing.T) {
 
 	c := NewVlogTruncator(db)
 
-	require.NoError(t, c.Truncate(context.Background(), hdr.ID))
+	require.NoError(t, c.TruncateUptoTx(context.Background(), hdr.ID))
 
 	for i := deletePointTx; i < 10; i++ {
 		tx := store.NewTx(db.st.MaxTxEntries(), db.st.MaxKeyLen())
@@ -211,7 +211,7 @@ func Test_vlogCompactor_WithConcurrentWritersOnSingleIO(t *testing.T) {
 
 	c := NewVlogTruncator(db)
 
-	require.NoError(t, c.Truncate(context.Background(), hdr.ID))
+	require.NoError(t, c.TruncateUptoTx(context.Background(), hdr.ID))
 
 	for i := deletePointTx; i <= 30; i++ {
 		tx := store.NewTx(db.st.MaxTxEntries(), db.st.MaxKeyLen())
@@ -354,7 +354,7 @@ func Test_vlogCompactor_with_sql(t *testing.T) {
 
 		c := NewVlogTruncator(db)
 
-		require.NoError(t, c.Truncate(context.Background(), hdr.ID))
+		require.NoError(t, c.TruncateUptoTx(context.Background(), hdr.ID))
 
 		// should add an extra transaction with catalogue
 		require.Equal(t, lastCommitTx+1, db.st.LastCommittedTxID())
@@ -436,7 +436,7 @@ func Test_vlogCompactor_without_data(t *testing.T) {
 
 	c := NewVlogTruncator(db)
 
-	require.NoError(t, c.Truncate(context.Background(), hdr.ID))
+	require.NoError(t, c.TruncateUptoTx(context.Background(), hdr.ID))
 
 	// ensure that a transaction is added for the sql catalog commit
 	require.Equal(t, uint64(2), db.st.LastCommittedTxID())
@@ -497,7 +497,7 @@ func Test_vlogCompactor_with_multiple_truncates(t *testing.T) {
 
 		c := NewVlogTruncator(db)
 
-		require.NoError(t, c.Truncate(context.Background(), hdr.ID))
+		require.NoError(t, c.TruncateUptoTx(context.Background(), hdr.ID))
 
 		// should add an extra transaction with catalogue
 		require.Equal(t, lastCommitTx+1, db.st.LastCommittedTxID())
@@ -529,7 +529,7 @@ func Test_vlogCompactor_with_multiple_truncates(t *testing.T) {
 
 		c := NewVlogTruncator(db)
 
-		require.NoError(t, c.Truncate(context.Background(), hdr.ID))
+		require.NoError(t, c.TruncateUptoTx(context.Background(), hdr.ID))
 
 		// should add an extra transaction with catalogue
 		require.Equal(t, lastCommitTx+1, db.st.LastCommittedTxID())
@@ -597,7 +597,7 @@ func Test_vlogCompactor_for_read_conflict(t *testing.T) {
 
 		c := NewVlogTruncator(db)
 
-		require.NoError(t, c.Truncate(context.Background(), hdr.ID))
+		require.NoError(t, c.TruncateUptoTx(context.Background(), hdr.ID))
 
 		close(doneTruncateCh)
 	}()

--- a/pkg/database/truncator_test.go
+++ b/pkg/database/truncator_test.go
@@ -426,6 +426,7 @@ func Test_vlogCompactor_without_data(t *testing.T) {
 
 	db := makeDbWith(t, "db", options)
 
+	db.Set(context.Background(), &schema.SetRequest{KVs: []*schema.KeyValue{{Key: []byte("key1")}}})
 	require.Equal(t, uint64(1), db.st.LastCommittedTxID())
 
 	deletePointTx := uint64(1)
@@ -556,7 +557,7 @@ func Test_vlogCompactor_for_read_conflict(t *testing.T) {
 	options.storeOpts.VLogCacheSize = 0
 
 	db := makeDbWith(t, "db", options)
-	require.Equal(t, uint64(1), db.st.LastCommittedTxID())
+	require.Equal(t, uint64(0), db.st.LastCommittedTxID())
 
 	for i := 1; i <= 10; i++ {
 		kv := &schema.KeyValue{

--- a/pkg/integration/client_test.go
+++ b/pkg/integration/client_test.go
@@ -927,9 +927,6 @@ func TestImmuClient_SetAll(t *testing.T) {
 	_, err = client.FlushIndex(ctx, 1, false)
 	require.NoError(t, err)
 
-	err = client.CompactIndex(ctx, &emptypb.Empty{})
-	require.NoError(t, err)
-
 	for _, kv := range setRequest.KVs {
 		i, err := client.Get(ctx, kv.Key)
 
@@ -1058,14 +1055,14 @@ func TestImmuClient_TxScan(t *testing.T) {
 	require.NoError(t, err)
 
 	txls, err := client.TxScan(ctx, &schema.TxScanRequest{
-		InitialTx: 2,
+		InitialTx: 1,
 	})
 	require.IsType(t, &schema.TxList{}, txls)
 	require.NoError(t, err)
 	require.Len(t, txls.Txs, 3)
 
 	txls, err = client.TxScan(ctx, &schema.TxScanRequest{
-		InitialTx: 4,
+		InitialTx: 3,
 		Limit:     3,
 		Desc:      true,
 	})
@@ -1074,7 +1071,7 @@ func TestImmuClient_TxScan(t *testing.T) {
 	require.Len(t, txls.Txs, 3)
 
 	txls, err = client.TxScan(ctx, &schema.TxScanRequest{
-		InitialTx: 3,
+		InitialTx: 2,
 		Limit:     1,
 		Desc:      true,
 	})

--- a/pkg/integration/replication/synchronous_replication_test.go
+++ b/pkg/integration/replication/synchronous_replication_test.go
@@ -389,7 +389,7 @@ func (suite *SyncTestRecoverySpeedSuite) TestReplicaRecoverySpeed() {
 
 		state, err := client.CurrentState(ctx)
 		suite.Require().NoError(err)
-		suite.Require().Greater(state.TxId, txWritten, "Ensure enough TXs were written")
+		suite.Require().Equal(state.TxId, txWritten, "Ensure enough TXs were written")
 
 		// Check if we can recover the cluster and perform write within a reasonable amount of time
 		// that was needed for initial sampling. The replica that was initially stopped and now
@@ -509,7 +509,7 @@ func (suite *SyncTestWithAsyncReplicaSuite) TestSyncReplicationAlongWithAsyncRep
 
 		state, err := client.CurrentState(ctx)
 		suite.Require().NoError(err)
-		suite.Require().Greater(state.TxId, txWritten, "Ensure enough TXs were written")
+		suite.Require().Equal(state.TxId, txWritten, "Ensure enough TXs were written")
 
 		for i := 0; i < suite.GetReplicasCount(); i++ {
 			suite.Run(fmt.Sprintf("replica %d", i), func() {

--- a/pkg/integration/stream/stream_replication_test.go
+++ b/pkg/integration/stream/stream_replication_test.go
@@ -77,7 +77,7 @@ func TestImmuClient_ExportAndReplicateTx(t *testing.T) {
 	)
 	rctx := metadata.NewOutgoingContext(context.Background(), rmd)
 
-	for i := uint64(1); i <= 2; i++ {
+	for i := uint64(1); i <= hdr.Id; i++ {
 		exportTxStream, err := client.ExportTx(context.Background(), &schema.ExportTxRequest{
 			Tx:                 i,
 			SkipIntegrityCheck: true,

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -874,9 +874,6 @@ func testServerSetGetBatch(ctx context.Context, s *ImmuServer, t *testing.T) {
 	_, err = s.FlushIndex(ctx, &schema.FlushIndexRequest{CleanupPercentage: 1})
 	require.NoError(t, err)
 
-	_, err = s.CompactIndex(ctx, nil)
-	require.NoError(t, err)
-
 	_, err = s.CompactIndex(ctx, &emptypb.Empty{})
 	require.ErrorIs(t, err, tbtree.ErrCompactionThresholdNotReached)
 

--- a/pkg/truncator/truncator.go
+++ b/pkg/truncator/truncator.go
@@ -169,7 +169,7 @@ func (t *Truncator) Truncate(ctx context.Context, retentionPeriod time.Duration)
 
 		// Truncate discards the appendable log upto the offset
 		// specified in the transaction hdr
-		err = c.Truncate(ctx, hdr.ID)
+		err = c.TruncateUptoTx(ctx, hdr.ID)
 		if err != nil {
 			return err
 		}

--- a/pkg/truncator/truncator_test.go
+++ b/pkg/truncator/truncator_test.go
@@ -83,7 +83,7 @@ func TestDatabase_truncate_with_duration(t *testing.T) {
 		require.NoError(t, err)
 		require.LessOrEqual(t, time.Unix(hdr.Ts, 0), queryTime)
 
-		err = c.Truncate(ctx, hdr.ID)
+		err = c.TruncateUptoTx(ctx, hdr.ID)
 		require.NoError(t, err)
 
 		for i := uint64(1); i < hdr.ID-1; i++ {
@@ -221,9 +221,9 @@ func (m *mockTruncator) Plan(context.Context, time.Time) (*store.TxHeader, error
 	return nil, m.err
 }
 
-// Truncate runs truncation against the relevant appendable logs. Must
+// TruncateUptoTx runs truncation against the relevant appendable logs. Must
 // be called after result of Plan().
-func (m *mockTruncator) Truncate(context.Context, uint64) error {
+func (m *mockTruncator) TruncateUptoTx(context.Context, uint64) error {
 	return m.err
 }
 


### PR DESCRIPTION
This PR simplifies the SQL engine.
Multi-database support is only allowed when an external handler has been provisioned.

No database creation statement is required in order to work with SQL layer from now on.

Changes are backward-compatible, it means existent databases can be opened without issues