### PR TITLE
fix(embedded/sql): crash when RowReader.Read() returns error

### DIFF
--- a/embedded/sql/engine_test.go
+++ b/embedded/sql/engine_test.go
@@ -1654,6 +1654,27 @@ func TestUpdate(t *testing.T) {
 	})
 }
 
+func TestErrorDuringUpdate(t *testing.T) {
+	engine := setupCommonTest(t)
+
+	_, _, err := engine.Exec(
+		context.Background(), nil,
+		`
+		create table mytable(id varchar[256], value integer, primary key id);
+		insert into mytable(id, value) values('aa',12), ('ab',13);
+	`, nil)
+	require.NoError(t, err)
+
+	_, _, err = engine.Exec(context.Background(), nil, "update mytable set value=@val where id=@id", nil)
+	require.ErrorIs(t, err, ErrMissingParameter)
+
+	params := make(map[string]interface{})
+	params["id"] = "ab";
+	params["val"] = 15;
+	_, _, err = engine.Exec(context.Background(), nil, "update mytable set value=@val where id=@id", params)
+	require.NoError(t, err)
+}
+
 func TestTransactions(t *testing.T) {
 	engine := setupCommonTest(t)
 

--- a/embedded/sql/stmt.go
+++ b/embedded/sql/stmt.go
@@ -1040,6 +1040,8 @@ func (stmt *UpdateStmt) execAt(ctx context.Context, tx *SQLTx, params map[string
 		row, err := rowReader.Read(ctx)
 		if err == ErrNoMoreRows {
 			break
+		} else if err != nil {
+			return nil, err
 		}
 
 		valuesByColID := make(map[uint32]TypedValue, len(row.ValuesBySelector))


### PR DESCRIPTION
One way an error can be returned is when an SQL parameter in a WHERE statement is missing.

fixes #1508