### PR TITLE
chore(embedded/store): improve index flush logic

### DIFF
--- a/cmd/immudb/command/init.go
+++ b/cmd/immudb/command/init.go
@@ -44,6 +44,7 @@ func (cl *Commandline) setupFlags(cmd *cobra.Command, options *server.Options) {
 	cmd.Flags().Bool("replication-allow-tx-discarding", options.ReplicationOptions.AllowTxDiscarding, "allow precommitted transactions to be discarded if the replica diverges from the primary")
 	cmd.Flags().Bool("replication-skip-integrity-check", options.ReplicationOptions.SkipIntegrityCheck, "disable integrity check when reading data during replication")
 	cmd.Flags().Bool("replication-wait-for-indexing", options.ReplicationOptions.WaitForIndexing, "wait for indexing to be up to date during replication")
+	cmd.Flags().Int("shared-index-cache-size", options.SharedIndexCacheSize, "size (in bytes) of shared index cache")
 
 	cmd.PersistentFlags().StringVar(&cl.config.CfgFn, "config", "", "config file (default path are configs or $HOME. Default filename is immudb.toml)")
 	cmd.Flags().String("pidfile", options.Pidfile, "pid path with filename e.g. /var/run/immudb.pid")

--- a/embedded/sql/functions.go
+++ b/embedded/sql/functions.go
@@ -144,7 +144,7 @@ func (f *SubstringFn) requiresType(t SQLValueType, cols map[string]ColDescriptor
 
 func (f *SubstringFn) Apply(tx *SQLTx, params []TypedValue) (TypedValue, error) {
 	if len(params) != 3 {
-		return nil, fmt.Errorf("%w: '%s' function does expects one argument but %d were provided", ErrIllegalArguments, SubstringFnCall, len(params))
+		return nil, fmt.Errorf("%w: '%s' function does expects three argument but %d were provided", ErrIllegalArguments, SubstringFnCall, len(params))
 	}
 
 	v1, v2, v3 := params[0], params[1], params[2]
@@ -163,6 +163,10 @@ func (f *SubstringFn) Apply(tx *SQLTx, params []TypedValue) (TypedValue, error) 
 
 	if length < 0 {
 		return nil, fmt.Errorf("%w: parameter 'length' cannot be negative", ErrIllegalArguments)
+	}
+
+	if pos-1 >= int64(len(s)) {
+		return &Varchar{val: ""}, nil
 	}
 
 	end := pos - 1 + length

--- a/embedded/store/options_test.go
+++ b/embedded/store/options_test.go
@@ -85,6 +85,9 @@ func TestInvalidIndexOptions(t *testing.T) {
 		{"NodesLogMaxOpenedFiles", DefaultIndexOptions().WithNodesLogMaxOpenedFiles(0)},
 		{"HistoryLogMaxOpenedFiles", DefaultIndexOptions().WithHistoryLogMaxOpenedFiles(0)},
 		{"CommitLogMaxOpenedFiles", DefaultIndexOptions().WithCommitLogMaxOpenedFiles(0)},
+		{"MaxGlobalBufferedDataSize", DefaultIndexOptions().WithMaxGlobalBufferedDataSize(0)},
+		{"MaxGlobalBufferedDataSize", DefaultIndexOptions().WithMaxGlobalBufferedDataSize(DefaultIndexOptions().MaxBufferedDataSize - 1)},
+		{"MaxBufferedDataSize", DefaultIndexOptions().WithMaxBufferedDataSize(0)},
 	} {
 		t.Run(d.n, func(t *testing.T) {
 			require.ErrorIs(t, d.opts.Validate(), ErrInvalidOptions)
@@ -195,6 +198,8 @@ func TestValidOptions(t *testing.T) {
 	require.Equal(t, 1*time.Millisecond, indexOpts.WithDelayDuringCompaction(1*time.Millisecond).DelayDuringCompaction)
 	require.Equal(t, 4096*2, indexOpts.WithFlushBufferSize(4096*2).FlushBufferSize)
 	require.Equal(t, float32(10), indexOpts.WithCleanupPercentage(10).CleanupPercentage)
+	require.Equal(t, int(10), indexOpts.WithMaxBufferedDataSize(10).MaxBufferedDataSize)
+	require.Equal(t, int(10), indexOpts.WithMaxGlobalBufferedDataSize(10).MaxGlobalBufferedDataSize)
 
 	require.Nil(t, opts.WithAHTOptions(nil).AHTOpts)
 	require.ErrorIs(t, opts.Validate(), ErrInvalidOptions)

--- a/pkg/database/types.go
+++ b/pkg/database/types.go
@@ -41,7 +41,7 @@ type dbRef struct {
 	deleted bool
 }
 
-//NewDatabaseList constructs a new database list
+// NewDatabaseList constructs a new database list
 func NewDatabaseList() DatabaseList {
 	return &databaseList{
 		databases:      make([]DB, 0),

--- a/pkg/helpers/semaphore/semaphore.go
+++ b/pkg/helpers/semaphore/semaphore.go
@@ -1,0 +1,35 @@
+package semaphore
+
+import "sync/atomic"
+
+type Semaphore struct {
+	maxWeight  uint64
+	currWeight uint64
+}
+
+func New(maxWeight uint64) *Semaphore {
+	return &Semaphore{
+		maxWeight:  maxWeight,
+		currWeight: 0,
+	}
+}
+
+func (m *Semaphore) Acquire(n uint64) bool {
+	if newVal := atomic.AddUint64(&m.currWeight, n); newVal <= m.maxWeight {
+		return true
+	}
+	m.Release(n)
+	return false
+}
+
+func (m *Semaphore) Release(n uint64) {
+	atomic.AddUint64(&m.currWeight, ^uint64(n-1))
+}
+
+func (m *Semaphore) Value() uint64 {
+	return atomic.LoadUint64(&m.currWeight)
+}
+
+func (m *Semaphore) MaxWeight() uint64 {
+	return m.maxWeight
+}

--- a/pkg/server/options.go
+++ b/pkg/server/options.go
@@ -77,6 +77,7 @@ type Options struct {
 	GRPCReflectionServerEnabled bool
 	SwaggerUIEnabled            bool
 	LogRequestMetadata          bool
+	SharedIndexCacheSize        int
 }
 
 type RemoteStorageOptions struct {
@@ -147,6 +148,7 @@ func DefaultOptions() *Options {
 		GRPCReflectionServerEnabled: true,
 		SwaggerUIEnabled:            true,
 		LogRequestMetadata:          false,
+		SharedIndexCacheSize:        1 << 27, // 128MB
 	}
 }
 

--- a/pkg/server/remote_storage.go
+++ b/pkg/server/remote_storage.go
@@ -27,6 +27,7 @@ import (
 	"github.com/codenotary/immudb/embedded/appendable"
 	"github.com/codenotary/immudb/embedded/appendable/multiapp"
 	"github.com/codenotary/immudb/embedded/appendable/remoteapp"
+	"github.com/codenotary/immudb/embedded/cache"
 	"github.com/codenotary/immudb/embedded/remotestorage"
 	"github.com/codenotary/immudb/embedded/remotestorage/s3"
 	"github.com/codenotary/immudb/embedded/store"
@@ -156,6 +157,16 @@ func (s *ImmuServer) initRemoteIdentifier(ctx context.Context, storage remotesto
 func (s *ImmuServer) updateRemoteUUID(remoteStorage remotestorage.Storage) error {
 	ctx := context.Background()
 	return remoteStorage.Put(ctx, IDENTIFIER_FNAME, filepath.Join(s.Options.Dir, IDENTIFIER_FNAME))
+}
+
+func (s *ImmuServer) indexCacheFactoryFunc() store.IndexCacheFactoryFunc {
+	if s.indexCacheFunc == nil {
+		c, _ := cache.NewCache(s.Options.SharedIndexCacheSize)
+		s.indexCacheFunc = func() *cache.Cache {
+			return c
+		}
+	}
+	return s.indexCacheFunc
 }
 
 func (s *ImmuServer) storeOptionsForDB(name string, remoteStorage remotestorage.Storage, stOpts *store.Options) *store.Options {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1029,7 +1029,7 @@ func (s *ImmuServer) LoadDatabase(ctx context.Context, req *schema.LoadDatabaseR
 		return nil, ErrIllegalArguments
 	}
 
-	s.Logger.Infof("loadinig database '%s'...", req.Database)
+	s.Logger.Infof("loading database '%s'...", req.Database)
 
 	defer func() {
 		if err == nil {

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -26,6 +26,7 @@ import (
 	"github.com/codenotary/immudb/pkg/server/sessions"
 	"github.com/codenotary/immudb/pkg/truncator"
 
+	"github.com/codenotary/immudb/embedded/cache"
 	"github.com/codenotary/immudb/embedded/remotestorage"
 	pgsqlsrv "github.com/codenotary/immudb/pkg/pgsql/server"
 	"github.com/codenotary/immudb/pkg/replication"
@@ -83,9 +84,9 @@ type ImmuServer struct {
 	StreamServiceFactory stream.ServiceFactory
 	PgsqlSrv             pgsqlsrv.PGSQLServer
 
-	remoteStorage remotestorage.Storage
-
-	SessManager sessions.Manager
+	remoteStorage  remotestorage.Storage
+	indexCacheFunc func() *cache.Cache
+	SessManager    sessions.Manager
 }
 
 // DefaultServer ...


### PR DESCRIPTION
    - implement memory aware flushing;
    - share node cache across multiple indexes;
    - implement write stalling;
    - avoid to allocate large buffers when store.maxValueSize is too large.