### PR TITLE
feat: add entrypoint script, which can create a user and related database, to the full Docker image

### DIFF
--- a/build/Dockerfile.full
+++ b/build/Dockerfile.full
@@ -13,6 +13,7 @@ LABEL org.opencontainers.image.authors="Codenotary Inc. <info@codenotary.com>"
 COPY --from=build /src/immudb /usr/sbin/immudb
 COPY --from=build /src/immuadmin /src/immuclient /usr/local/bin/
 COPY --from=build "/etc/ssl/certs/ca-certificates.crt" "/etc/ssl/certs/ca-certificates.crt"
+COPY tools/user_db/create_user_db.sh /usr/local/bin/create_user_db.sh
 
 ARG IMMU_UID="3322"
 ARG IMMU_GID="3322"
@@ -29,6 +30,9 @@ ENV IMMUDB_HOME="/usr/share/immudb" \
     IMMUDB_DEVMODE="true" \
     IMMUDB_MAINTENANCE="false" \
     IMMUDB_ADMIN_PASSWORD="immudb" \
+    IMMUDB_USER="" \
+    IMMUDB_PASSWORD="" \
+    IMMUDB_DATABASE="" \
     IMMUDB_PGSQL_SERVER="true" \
     IMMUADMIN_TOKENFILE="/var/lib/immudb/admin_token"
 
@@ -38,7 +42,15 @@ RUN addgroup --system --gid $IMMU_GID immu && \
     mkdir -p "$IMMUDB_DIR" && \
     chown -R immu:immu "$IMMUDB_HOME" "$IMMUDB_DIR" && \
     chmod -R 777 "$IMMUDB_HOME" "$IMMUDB_DIR" && \
-    chmod +x /usr/sbin/immudb /usr/local/bin/immuadmin /usr/local/bin/immuclient
+    chmod +x /usr/sbin/immudb /usr/local/bin/immuadmin /usr/local/bin/immuclient && \
+    mkdir -p /var/run/immudb && \
+    chown immu:immu /var/run/immudb && \
+    chmod 775 /var/run/immudb && \
+    chmod 555 /usr/local/bin/create_user_db.sh
+
+RUN apt-get update && \
+    apt-get install -y expect && \
+    apt-get clean
 
 EXPOSE 3322
 EXPOSE 9497
@@ -47,4 +59,4 @@ EXPOSE 5432
 
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD [ "/usr/local/bin/immuadmin", "status" ]
 USER immu
-ENTRYPOINT ["/usr/sbin/immudb"]
+ENTRYPOINT ["/usr/local/bin/create_user_db.sh", "/usr/sbin/immudb"]

--- a/build/Dockerfile.full
+++ b/build/Dockerfile.full
@@ -32,6 +32,7 @@ ENV IMMUDB_HOME="/usr/share/immudb" \
     IMMUDB_ADMIN_PASSWORD="immudb" \
     IMMUDB_USER="" \
     IMMUDB_PASSWORD="" \
+    IMMUDB_PASSWORD_FILE="" \
     IMMUDB_DATABASE="" \
     IMMUDB_PGSQL_SERVER="true" \
     IMMUADMIN_TOKENFILE="/var/lib/immudb/admin_token"

--- a/tools/user_db/create_user_db.sh
+++ b/tools/user_db/create_user_db.sh
@@ -26,6 +26,18 @@ INIT() {
       CREATE_USER=1
    fi
 
+   # Check if a secret file for the user password was specified.
+   if [ -n "$IMMUDB_PASSWORD_FILE" ]
+   then
+      if [ -f "$IMMUDB_PASSWORD_FILE" ]
+      then
+         IMMUDB_PASSWORD=$(cat "$IMMUDB_PASSWORD_FILE" | tr -d \d\r)
+      else
+         echo "file ${IMMUDB_PASSWORD_FILE} specified for IMMUDB_PASSWORD_FILE does not exist"
+         return 1
+      fi
+   fi
+   
    # Run immudb on localhost.
    if [ $CREATE_USER -eq 0 ] && [ $CREATE_DATABASE -eq 0 ]
    then

--- a/tools/user_db/create_user_db.sh
+++ b/tools/user_db/create_user_db.sh
@@ -1,0 +1,117 @@
+#!/bin/sh
+
+# PID file to use for an initialization immudb instance.
+INIT_PID_FILE=/var/run/immudb/init.pid
+
+# Trap interrupts.
+# This is required to exit the waiting loops in the init function.
+trap "echo aborted; exit;" INT TERM
+
+INIT() {
+   # If an initial user or database to be created is configured,
+   # run immudb on localhost on perform the necessary actions.
+
+   # Determine the configured user database.
+   USER_DATABASE="${IMMUDB_DATABASE:-defaultdb}"
+
+   # Test if a database and/or user should be created.
+   CREATE_DATABASE=0
+   if [ $USER_DATABASE != "defaultdb" ]
+   then
+      CREATE_DATABASE=1
+   fi
+   CREATE_USER=0
+   if [ -n "$IMMUDB_USER" ] && [ -n "$IMMUDB_PASSWORD" ]
+   then
+      CREATE_USER=1
+   fi
+
+   # Run immudb on localhost.
+   if [ $CREATE_USER -eq 0 ] && [ $CREATE_DATABASE -eq 0 ]
+   then
+      return
+   fi
+   echo "starting init immudb instance on localhost."
+   if ! $@ --address 127.0.0.1 -d --pidfile $INIT_PID_FILE
+   then
+      echo "starting init immudb instance failed"
+      return 1
+   fi
+
+   # Wait until the server is running.
+   until immuadmin status
+   do
+      echo "waiting for immudb instance on localhost to be ready"
+      sleep 1
+   done
+
+   # Log into the immudb instance.
+   echo -n "$IMMUDB_ADMIN_PASSWORD" | immuadmin login immudb
+
+   # Create it, if it is not the database created by default.
+   if [ $CREATE_DATABASE -eq 1 ]
+   then
+      echo "creating uesr database $IMMUDB_DATABASE"
+      if ! immuadmin database create $IMMUDB_DATABASE
+      then
+        echo "creating database $IMMUDB_DATABASE failed"
+        return 1
+      fi
+   fi
+   # Create a user if configured and grant it access to the user database.
+   if [ $CREATE_USER -eq 1 ]
+   then
+      echo "creating user $IMMUDB_USER"
+      # Assemble expect script to create the user.
+      CREATE_USER_SCRIPT="
+spawn immuadmin user create $IMMUDB_USER readwrite $USER_DATABASE
+expect \"Choose a password for $IMMUDB_USER:\"
+send \"$IMMUDB_PASSWORD\r\"
+expect {
+    timeout     { exit 1 }
+    eof         { exit 1 }
+    \"Password does not meet the requirements.\"  { exit 1 }
+    \"Confirm password:\"
+}
+send \"$IMMUDB_PASSWORD\r\"
+catch wait result
+exit [lindex \$result 3]
+"
+      if ! expect -c "$CREATE_USER_SCRIPT"
+      then
+        echo "creating user $IMMUDB_USER failed"
+        return 1
+      fi
+   fi
+
+   # Stop the init instance.
+   if [ -f $INIT_PID_FILE ]
+   then
+      echo "stopping init immudb instance on localhost."
+      # Log out of the instance.
+      immuadmin logout
+      # Kill the immudb instance.
+      INIT_PID=$(cat $INIT_PID_FILE)
+      kill $INIT_PID
+      # Wait for the proccess to exit.
+      while kill -0 $INIT_PID 2> /dev/null
+      do
+         echo "waiting for init immudb instance to stop"
+         sleep 1
+      done
+   fi
+}
+
+# Check if this is the first time immudb is run.
+if [ ! -f "$IMMUDB_DIR/immudb.identifier" ]
+then
+    # Initialize a user database from environment variables.
+    echo "initialilzing database"
+    if ! INIT $@
+    then
+       echo "initializing database failed"
+       exit 1
+    fi
+fi
+
+exec $@


### PR DESCRIPTION
This PR adds an entrypoint script to the full container image. This script creates a database and a user which is granted readwrite access to this database. The intention of this change is to facilitate deployments. It allows to define a user without admin priveleges to be used by other services directly in e.g. a docker-compose.yml oder a helm values.yml file and create it automatically. Currently only an admin user is available during the deployment, but using an admin user for services accessing the database is not a preferred option.

The credentials of the to be crated user as well as the name of the database can be set using the environment variables:
   * IMMUDB_USER
   * IMMUDB_PASSWORD
   * IMMUDB_PASSWORD_FILE
   * IMMUDB_DATABASE
   
Thereby IMMUDB_PASSWORD_FILE specifies a file that contains the password.