### PR TITLE
fix check ctx.Err() != nil but return a nil value error err

### DIFF
--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -1771,7 +1771,7 @@ func (d *db) FindTruncationPoint(ctx context.Context, until time.Time) (*schema.
 			break
 		}
 
-		if ctx.Err() != nil {
+		if err:= ctx.Err(); err != nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
the err has been check in line 1764,  the ctx.Err() is not nil and return a nil 