### PR TITLE
fix: source /etc/sysconfig/immudb on AWS EC2 startup

### DIFF
--- a/tools/rndpass/startup.sh
+++ b/tools/rndpass/startup.sh
@@ -1,9 +1,12 @@
 #!/bin/sh
-
+if [ -f /etc/sysconfig/immudb ]
+then
+    source /etc/sysconfig/immudb
+fi
 if [ -z "$IMMUDB_ADMIN_PASSWORD" ]
 then
-   export IMMUDB_ADMIN_PASSWORD=`tr -cd '[:alnum:].,:;/@_=' < /dev/urandom|head -c 16`
+   IMMUDB_ADMIN_PASSWORD=`tr -cd '[:alnum:].,:;/@_=' < /dev/urandom|head -c 16`
    echo "Generated immudb password: $IMMUDB_ADMIN_PASSWORD"
 fi
-
+export IMMUDB_ADMIN_PASSWORD
 exec $@


### PR DESCRIPTION
Fix https://github.com/codenotary/immudb/issues/1868: user can just set
/etc/sysconfig/immudb with desired env variables.
