### PR TITLE
fix(embedded/appendable): explicit freebsd build clauses

### DIFF
--- a/embedded/appendable/fileutils/fileutils_unix_nonlinux.go
+++ b/embedded/appendable/fileutils/fileutils_unix_nonlinux.go
@@ -1,5 +1,5 @@
-//go:build unix && !linux && !darwin
-// +build unix,!linux,!darwin
+//go:build unix && !linux && !darwin && !freebsd
+// +build unix,!linux,!darwin,!freebsd
 
 /*
 Copyright 2023 Codenotary Inc. All rights reserved.


### PR DESCRIPTION
freebsd binaries were correctly build during the release but it may depend on the go version

this PR aims to fix #1716 