### PR TITLE
Allow order by on non-indexed fields

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ COPY --from=build /src/immudb /usr/sbin/immudb
 COPY --from=build /src/immuadmin /usr/local/bin/immuadmin
 COPY --from=build --chown="$IMMU_UID:$IMMU_GID" /empty "$IMMUDB_HOME"
 COPY --from=build --chown="$IMMU_UID:$IMMU_GID" /empty "$IMMUDB_DIR"
+COPY --from=build --chown="$IMMU_UID:$IMMU_GID" /empty /tmp
 COPY --from=build "/etc/ssl/certs/ca-certificates.crt" "/etc/ssl/certs/ca-certificates.crt"
 
 EXPOSE 3322

--- a/embedded/sql/file_sort.go
+++ b/embedded/sql/file_sort.go
@@ -1,0 +1,385 @@
+/*
+Copyright 2024 Codenotary Inc. All rights reserved.
+
+SPDX-License-Identifier: BUSL-1.1
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://mariadb.com/bsl11/
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sql
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+	"io"
+	"os"
+	"sort"
+)
+
+type sortedChunk struct {
+	offset uint64
+	size   uint64
+}
+
+type fileSorter struct {
+	colPosBySelector map[string]int
+	colTypes         []string
+	cmp              func(r1, r2 Tuple) bool
+
+	tx          *SQLTx
+	sortBufSize int
+	sortBuf     []*Row
+	nextIdx     int
+
+	tempFile     *os.File
+	writer       *bufio.Writer
+	tempFileSize uint64
+
+	chunksToMerge []sortedChunk
+}
+
+func (s *fileSorter) update(r *Row) error {
+	if s.nextIdx == s.sortBufSize {
+		err := s.sortAndFlushBuffer()
+		if err != nil {
+			return err
+		}
+		s.nextIdx = 0
+	}
+
+	s.sortBuf[s.nextIdx] = r
+	s.nextIdx++
+
+	return nil
+}
+
+func (s *fileSorter) finalize() (resultReader, error) {
+	if s.nextIdx > 0 {
+		s.sortBuffer()
+	}
+
+	// result rows are all in memory
+	if len(s.chunksToMerge) == 0 {
+		return &bufferResultReader{
+			sortBuf: s.sortBuf[:s.nextIdx],
+		}, nil
+	}
+
+	err := s.flushBuffer()
+	if err != nil {
+		return nil, err
+	}
+
+	err = s.writer.Flush()
+	if err != nil {
+		return nil, err
+	}
+	return s.mergeAllChunks()
+}
+
+func (s *fileSorter) mergeAllChunks() (resultReader, error) {
+	currFile := s.tempFile
+
+	outFile, err := s.tx.createTempFile()
+	if err != nil {
+		return nil, err
+	}
+
+	lbuf := &bufio.Reader{}
+	rbuf := &bufio.Reader{}
+
+	lr := &fileRowReader{
+		colTypes: s.colTypes,
+		reader:   lbuf,
+	}
+	rr := &fileRowReader{
+		colTypes: s.colTypes,
+		reader:   rbuf,
+	}
+
+	chunks := s.chunksToMerge
+	for len(chunks) > 1 {
+		s.writer.Reset(outFile)
+
+		var offset uint64
+
+		newChunks := make([]sortedChunk, (len(chunks)+1)/2)
+		for i := 0; i < len(chunks)/2; i++ {
+			c1 := chunks[i*2]
+			c2 := chunks[i*2+1]
+
+			lbuf.Reset(io.NewSectionReader(currFile, int64(c1.offset), int64(c1.size)))
+			rbuf.Reset(io.NewSectionReader(currFile, int64(c2.offset), int64(c2.size)))
+
+			err := s.mergeChunks(lr, rr, s.writer)
+			if err != nil {
+				return nil, err
+			}
+
+			newChunks[i] = sortedChunk{
+				offset: offset,
+				size:   c1.size + c2.size,
+			}
+			offset += c1.size + c2.size
+		}
+
+		err := s.writer.Flush()
+		if err != nil {
+			return nil, err
+		}
+
+		if len(chunks)%2 != 0 { // copy last sorted chunk
+			lastChunk := chunks[len(chunks)-1]
+
+			_, err := io.Copy(outFile, io.NewSectionReader(currFile, int64(lastChunk.offset), int64(lastChunk.size)))
+			if err != nil {
+				return nil, err
+			}
+			newChunks[len(chunks)/2] = lastChunk
+		}
+
+		temp := currFile
+		currFile = outFile
+		outFile = temp
+
+		_, err = outFile.Seek(0, io.SeekStart)
+		if err != nil {
+			return nil, err
+		}
+
+		chunks = newChunks
+	}
+
+	return &fileRowReader{
+		colTypes:         s.colTypes,
+		colPosBySelector: s.colPosBySelector,
+		reader:           bufio.NewReader(io.NewSectionReader(currFile, 0, int64(s.tempFileSize))),
+	}, nil
+}
+
+func (s *fileSorter) mergeChunks(lr, rr *fileRowReader, writer io.Writer) error {
+	var err error
+	var lrAtEOF bool
+	var t1, t2 Tuple
+
+	for {
+		if t1 == nil {
+			t1, err = lr.ReadValues()
+			if err == io.EOF {
+				lrAtEOF = true
+				break
+			}
+
+			if err != nil {
+				return err
+			}
+		}
+
+		if t2 == nil {
+			t2, err = rr.ReadValues()
+			if err == io.EOF {
+				break
+			}
+
+			if err != nil {
+				return err
+			}
+		}
+
+		var rawData []byte
+		if s.cmp(t1, t2) {
+			rawData = lr.rowBuf.Bytes()
+			t1 = nil
+		} else {
+			rawData = rr.rowBuf.Bytes()
+			t2 = nil
+		}
+
+		_, err := writer.Write(rawData)
+		if err != nil {
+			return err
+		}
+	}
+
+	readerToCopy := lr
+	if lrAtEOF {
+		readerToCopy = rr
+	}
+
+	_, err = writer.Write(readerToCopy.rowBuf.Bytes())
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(writer, readerToCopy.reader)
+	return err
+}
+
+type resultReader interface {
+	Read() (*Row, error)
+}
+
+type bufferResultReader struct {
+	sortBuf []*Row
+	nextIdx int
+}
+
+func (r *bufferResultReader) Read() (*Row, error) {
+	if r.nextIdx == len(r.sortBuf) {
+		return nil, ErrNoMoreRows
+	}
+
+	row := r.sortBuf[r.nextIdx]
+	r.nextIdx++
+	return row, nil
+}
+
+type fileRowReader struct {
+	colPosBySelector map[string]int
+	colTypes         []SQLValueType
+	reader           io.Reader
+	rowBuf           bytes.Buffer
+}
+
+func (r *fileRowReader) ReadValues() ([]TypedValue, error) {
+	var size uint16
+	err := binary.Read(r.reader, binary.BigEndian, &size)
+	if err != nil {
+		return nil, err
+	}
+
+	r.rowBuf.Reset()
+
+	binary.Write(&r.rowBuf, binary.BigEndian, &size)
+
+	_, err = io.CopyN(&r.rowBuf, r.reader, int64(size))
+	if err != nil {
+		return nil, err
+	}
+
+	data := r.rowBuf.Bytes()
+	return decodeValues(data[2:], r.colTypes)
+}
+
+func (r *fileRowReader) Read() (*Row, error) {
+	values, err := r.ReadValues()
+	if err == io.EOF {
+		return nil, ErrNoMoreRows
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	valuesBySelector := make(map[string]TypedValue)
+	for sel, pos := range r.colPosBySelector {
+		valuesBySelector[sel] = values[pos]
+	}
+
+	row := &Row{
+		ValuesByPosition: values,
+		ValuesBySelector: valuesBySelector,
+	}
+	return row, nil
+}
+
+func decodeValues(data []byte, cols []string) ([]TypedValue, error) {
+	values := make([]TypedValue, len(cols))
+
+	var voff int
+	for i, col := range cols {
+		v, n, err := DecodeValue(data[voff:], col)
+		if err != nil {
+			return nil, err
+		}
+		voff += n
+
+		values[i] = v
+	}
+	return values, nil
+}
+
+func (s *fileSorter) sortAndFlushBuffer() error {
+	s.sortBuffer()
+	return s.flushBuffer()
+}
+
+func (s *fileSorter) sortBuffer() {
+	buf := s.sortBuf[:s.nextIdx]
+
+	sort.Slice(buf, func(i, j int) bool {
+		r1 := buf[i]
+		r2 := buf[j]
+
+		return s.cmp(r1.ValuesByPosition, r2.ValuesByPosition)
+	})
+}
+
+func (s *fileSorter) flushBuffer() error {
+	writer, err := s.tempFileWriter()
+	if err != nil {
+		return err
+	}
+
+	var chunkSize uint64
+	for _, row := range s.sortBuf[:s.nextIdx] {
+		data, err := encodeRow(row)
+		if err != nil {
+			return err
+		}
+
+		_, err = writer.Write(data)
+		if err != nil {
+			return err
+		}
+
+		chunkSize += uint64(len(data))
+	}
+
+	s.chunksToMerge = append(s.chunksToMerge, sortedChunk{
+		offset: s.tempFileSize,
+		size:   chunkSize,
+	})
+	s.tempFileSize += chunkSize
+	return nil
+}
+
+func (s *fileSorter) tempFileWriter() (*bufio.Writer, error) {
+	if s.writer != nil {
+		return s.writer, nil
+	}
+	file, err := s.tx.createTempFile()
+	if err != nil {
+		return nil, err
+	}
+	s.tempFile = file
+	s.writer = bufio.NewWriter(file)
+	return s.writer, nil
+}
+
+func encodeRow(r *Row) ([]byte, error) {
+	var buf bytes.Buffer
+	buf.Write([]byte{0, 0}) // make room for size field
+
+	for _, v := range r.ValuesByPosition {
+		rawValue, err := EncodeValue(v, v.Type(), -1)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(rawValue)
+	}
+
+	data := buf.Bytes()
+	size := uint16(len(data) - 2)
+	binary.BigEndian.PutUint16(data, size)
+
+	return data, nil
+}

--- a/embedded/sql/options_test.go
+++ b/embedded/sql/options_test.go
@@ -42,5 +42,11 @@ func TestOptions(t *testing.T) {
 	opts.WithAutocommit(true)
 	require.True(t, opts.autocommit)
 
+	opts.WithSortBufferSize(0)
+	require.Error(t, opts.Validate())
+
+	opts.WithSortBufferSize(defaultSortBufferSize)
+	require.Equal(t, opts.sortBufferSize, defaultSortBufferSize)
+
 	require.NoError(t, opts.Validate())
 }

--- a/embedded/sql/row_reader.go
+++ b/embedded/sql/row_reader.go
@@ -45,6 +45,7 @@ type ScanSpecs struct {
 	rangesByColID  map[uint32]*typedValueRange
 	IncludeHistory bool
 	DescOrder      bool
+	SortRequired   bool
 }
 
 type Row struct {

--- a/embedded/sql/sort_reader.go
+++ b/embedded/sql/sort_reader.go
@@ -1,0 +1,208 @@
+/*
+Copyright 2024 Codenotary Inc. All rights reserved.
+
+SPDX-License-Identifier: BUSL-1.1
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://mariadb.com/bsl11/
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sql
+
+import (
+	"context"
+)
+
+type sortRowReader struct {
+	rowReader          RowReader
+	selectors          []Selector
+	orderByDescriptors []ColDescriptor
+	sortKeysPositions  []int
+	desc               bool
+	sorter             fileSorter
+
+	resultReader resultReader
+}
+
+func newSortRowReader(rowReader RowReader, selectors []Selector, desc bool) (*sortRowReader, error) {
+	if rowReader == nil || len(selectors) == 0 {
+		return nil, ErrIllegalArguments
+	}
+
+	descriptors, err := rowReader.Columns(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	colPosBySelector, err := getColPositionsBySelector(descriptors)
+	if err != nil {
+		return nil, err
+	}
+
+	colTypes, err := getColTypes(rowReader)
+	if err != nil {
+		return nil, err
+	}
+
+	sortKeysPositions := getSortKeysPositions(colPosBySelector, selectors, rowReader.TableAlias())
+
+	tx := rowReader.Tx()
+	sr := &sortRowReader{
+		rowReader:          rowReader,
+		orderByDescriptors: getOrderByDescriptors(descriptors, sortKeysPositions),
+		selectors:          selectors,
+		desc:               desc,
+		sortKeysPositions:  sortKeysPositions,
+		sorter: fileSorter{
+			colPosBySelector: colPosBySelector,
+			colTypes:         colTypes,
+			tx:               tx,
+			sortBufSize:      tx.engine.sortBufferSize,
+			sortBuf:          make([]*Row, tx.engine.sortBufferSize),
+		},
+	}
+
+	sr.sorter.cmp = func(t1, t2 Tuple) bool {
+		k1 := sr.extractSortKey(t1)
+		k2 := sr.extractSortKey(t2)
+
+		res, _ := k1.Compare(k2)
+		if desc {
+			return res > 0
+		}
+		return res <= 0
+	}
+	return sr, nil
+}
+
+func getColTypes(r RowReader) ([]string, error) {
+	descriptors, err := r.Columns(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	cols := make([]string, len(descriptors))
+	for i, desc := range descriptors {
+		cols[i] = desc.Type
+	}
+	return cols, err
+}
+
+func getSortKeysPositions(colPosBySelector map[string]int, selectors []Selector, tableAlias string) []int {
+	sortKeysPositions := make([]int, len(selectors))
+	for i, sel := range selectors {
+		aggFn, table, col := sel.resolve(tableAlias)
+		encSel := EncodeSelector(aggFn, table, col)
+		pos := colPosBySelector[encSel]
+		sortKeysPositions[i] = pos
+	}
+	return sortKeysPositions
+}
+
+func getColPositionsBySelector(desc []ColDescriptor) (map[string]int, error) {
+	colPositionsBySelector := make(map[string]int)
+	for i, desc := range desc {
+		colPositionsBySelector[desc.Selector()] = i
+	}
+	return colPositionsBySelector, nil
+}
+
+func (sr *sortRowReader) extractSortKey(t Tuple) Tuple {
+	sortKey := make([]TypedValue, len(sr.sortKeysPositions))
+	for i, pos := range sr.sortKeysPositions {
+		sortKey[i] = t[pos]
+	}
+	return sortKey
+}
+
+func getOrderByDescriptors(descriptors []ColDescriptor, sortKeysPositions []int) []ColDescriptor {
+	orderByDescriptors := make([]ColDescriptor, len(sortKeysPositions))
+	for i, pos := range sortKeysPositions {
+		orderByDescriptors[i] = descriptors[pos]
+	}
+	return orderByDescriptors
+}
+
+func (sr *sortRowReader) onClose(callback func()) {
+	sr.rowReader.onClose(callback)
+}
+
+func (sr *sortRowReader) Tx() *SQLTx {
+	return sr.rowReader.Tx()
+}
+
+func (sr *sortRowReader) TableAlias() string {
+	return sr.rowReader.TableAlias()
+}
+
+func (sr *sortRowReader) Parameters() map[string]interface{} {
+	return sr.rowReader.Parameters()
+}
+
+func (sr *sortRowReader) OrderBy() []ColDescriptor {
+	return sr.orderByDescriptors
+}
+
+func (sr *sortRowReader) ScanSpecs() *ScanSpecs {
+	return sr.rowReader.ScanSpecs()
+}
+
+func (sr *sortRowReader) Columns(ctx context.Context) ([]ColDescriptor, error) {
+	return sr.rowReader.Columns(ctx)
+}
+
+func (sr *sortRowReader) colsBySelector(ctx context.Context) (map[string]ColDescriptor, error) {
+	return sr.rowReader.colsBySelector(ctx)
+}
+
+func (sr *sortRowReader) InferParameters(ctx context.Context, params map[string]SQLValueType) error {
+	return sr.rowReader.InferParameters(ctx, params)
+}
+
+func (sr *sortRowReader) Read(ctx context.Context) (*Row, error) {
+	if sr.resultReader == nil {
+		reader, err := sr.readAndSort(ctx)
+		if err != nil {
+			return nil, err
+		}
+		sr.resultReader = reader
+	}
+	return sr.resultReader.Read()
+}
+
+func (sr *sortRowReader) readAndSort(ctx context.Context) (resultReader, error) {
+	err := sr.readAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return sr.sorter.finalize()
+}
+
+func (sr *sortRowReader) readAll(ctx context.Context) error {
+	for {
+		row, err := sr.rowReader.Read(ctx)
+		if err == ErrNoMoreRows {
+			return nil
+		}
+
+		if err != nil {
+			return err
+		}
+
+		err = sr.sorter.update(row)
+		if err != nil {
+			return err
+		}
+	}
+}
+
+func (sr *sortRowReader) Close() error {
+	return sr.rowReader.Close()
+}

--- a/embedded/sql/sort_reader_test.go
+++ b/embedded/sql/sort_reader_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2024 Codenotary Inc. All rights reserved.
+
+SPDX-License-Identifier: BUSL-1.1
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	https://mariadb.com/bsl11/
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/codenotary/immudb/embedded/store"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSortRowReader(t *testing.T) {
+	st, err := store.Open(t.TempDir(), store.DefaultOptions().WithMultiIndexing(true))
+	require.NoError(t, err)
+
+	engine, err := NewEngine(st, DefaultOptions().WithPrefix(sqlPrefix))
+	require.NoError(t, err)
+
+	_, err = newSortRowReader(nil, nil, false)
+	require.ErrorIs(t, err, ErrIllegalArguments)
+
+	tx, err := engine.NewTx(context.Background(), DefaultTxOptions())
+	require.NoError(t, err)
+
+	_, _, err = engine.Exec(context.Background(), tx, "CREATE TABLE table1(id INTEGER, number INTEGER, PRIMARY KEY id)", nil)
+	require.NoError(t, err)
+
+	tx, err = engine.NewTx(context.Background(), DefaultTxOptions())
+	require.NoError(t, err)
+
+	defer tx.Cancel()
+
+	table := tx.catalog.tables[0]
+
+	r, err := newRawRowReader(tx, nil, table, period{}, "", &ScanSpecs{Index: table.primaryIndex, SortRequired: true})
+	require.NoError(t, err)
+
+	sr, err := newSortRowReader(r, []Selector{&ColSelector{col: "number"}}, false)
+	require.NoError(t, err)
+
+	orderBy := sr.OrderBy()
+	require.NotNil(t, orderBy)
+	require.Len(t, orderBy, 1)
+	require.Equal(t, "number", orderBy[0].Column)
+	require.Equal(t, "table1", orderBy[0].Table)
+
+	cols, err := sr.Columns(context.Background())
+	require.NoError(t, err)
+	require.Len(t, cols, 2)
+
+	require.Empty(t, sr.Parameters())
+
+	scanSpecs := sr.ScanSpecs()
+	require.NotNil(t, scanSpecs)
+	require.NotNil(t, scanSpecs.Index)
+	require.True(t, scanSpecs.SortRequired)
+	require.True(t, scanSpecs.Index.IsPrimary())
+}

--- a/embedded/sql/stmt.go
+++ b/embedded/sql/stmt.go
@@ -1550,6 +1550,20 @@ type TypedValue interface {
 	IsNull() bool
 }
 
+type Tuple []TypedValue
+
+func (t Tuple) Compare(other Tuple) (int, error) {
+	i := 0
+	for i < len(t) && i < len(other) {
+		res, err := t[i].Compare(other[i])
+		if err != nil || res != 0 {
+			return res, err
+		}
+		i++
+	}
+	return len(t) - len(other), nil
+}
+
 func NewNull(t SQLValueType) *NullValue {
 	return &NullValue{t: t}
 }
@@ -2435,30 +2449,6 @@ func (stmt *SelectStmt) execAt(ctx context.Context, tx *SQLTx, params map[string
 	if len(stmt.orderBy) > 1 {
 		return nil, ErrLimitedOrderBy
 	}
-
-	if len(stmt.orderBy) > 0 {
-		tableRef, ok := stmt.ds.(*tableRef)
-		if !ok {
-			return nil, ErrLimitedOrderBy
-		}
-
-		table, err := tableRef.referencedTable(tx)
-		if err != nil {
-			return nil, err
-		}
-
-		colName := stmt.orderBy[0].sel.col
-
-		indexed, err := table.IsIndexed(colName)
-		if err != nil {
-			return nil, err
-		}
-
-		if !indexed {
-			return nil, ErrLimitedOrderBy
-		}
-	}
-
 	return tx, nil
 }
 
@@ -2488,6 +2478,13 @@ func (stmt *SelectStmt) Resolve(ctx context.Context, tx *SQLTx, params map[strin
 
 	if stmt.where != nil {
 		rowReader = newConditionalRowReader(rowReader, stmt.where)
+	}
+
+	if scanSpecs.SortRequired {
+		rowReader, err = newSortRowReader(rowReader, stmt.orderBySelectors(), scanSpecs.DescOrder)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	containsAggregations := false
@@ -2593,9 +2590,15 @@ func (stmt *SelectStmt) Alias() string {
 }
 
 func (stmt *SelectStmt) genScanSpecs(tx *SQLTx, params map[string]interface{}) (*ScanSpecs, error) {
+	sortingRequired := len(stmt.orderBy) > 0
+	descOrder := sortingRequired && stmt.orderBy[0].descOrder
+
 	tableRef, isTableRef := stmt.ds.(*tableRef)
 	if !isTableRef {
-		return nil, nil
+		return &ScanSpecs{
+			SortRequired: sortingRequired,
+			DescOrder:    descOrder,
+		}, nil
 	}
 
 	table, err := tableRef.referencedTable(tx)
@@ -2611,39 +2614,12 @@ func (stmt *SelectStmt) genScanSpecs(tx *SQLTx, params map[string]interface{}) (
 		}
 	}
 
-	var preferredIndex *Index
-
-	if len(stmt.indexOn) > 0 {
-		cols := make([]*Column, len(stmt.indexOn))
-
-		for i, colName := range stmt.indexOn {
-			col, err := table.GetColumnByName(colName)
-			if err != nil {
-				return nil, err
-			}
-
-			cols[i] = col
-		}
-
-		index, err := table.GetIndexByName(indexName(table.name, cols))
-		if err != nil {
-			return nil, err
-		}
-
-		preferredIndex = index
+	preferredIndex, err := stmt.selectIndex(table)
+	if err != nil {
+		return nil, err
 	}
 
 	var sortingIndex *Index
-	var descOrder bool
-
-	if stmt.orderBy == nil {
-		if preferredIndex == nil {
-			sortingIndex = table.primaryIndex
-		} else {
-			sortingIndex = preferredIndex
-		}
-	}
-
 	if len(stmt.orderBy) > 0 {
 		col, err := table.GetColumnByName(stmt.orderBy[0].sel.col)
 		if err != nil {
@@ -2654,16 +2630,19 @@ func (stmt *SelectStmt) genScanSpecs(tx *SQLTx, params map[string]interface{}) (
 			if idx.sortableUsing(col.id, rangesByColID) {
 				if preferredIndex == nil || idx.id == preferredIndex.id {
 					sortingIndex = idx
+					sortingRequired = false
 					break
 				}
 			}
 		}
-
-		descOrder = stmt.orderBy[0].descOrder
 	}
 
 	if sortingIndex == nil {
-		return nil, ErrNoAvailableIndex
+		if preferredIndex == nil {
+			sortingIndex = table.primaryIndex
+		} else {
+			sortingIndex = preferredIndex
+		}
 	}
 
 	if tableRef.history && !sortingIndex.IsPrimary() {
@@ -2675,7 +2654,37 @@ func (stmt *SelectStmt) genScanSpecs(tx *SQLTx, params map[string]interface{}) (
 		rangesByColID:  rangesByColID,
 		IncludeHistory: tableRef.history,
 		DescOrder:      descOrder,
+		SortRequired:   sortingRequired,
 	}, nil
+}
+
+func (stmt *SelectStmt) selectIndex(table *Table) (*Index, error) {
+	if len(stmt.indexOn) == 0 {
+		return nil, nil
+	}
+
+	cols := make([]*Column, len(stmt.indexOn))
+	for i, colName := range stmt.indexOn {
+		col, err := table.GetColumnByName(colName)
+		if err != nil {
+			return nil, err
+		}
+
+		cols[i] = col
+	}
+	return table.GetIndexByName(indexName(table.name, cols))
+}
+
+func (stmt *SelectStmt) orderBySelectors() []Selector {
+	var selectors []Selector
+	for _, col := range stmt.orderBy {
+		sel := &ColSelector{
+			table: col.sel.table,
+			col:   col.sel.col,
+		}
+		selectors = append(selectors, sel)
+	}
+	return selectors
 }
 
 type UnionStmt struct {


### PR DESCRIPTION
This merge request is meant to support the order by clause on non indexed fields.
If the query planner determines that the output is not already sorted, then an additional sorting step is added through a new type of reader: `sortReader`.
When the client attempts to read the first row on the sort reader, all rows gets fetched from the underlying reader and collected to a buffer. When the buffer contains at least 1024 rows, sorting is performed in memory and the sorted chunk is spilled to a temporary disk file. The process continues until all the result rows have been read. 
At this point, sorted disk chunks (if any) are merged into a single bigger sorted chunk and a reader to such a file is returned to the client. If the output contains a number of rows <= 1024, then a reader to the buffer is simply returned.


