### PR TITLE
test: use `t.Setenv` to set env vars in tests

### DIFF
--- a/embedded/logger/memory_test.go
+++ b/embedded/logger/memory_test.go
@@ -18,7 +18,6 @@ package logger_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/codenotary/immudb/embedded/logger"
@@ -26,9 +25,7 @@ import (
 )
 
 func TestMemoryLogger(t *testing.T) {
-
-	os.Setenv("LOG_LEVEL", "error")
-	defer os.Unsetenv("LOG_LEVEL")
+	t.Setenv("LOG_LEVEL", "error")
 
 	ml := logger.NewMemoryLogger()
 	defer ml.Close()

--- a/embedded/logger/simple_test.go
+++ b/embedded/logger/simple_test.go
@@ -20,15 +20,14 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestSimpleLogger(t *testing.T) {
-	os.Setenv("LOG_LEVEL", "error")
-	defer os.Unsetenv("LOG_LEVEL")
+	t.Setenv("LOG_LEVEL", "error")
+
 	name := "test-simple-logger"
 	outputWriter := bytes.NewBufferString("")
 	sl := NewSimpleLogger(name, outputWriter)
@@ -63,13 +62,24 @@ func TestSimpleLogger(t *testing.T) {
 func TestLogLevelFromEnvironment(t *testing.T) {
 	defaultLevel := LogLevelFromEnvironment()
 	require.Equal(t, LogInfo, defaultLevel)
-	defer os.Unsetenv("LOG_LEVEL")
-	os.Setenv("LOG_LEVEL", "error")
-	require.Equal(t, LogError, LogLevelFromEnvironment())
-	os.Setenv("LOG_LEVEL", "warn")
-	require.Equal(t, LogWarn, LogLevelFromEnvironment())
-	os.Setenv("LOG_LEVEL", "info")
-	require.Equal(t, LogInfo, LogLevelFromEnvironment())
-	os.Setenv("LOG_LEVEL", "debug")
-	require.Equal(t, LogDebug, LogLevelFromEnvironment())
+
+	t.Run("error", func(t *testing.T) {
+		t.Setenv("LOG_LEVEL", "error")
+		require.Equal(t, LogError, LogLevelFromEnvironment())
+	})
+
+	t.Run("warn", func(t *testing.T) {
+		t.Setenv("LOG_LEVEL", "warn")
+		require.Equal(t, LogWarn, LogLevelFromEnvironment())
+	})
+
+	t.Run("info", func(t *testing.T) {
+		t.Setenv("LOG_LEVEL", "info")
+		require.Equal(t, LogInfo, LogLevelFromEnvironment())
+	})
+
+	t.Run("debug", func(t *testing.T) {
+		t.Setenv("LOG_LEVEL", "debug")
+		require.Equal(t, LogDebug, LogLevelFromEnvironment())
+	})
 }

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -19,7 +19,6 @@ package errors_test
 import (
 	stdErrors "errors"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/codenotary/immudb/pkg/errors"
@@ -28,8 +27,7 @@ import (
 )
 
 func Test_Immuerror(t *testing.T) {
-	os.Setenv("LOG_LEVEL", "debug")
-	defer os.Unsetenv("LOG_LEVEL")
+	t.Setenv("LOG_LEVEL", "debug")
 
 	cause := "cause error"
 	err := errors.New(cause)
@@ -41,12 +39,10 @@ func Test_Immuerror(t *testing.T) {
 	require.ErrorIs(t, err, err.Cause())
 	require.Equal(t, err.RetryDelay(), int32(0))
 	require.NotNil(t, err.Stack())
-
 }
 
 func Test_WrappingError(t *testing.T) {
-	os.Setenv("LOG_LEVEL", "debug")
-	defer os.Unsetenv("LOG_LEVEL")
+	t.Setenv("LOG_LEVEL", "debug")
 
 	cause := "std error"
 	err := errors.New(cause)
@@ -65,8 +61,7 @@ func Test_WrappingError(t *testing.T) {
 }
 
 func Test_WrappingImmuerror(t *testing.T) {
-	os.Setenv("LOG_LEVEL", "debug")
-	defer os.Unsetenv("LOG_LEVEL")
+	t.Setenv("LOG_LEVEL", "debug")
 
 	cause := "cause error"
 	err := errors.New(cause)
@@ -83,8 +78,7 @@ func Test_WrappingImmuerror(t *testing.T) {
 }
 
 func Test_ImmuerrorIs(t *testing.T) {
-	os.Setenv("LOG_LEVEL", "debug")
-	defer os.Unsetenv("LOG_LEVEL")
+	t.Setenv("LOG_LEVEL", "debug")
 
 	cause := "cause error"
 	err := errors.New(cause).WithCode(errors.CodInternalError)
@@ -104,8 +98,7 @@ func Test_ImmuerrorIs(t *testing.T) {
 }
 
 func Test_CauseComparisonWrappedError(t *testing.T) {
-	os.Setenv("LOG_LEVEL", "debug")
-	defer os.Unsetenv("LOG_LEVEL")
+	t.Setenv("LOG_LEVEL", "debug")
 
 	cause := "std error"
 	err := errors.New(cause)
@@ -123,8 +116,7 @@ func Test_CauseComparisonWrappedError(t *testing.T) {
 }
 
 func Test_CauseComparisonError(t *testing.T) {
-	os.Setenv("LOG_LEVEL", "debug")
-	defer os.Unsetenv("LOG_LEVEL")
+	t.Setenv("LOG_LEVEL", "debug")
 
 	cause := "std error"
 	err := errors.New(cause).WithCode(errors.CodSqlclientUnableToEstablishSqlConnection)
@@ -141,8 +133,7 @@ func Test_CauseComparisonError(t *testing.T) {
 }
 
 func Test_WrappingImmuerrorWithKnowCode(t *testing.T) {
-	os.Setenv("LOG_LEVEL", "debug")
-	defer os.Unsetenv("LOG_LEVEL")
+	t.Setenv("LOG_LEVEL", "debug")
 
 	cause := "cause error"
 	err := errors.New(cause)

--- a/pkg/errors/grpc_status_test.go
+++ b/pkg/errors/grpc_status_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package errors
 
 import (
-	"os"
 	"testing"
 
 	"github.com/codenotary/immudb/pkg/api/schema"
@@ -59,8 +58,7 @@ func TestWrappedError_GRPCStatusEmptyCause(t *testing.T) {
 }
 
 func TestImmuError_GRPCStatusWithStack(t *testing.T) {
-	os.Setenv("LOG_LEVEL", "debug")
-	defer os.Unsetenv("LOG_LEVEL")
+	t.Setenv("LOG_LEVEL", "debug")
 
 	ie := &immuError{
 		code:       "",

--- a/pkg/integration/error_test.go
+++ b/pkg/integration/error_test.go
@@ -18,7 +18,6 @@ package integration
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/codenotary/immudb/pkg/client"
@@ -27,13 +26,11 @@ import (
 )
 
 func TestGRPCError(t *testing.T) {
-	os.Setenv("LOG_LEVEL", "debug")
-	defer os.Unsetenv("LOG_LEVEL")
+	t.Setenv("LOG_LEVEL", "debug")
 
 	bs, cli, _ := setupTestServerAndClientWithToken(t)
 
 	t.Run("errors with token-based auth", func(t *testing.T) {
-
 		_, err := cli.Login(context.Background(), []byte(`immudb`), []byte(`wrong`))
 
 		require.Equal(t, err.(errors.ImmuError).Error(), "invalid user name or password")
@@ -41,7 +38,6 @@ func TestGRPCError(t *testing.T) {
 		require.Equal(t, err.(errors.ImmuError).Code(), errors.CodSqlserverRejectedEstablishmentOfSqlconnection)
 		require.Equal(t, int32(0), err.(errors.ImmuError).RetryDelay())
 		require.NotNil(t, err.(errors.ImmuError).Stack())
-
 	})
 
 	t.Run("errors with session-based auth", func(t *testing.T) {


### PR DESCRIPTION
Starting from Go 1.17, we can use `t.Setenv` to set environment variable in test. The environment variable is automatically restored to its original value when the test and all its subtests complete. This ensures that each test does not start with leftover environment variables from previous completed tests.

Reference: https://pkg.go.dev/testing#T.Setenv

```go
func TestFoo(t *testing.T) {
	// before
	os.Setenv(key, "new value")
	defer os.Unsetenv(key)
	
	// after
	t.Setenv(key, "new value")
}
```