### PR TITLE
feat(pkg/server): add support of underscore in db name

### DIFF
--- a/pkg/integration/database_creation_test.go
+++ b/pkg/integration/database_creation_test.go
@@ -155,3 +155,13 @@ func TestCreateDatabaseV2(t *testing.T) {
 	_, err = client.UpdateDatabaseV2(ctx, "db1", &schema.DatabaseNullableSettings{})
 	require.NoError(t, err)
 }
+
+func TestCreateDatabaseWithUnderscoreCharacter(t *testing.T) {
+	_, client, ctx := setupTestServerAndClient(t)
+
+	_, err := client.CreateDatabaseV2(ctx, "db_with_", nil)
+	require.NoError(t, err)
+
+	_, err = client.UseDatabase(ctx, &schema.Database{DatabaseName: "db_with_"})
+	require.NoError(t, err)
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1585,6 +1585,7 @@ func isValidDBName(dbName string) error {
 		switch {
 		case unicode.IsLower(ch):
 		case unicode.IsDigit(ch):
+		case ch == '_':
 		case unicode.IsPunct(ch) || unicode.IsSymbol(ch):
 			hasSpecial = true
 		default:

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1889,6 +1889,9 @@ func TestServerIsValidDBName(t *testing.T) {
 
 	err = isValidDBName(strings.Repeat("a", 32))
 	require.NoError(t, err)
+
+	err = isValidDBName("_")
+	require.NoError(t, err)
 }
 
 func TestServerMandatoryAuth(t *testing.T) {


### PR DESCRIPTION
This should solve the #1770. This change introduces the support of an underscore in the database name.  

- `pkg/server/server.go` - adds an additional case to checking the character validation.
- `pkg/integration/database_creation_test.go#159` - a new test for db creation with a name containing the `_`
- `pkg/server/server_test.go#1892` - unit test which tests the underscore in the isValidDBName

Signed-off-by: Martin Jirku <martin@jirku.sk>