### PR TITLE
Performance test matrix

### DIFF
--- a/test/release_perf_test/.gitignore
+++ b/test/release_perf_test/.gitignore
@@ -1,0 +1,1 @@
+result.csv

--- a/test/release_perf_test/Dockerfile
+++ b/test/release_perf_test/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.18 as builder
+WORKDIR /src/immudb
+COPY go.mod go.sum /src/immudb
+RUN go mod download -x
+COPY . .
+RUN rm -rf /src/webconsole/dist &&   mkdir /var/lib/immudb
+RUN GOOS=linux GOARCH=amd64 make immuadmin-static immudb-static immuclient-static
+
+FROM debian:stable-slim
+COPY --from=builder /src/immudb/immuadmin /src/immudb/immudb /src/immudb/immuclient \
+	/src/immudb/test/release_perf_test/startup.sh /usr/local/bin
+ENTRYPOINT ["/usr/local/bin/startup.sh"]
+CMD ["standalone"]

--- a/test/release_perf_test/Dockerfile-141
+++ b/test/release_perf_test/Dockerfile-141
@@ -1,0 +1,12 @@
+FROM golang:1.18 as builder
+WORKDIR /src/immudb
+RUN git clone --branch v1.4.1 https://github.com/codenotary/immudb .
+RUN go mod download -x
+RUN rm -rf /src/webconsole/dist &&   mkdir /var/lib/immudb
+RUN GOOS=linux GOARCH=amd64 make immuadmin-static immudb-static immuclient-static
+
+FROM debian:stable-slim
+COPY --from=builder /src/immudb/immuadmin /src/immudb/immudb /src/immudb/immuclient /usr/local/bin
+COPY test/release_perf_test/startup.sh /usr/local/bin
+ENTRYPOINT ["/usr/local/bin/startup.sh"]
+CMD ["standalone"]

--- a/test/release_perf_test/Dockerfile.tools
+++ b/test/release_perf_test/Dockerfile.tools
@@ -1,0 +1,16 @@
+FROM golang:1.19 as builder
+WORKDIR /src/immudb-tools
+RUN git clone https://github.com/codenotary/immudb-tools .
+RUN (cd stresser2 && go build)
+RUN (cd paralsql && go build)
+
+FROM python:3.10-slim
+COPY --from=builder /src/immudb-tools/stresser2/stresser2 /src/immudb-tools/paralsql/paralsql /usr/local/bin/
+COPY --from=builder /src/immudb-tools/test-web-api/ /usr/local/immudb-tools/test-web-api/
+RUN apt-get update && apt-get install -y curl && \
+    curl -sSL https://install.python-poetry.org | POETRY_HOME=/etc/poetry python3 - --version 1.4.2
+ENV PATH="$PATH:/etc/poetry/venv/bin"
+RUN cd /usr/local/immudb-tools/test-web-api/ && \
+    poetry config virtualenvs.create false && poetry install
+ENTRYPOINT ["/bin/bash", "-c"]
+CMD ["echo hello world"]

--- a/test/release_perf_test/README.md
+++ b/test/release_perf_test/README.md
@@ -1,0 +1,104 @@
+# Performance test
+
+This utility test performs a set of performance test on immudb and outputs a CSV table that
+can be easily imported in a spreadsheet.
+Both immudb and the testing tools are built in a docker container. Docker compose is then used
+to run immudb and the test.
+
+# Usage
+
+## Quickstart
+
+Just launch `./runme.sh` and come back tomorrow.
+
+## Script usage
+
+**Note**: We recommend using `screen` or `tmux` to detach the session from the console. The test
+will run for a very long time and you risk a disconnection will ruin the result.
+
+The `runme.sh` scripts accept some options. Please refer to the test description below to better
+understand what the meaning of each of them is.
+
+```sh
+./runme.sh [ -d duration ] [ -B ] [ -D ] [ -Q ] [ -K ]
+        -d duration: duration of each test in seconds
+        -B (nobuild): skip building of containers
+        -D (nodocument): skip document test
+        -Q (nosql): skip sql test
+        -K (nokv): skip KV test
+```
+
+By default, the duration of each test is 600 seconds (10 minutes). You can change that with the `-d`
+parameter. You can also skip a test section with flags `-D`, `-Q`, `-K` or avoid building the
+containers (useful if they are already built) with `-B`.
+
+## Result / Output
+
+At the end of the tests a table will be printed, in CSV format, like this:
+```csv
+test;client,batchsize,replication,Write TX/s,Write KV/s
+kv;1;1;no;31;31
+kv;10;1;no;261;261
+kv;100;1;no;2218;2218
+kv;1;100;no;2717;271700
+kv;10;100;no;21033;2103300
+[...]
+doc;1;100;async;14.9457;1494.568
+doc;10;100;async;16.7671;1676.706
+doc;100;100;async;18.2019;1820.194
+doc;1;1000;async;11.4383;11438.330
+doc;10;1000;async;12.8969;12896.903
+doc;100;1000;async;13.6866;13686.639
+```
+
+This table is also saved in file `result.csv`. It shows all tests performed, with the indication of
+the subsystem (kv, sql, doc), the number of clients, the batchsize, the type of replication setup and
+(finally) the number of transaction per second and the number of document (KV pair, SQL lines or JSON
+document) inserted per second.
+
+## Test matrix
+
+Three set of tests are executed: key/value inserts (KV), SQL inserts (SQL) and json document
+insertion, using HTTP APIs. For each set, we execute multiple runs, with different number of concurrent
+client, and with different batch size.
+We use runs with 1, 10, 100 clients and batch size 1, 100, 1000. So each single test is executed 9 times.
+Each run has a fixed duration, which by default is 10 minutes.
+
+### Replication
+On top of that, each test matrix is run three times:
+- on a single immudb instance,
+- on an asynchronous replicated couple of instances,
+- and on a synchronous replicated couple of instance.
+
+So every subsystem (KV, SQL, DOC) performs 27 tests, each lasting by default 10 minutes, for a total of
+81 tests, or 810 minutes. Plus startup/teardown time. So the whole test procedure can easily last 14 hours.
+
+## Immudb Version tested
+
+By default, the current immudb code is compiled and tested. It is possible to have a different
+immudb version, by using a specifically crafted Dockerfile to create a custom immudb docker.
+As a reference, we have the `Dockerfile-141` file that builds immudb 1.4.1
+
+To use the custom dockerfile, simply set the `DOCKERFILE` variable (i.e. `export DOCKERFILE=Dockerfile-1.4.1`)
+before running the script.
+
+## Docker architecture
+
+We use docker-compose to build and run the tests
+
+### Containers
+The server is built using the `Dockerfile` in the present directory. It compiles immudb from the
+very same branch that is checked out, adding a startup scripts that takes care of tuning the server
+startup parameters, creating a testing database with correct settings and, if required, needed replication
+options.
+
+The client docker checks out the testing tools from the `immudb-tools` repository and builds a client
+that contains all the binaries and scripts needed for testing.
+
+### Running the tests
+
+Docker compose "recycles" the same server container for all different replication scenario, just
+providing the startup script with the correct option.
+The test is then run by providing the client container the correct entrypoint for the test that is
+being performed.
+

--- a/test/release_perf_test/docker-compose.yaml
+++ b/test/release_perf_test/docker-compose.yaml
@@ -1,0 +1,55 @@
+version: '3.9'
+services:
+    immudb-perftest:
+        container_name: immudb-perftest
+        image: immudb-perftest
+        build:
+            context: ../..
+            dockerfile: test/release_perf_test/${DOCKERFILE:-Dockerfile}
+    immudb-tools:
+        container_name: immudb-tools
+        image: immudb-tools
+        build:
+            context: .
+            dockerfile: ./Dockerfile.tools
+
+    immudb-standalone:
+        container_name: immudb-standalone
+        image: immudb-perftest
+        command: ["standalone"]
+
+    immudb-async-main:
+        container_name: immudb-async-main
+        image: immudb-perftest
+        command: ["asyncmain"]
+    immudb-async-replica:
+        container_name: immudb-async-replica
+        image: immudb-perftest
+        command: ["asyncreplica"]
+
+    immudb-sync-main:
+        container_name: immudb-sync-main
+        image: immudb-perftest
+        command: ["syncmain"]
+    immudb-sync-replica:
+        container_name: immudb-sync-replica
+        image: immudb-perftest
+        command: ["syncreplica"]
+
+    immudb-tools-kv:
+        container_name: immudb-tools
+        image: immudb-tools
+        entrypoint:
+        - "/usr/local/bin/stresser2"
+
+    immudb-tools-sql:
+        container_name: immudb-tools
+        image: immudb-tools
+        entrypoint:
+        - "/usr/local/bin/paralsql"
+
+    immudb-tools-web-api:
+        container_name: immudb-tools
+        image: immudb-tools
+        working_dir: "/usr/local/immudb-tools/test-web-api/"
+        entrypoint: ['python', 'main.py']

--- a/test/release_perf_test/doctest.sh
+++ b/test/release_perf_test/doctest.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+docker-compose build immudb-perftest immudb-tools
+docker-compose up -d immudb-standalone
+docker-compose run immudb-tools-web-api -b http://immudb-standalone:8080 --duration 10 -w 1 -s 1

--- a/test/release_perf_test/runme.sh
+++ b/test/release_perf_test/runme.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+
+DURATION=600
+BUILD=1
+DOCTEST=1
+SQLTEST=1
+KVTEST=1
+
+while getopts "hd:DQKB" arg; do
+  case $arg in
+    d)
+      DURATION=$OPTARG
+      ;;
+    B)
+      unset BUILD
+      ;;
+    D)
+      unset DOCKTEST
+      ;;
+    Q)
+      unset SQLTEST
+      ;;
+    K)
+      unset KVTEST
+      ;;
+    h | *)
+      echo "Usage:"
+      echo "$0 [ -d duration ] [ -B ] [ -D ] [ -Q ] [ -K ]"
+      echo "        -d duration: duration of each test in seconds"
+      echo "        -B (nobuild): skip building of containers"
+      echo "        -D (nodocument): skip document test"
+      echo "        -Q (nosql): skip sql test"
+      echo "        -K (nokv): skip KV test"
+      exit 1
+      ;;
+  esac
+done
+
+if [ $BUILD ]
+then
+docker-compose build immudb-perftest immudb-tools
+fi
+CSV_LINES=( 'test,client,batchsize,replication,Write TX/s,Write KV/s' )
+
+
+function print_result() {
+	local REPL=$1
+	shift
+	local STATS=("$@")
+	# print resulting table
+	IDX=0
+	echo "#---"
+	echo "clients	batchsize	repl.	Write TX/s	Write KV/s"
+	for BATCHSIZE in 1 100 1000
+	do
+		for WORKERS in 1 10 100
+		do
+		TXS=${STATS[IDX]}
+		echo "$WORKERS	$BATCHSIZE		$REPL	$TXS	$((TXS*BATCHSIZE))"
+		IDX=$((IDX+1))
+		done
+done
+}
+
+function test_matrix_kv() {
+	SRV=$1
+	ADDR=$2
+	REPL=$3
+	STATS=()
+	> /tmp/runme.log
+	for BATCHSIZE in 1 100 1000
+	do
+		for WORKERS in 1 10 100
+		do
+		echo "BATCHSIZE $BATCHSIZE WORKERS $WORKERS REPL $REPL" | tee -a /tmp/runme.log
+		docker-compose up -d $SRV
+		sleep 5
+		docker-compose run immudb-tools-kv \
+			-addr $ADDR -db perf -duration $DURATION \
+			-read-workers 0 -read-batchsize 0 -write-speed 0 \
+			-write-workers $WORKERS -write-batchsize $BATCHSIZE \
+			-silent -summary 2>&1 | tee -a /tmp/runme.log
+		TXS=$(tail -n1 /tmp/runme.log|grep -F "TOTAL WRITE"|grep -Eo '[0-9]+ Txs/s'|cut -d ' ' -f 1)
+		STATS+=( $TXS )
+		CSVLINE="kv;$WORKERS;$BATCHSIZE;$REPL;$TXS;$((TXS*BATCHSIZE))"
+		CSV_LINES+=( $CSVLINE )
+		echo "TXS: $TXS, STATS: ${STATS[*]}"
+		docker-compose down --timeout 2
+		done
+	done
+	print_result "$REPL" "${STATS[@]}"
+}
+
+function test_matrix_sql() {
+	SRV=$1
+	ADDR=$2
+	REPL=$3
+	STATS=()
+	> /tmp/runme.log
+	for BATCHSIZE in 1 100 1000
+	do
+		for WORKERS in 1 10 100
+		do
+		echo "BATCHSIZE $BATCHSIZE WORKERS $WORKERS REPL $REPL" | tee -a /tmp/runme.log
+		docker-compose up -d $SRV
+		sleep 5
+		docker-compose run immudb-tools-sql \
+			-addr $ADDR -db perf -duration $DURATION \
+			-workers $WORKERS -txsize 1 -insert-size $BATCHSIZE \
+			2>&1 | tee -a /tmp/runme.log
+		WRS=$(tail -n1 /tmp/runme.log|grep -F "Total Writes"|grep -Eo '[0-9.]+ writes/s'|cut -d ' ' -f 1)
+		TXS=$(tail -n1 /tmp/runme.log|awk "/Total Writes/{print \$9/$BATCHSIZE}")
+		TRUNC_TRS=$(echo $WRS|grep -Eo '^[0-9]+')
+		STATS+=( $TRUNC_TRS )
+		CSVLINE="sql;$WORKERS;$BATCHSIZE;$REPL;$TXS;$WRS"
+		CSV_LINES+=( $CSVLINE )
+		echo "TXS: $TXS, WRS: $WRS, STATS: ${STATS[*]}"
+		docker-compose down --timeout 2
+		done
+	done
+	print_result "$REPL" "${STATS[@]}"
+}
+
+function test_matrix_doc() {
+	SRV=$1
+	ADDR=$2
+	REPL=$3
+	STATS=()
+	> /tmp/runme.log
+	for BATCHSIZE in 1 100 1000
+	do
+		for WORKERS in 1 10 100
+		do
+		echo "BATCHSIZE $BATCHSIZE WORKERS $WORKERS REPL $REPL" | tee -a /tmp/runme.log
+		docker-compose up -d $SRV
+		sleep 5
+		docker-compose run immudb-tools-web-api \
+			-b http://$ADDR:8080 --duration $DURATION -db perf \
+			-w $WORKERS -s $BATCHSIZE \
+			2>&1 | tee -a /tmp/runme.log
+		TX=$(awk '/TX:/{print $7}' /tmp/runme.log | tail -n 1)
+		TXS=$((TX/DURATION))
+		WRS=$((TX*BATCHSIZE/DURATION))
+		STATS+=( $TXS )
+		CSVLINE="doc;$WORKERS;$BATCHSIZE;$REPL;$TXS;$WRS"
+		CSV_LINES+=( $CSVLINE )
+		echo "TXS: $TXS, WRS: $WRS, STATS: ${STATS[*]}"
+		docker-compose down --timeout 2
+		done
+	done
+	print_result "$REPL" "${STATS[@]}"
+}
+if [ $KVTEST ]
+then
+test_matrix_kv "immudb-standalone" "immudb-standalone" "no"
+test_matrix_kv "immudb-async-main immudb-async-replica" "immudb-async-main" "async"
+test_matrix_kv "immudb-sync-main immudb-sync-replica" "immudb-sync-main" "sync"
+fi
+
+if [ $SQLTEST ]
+then
+test_matrix_sql "immudb-standalone" "immudb-standalone" "no"
+test_matrix_sql "immudb-async-main immudb-async-replica" "immudb-async-main" "async"
+# FIXME sql + sync is currently broken
+#test_matrix_sql "immudb-sync-main immudb-sync-replica" "immudb-sync-main" "sync"
+fi
+
+if [ $DOCTEST ]
+then
+test_matrix_doc "immudb-standalone" "immudb-standalone" "no"
+test_matrix_doc "immudb-async-main immudb-async-replica" "immudb-async-main" "async"
+test_matrix_doc "immudb-sync-main immudb-sync-replica" "immudb-sync-main" "sync"
+fi
+
+printf '%s\n' "${CSV_LINES[@]}"
+printf '%s\n' "${CSV_LINES[@]}" > result.csv
+
+

--- a/test/release_perf_test/startup.sh
+++ b/test/release_perf_test/startup.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+IMMUDB=/usr/local/bin/immudb
+IMMUADMIN=/usr/local/bin/immuadmin
+
+if [ -z "$1" ]
+then
+MODE="standalone"
+else
+MODE=$1
+fi
+
+echo "Startup mode '$MODE'"
+
+case $MODE in
+  standalone)
+  (
+  sleep 3
+  echo -n immudb | $IMMUADMIN login immudb
+  $IMMUADMIN database create perf --max-commit-concurrency 120
+  ) &
+  $IMMUDB --dir /var/lib/immudb --web-server
+  ;;
+
+  asyncmain)
+  (
+  sleep 3
+  echo -n immudb | $IMMUADMIN login immudb
+  $IMMUADMIN database create perf --max-commit-concurrency 120
+  ) &
+  $IMMUDB --dir /var/lib/immudb --max-sessions 120 --web-server
+  ;;
+  asyncreplica)
+  (
+  sleep 3
+  echo -n immudb | $IMMUADMIN login immudb
+  $IMMUADMIN database create perf \
+    --max-commit-concurrency 120 \
+    --replication-is-replica \
+    --replication-primary-database perf \
+    --replication-primary-host immudb-async-main \
+    --replication-primary-password immudb \
+    --replication-primary-port 3322 \
+    --replication-primary-username immudb
+  ) &
+  $IMMUDB --dir /var/lib/immudb --web-server
+  ;;
+
+  syncmain)
+  (
+  sleep 3
+  echo -n immudb | $IMMUADMIN login immudb
+  $IMMUADMIN database create perf --max-commit-concurrency 120 \
+    --replication-sync-enabled \
+    --replication-sync-acks 1
+  ) &
+  $IMMUDB --dir /var/lib/immudb --max-sessions 120
+  ;;
+  syncreplica)
+  (
+  sleep 3
+  echo -n immudb | $IMMUADMIN login immudb
+  $IMMUADMIN database create perf \
+    --max-commit-concurrency 120 \
+    --replication-sync-enabled \
+    --replication-is-replica \
+    --replication-primary-database perf \
+    --replication-primary-host immudb-sync-main \
+    --replication-primary-password immudb \
+    --replication-primary-port 3322 \
+    --replication-primary-username immudb
+  ) &
+  $IMMUDB --dir /var/lib/immudb
+  ;;
+  *)
+  echo "Wrong startup mode ($MODE)"
+  exit 1
+  ;;
+esac
+


### PR DESCRIPTION


This PR adds an automated suite for running a matrix of tests, with different batch sizes, different number of concurrent client and different replication settings, for KV, SQL and Json document subsystems.

Since the branch I was working on has some issue merging (some rebasing, maybe) I've created a new branch with all significant files
