### PR TITLE
Allow the user to force unsafe password in immuadmin

### DIFF
--- a/cmd/helper/terminal.go
+++ b/cmd/helper/terminal.go
@@ -2,11 +2,12 @@ package helper
 
 import (
 	"fmt"
-	"golang.org/x/crypto/ssh/terminal"
 	"io"
 	"io/ioutil"
 	"os"
 	"strings"
+
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 type terminalReader struct {

--- a/cmd/immuadmin/command/commandline.go
+++ b/cmd/immuadmin/command/commandline.go
@@ -19,6 +19,7 @@ package immuadmin
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/codenotary/immudb/pkg/client/homedir"
 	"github.com/codenotary/immudb/pkg/client/tokenservice"
@@ -54,6 +55,7 @@ type commandline struct {
 	config         c.Config
 	immuClient     client.ImmuClient
 	passwordReader c.PasswordReader
+	terminalReader c.TerminalReader
 	context        context.Context
 	ts             tokenservice.TokenService
 	onError        func(msg interface{})
@@ -64,6 +66,7 @@ func NewCommandLine() *commandline {
 	cl := &commandline{}
 	cl.config.Name = "immuadmin"
 	cl.passwordReader = c.DefaultPasswordReader
+	cl.terminalReader = c.NewTerminalReader(os.Stdin)
 	cl.context = context.Background()
 	//
 	return cl

--- a/cmd/immuadmin/command/login.go
+++ b/cmd/immuadmin/command/login.go
@@ -59,7 +59,7 @@ func (cl *commandline) login(cmd *cobra.Command) {
 			if string(responseWarning) == auth.WarnDefaultAdminPassword {
 				c.PrintfColorW(cmd.OutOrStdout(), c.Yellow, "SECURITY WARNING: %s\n", responseWarning)
 
-				changedPassMsg, newPass, err := cl.changeUserPassword(userStr, pass)
+				changedPassMsg, newPass, err := cl.changeUserPassword(cmd, userStr, pass)
 				if err != nil {
 					cl.quit(err)
 					return err
@@ -70,7 +70,7 @@ func (cl *commandline) login(cmd *cobra.Command) {
 					return err
 				}
 
-				fmt.Fprint(cmd.OutOrStdout(), changedPassMsg)
+				fmt.Fprintln(cmd.OutOrStdout(), changedPassMsg)
 			}
 
 			return nil

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -491,7 +491,7 @@ func (s *ImmuServer) loadSystemDatabase(
 	if !s.sysDB.IsReplica() {
 		s.sysDB.SetSyncReplication(false)
 
-		adminUsername, _, err := s.insertNewUser(context.Background(), []byte(auth.SysAdminUsername), []byte(adminPassword), auth.PermissionSysAdmin, "*", false, "")
+		adminUsername, _, err := s.insertNewUser(context.Background(), []byte(auth.SysAdminUsername), []byte(adminPassword), auth.PermissionSysAdmin, "*", "")
 		if err != nil {
 			return logErr(s.Logger, "%v", err)
 		}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1385,17 +1385,15 @@ func TestServerErrors(t *testing.T) {
 	adminCtx = metadata.NewIncomingContext(context.Background(), md)
 
 	// insertNewUser errors
-	_, _, err = s.insertNewUser(context.Background(), []byte("%"), nil, 1, DefaultDBName, true, auth.SysAdminUsername)
+	_, _, err = s.insertNewUser(context.Background(), []byte("%"), nil, 1, DefaultDBName, auth.SysAdminUsername)
 	require.ErrorContains(t, err, "username can only contain letters, digits and underscores")
 
 	username := "someusername"
 	usernameBytes := []byte(username)
 	password := "$omePassword1"
 	passwordBytes := []byte(password)
-	_, _, err = s.insertNewUser(context.Background(), usernameBytes, []byte("a"), 1, DefaultDBName, true, auth.SysAdminUsername)
-	require.ErrorContains(t, err, auth.PasswordRequirementsMsg)
 
-	_, _, err = s.insertNewUser(context.Background(), usernameBytes, passwordBytes, 99, DefaultDBName, false, auth.SysAdminUsername)
+	_, _, err = s.insertNewUser(context.Background(), usernameBytes, passwordBytes, 99, DefaultDBName, auth.SysAdminUsername)
 	require.ErrorContains(t, err, "unknown permission")
 
 	// getLoggedInUserDataFromUsername errors

--- a/pkg/server/user.go
+++ b/pkg/server/user.go
@@ -151,7 +151,7 @@ func (s *ImmuServer) CreateUser(ctx context.Context, r *schema.CreateUserRequest
 		return nil, fmt.Errorf("user already exists")
 	}
 
-	_, _, err = s.insertNewUser(ctx, r.User, r.Password, r.GetPermission(), r.Database, true, loggedInuser.Username)
+	_, _, err = s.insertNewUser(ctx, r.User, r.Password, r.GetPermission(), r.Database, loggedInuser.Username)
 	if err != nil {
 		return nil, err
 	}
@@ -519,19 +519,11 @@ func (s *ImmuServer) SetActiveUser(ctx context.Context, r *schema.SetActiveUserR
 // insertNewUser inserts a new user to the system database and returns username and plain text password
 // A new password is generated automatically if passed parameter is empty
 // If enforceStrongAuth is true it checks if username and password meet security criteria
-func (s *ImmuServer) insertNewUser(ctx context.Context, username []byte, plainPassword []byte, permission uint32, database string, enforceStrongAuth bool, createdBy string) ([]byte, []byte, error) {
-	if enforceStrongAuth {
-		if !auth.IsValidUsername(string(username)) {
-			return nil, nil, status.Errorf(
-				codes.InvalidArgument,
-				"username can only contain letters, digits and underscores")
-		}
-	}
-
-	if enforceStrongAuth {
-		if err := auth.IsStrongPassword(string(plainPassword)); err != nil {
-			return nil, nil, status.Errorf(codes.InvalidArgument, "%v", err)
-		}
+func (s *ImmuServer) insertNewUser(ctx context.Context, username []byte, plainPassword []byte, permission uint32, database string, createdBy string) ([]byte, []byte, error) {
+	if !auth.IsValidUsername(string(username)) {
+		return nil, nil, status.Errorf(
+			codes.InvalidArgument,
+			"username can only contain letters, digits and underscores")
 	}
 
 	userdata := new(auth.User)


### PR DESCRIPTION
This PR is meant to relax immudb's password policy in order to match `PostgreSQL/MySQL` behavior (allow any password to be set). 

Previously, the user was required to always set a strong password either at first login or user creation time (even though the `changepassword` command allowed to set a non strong password).
A warning is still prompted to the user in the case a weak password is entered, but they can choose to ignore it.