### PR TITLE
fix: insertion ts for key-values should not be equal to the current root ts

### DIFF
--- a/embedded/tbtree/tbtree.go
+++ b/embedded/tbtree/tbtree.go
@@ -1633,7 +1633,7 @@ func (t *TBtree) bulkInsert(kvts []*KVT) error {
 		if t == 0 {
 			// zero-valued timestamps are associated with current time plus one
 			t = currTs + 1
-		} else if kvt.T < currTs {
+		} else if kvt.T <= currTs { // insertion with a timestamp older or equal to the current timestamp should not be allowed
 			return fmt.Errorf("%w: specific timestamp is older than root's current timestamp", ErrIllegalArguments)
 		}
 

--- a/embedded/tbtree/tbtree_test.go
+++ b/embedded/tbtree/tbtree_test.go
@@ -1545,6 +1545,23 @@ func TestMultiTimedBulkInsertion(t *testing.T) {
 		require.Equal(t, initialTs, tbtree.Ts())
 	})
 
+	t.Run("bulk-insertion of the same key timestamp equal to current timestamp of root should not be possible", func(t *testing.T) {
+		_, _, err = tbtree.Flush()
+		require.NoError(t, err)
+
+		err = tbtree.Insert([]byte("key3_1"), []byte("value3_1"))
+		require.NoError(t, err)
+
+		currTs := tbtree.Ts()
+
+		kvts := []*KVT{
+			{K: []byte("key3_2"), V: []byte("value3_2"), T: currTs},
+		}
+
+		err = tbtree.BulkInsert(kvts)
+		require.ErrorIs(t, err, ErrIllegalArguments)
+	})
+
 	err = tbtree.Close()
 	require.NoError(t, err)
 }


### PR DESCRIPTION
This PR addresses an issue related to the insertion timestamp (ts) of key-value pairs within the tbtree. The problem is that the insertion ts for key-values was can be equal to the current root ts, which can cause unexpected behavior and inconsistencies in the data records.

I have added a test case to validate the correctness of this fix and to prevent any potential regressions in the future.