### PR TITLE
chore(test/perf-tests): use proxy on benchmark runner

### DIFF
--- a/test/performance-test-suite/pkg/runner/influxdb_client.go
+++ b/test/performance-test-suite/pkg/runner/influxdb_client.go
@@ -2,12 +2,24 @@ package runner
 
 import (
 	"context"
+	"net/http"
+	"net/url"
+	"os"
 
 	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
 )
 
 func SendResultsToInfluxDb(host string, token string, bucket string, runner string, version string, r *BenchmarkSuiteResult) {
-	client := influxdb2.NewClient(host, token)
+	var client influxdb2.Client
+
+	if runner == "benchmark" {
+		proxyUrl, _ := url.Parse(os.Getenv("HTTPS_PROXY"))
+		httpClient := &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(proxyUrl)}}
+		client = influxdb2.NewClientWithOptions(host, token, influxdb2.DefaultOptions().SetHTTPClient(httpClient))
+	} else {
+		client = influxdb2.NewClient(host, token)
+	}
+
 	writer := client.WriteAPIBlocking("Codenotary", bucket)
 
 	for _, b := range r.Benchmarks {


### PR DESCRIPTION
With the proxy the data will be sent to the InfluxDB instance when the performance tests run on the `benchmark` runner.