### PR TITLE
fix: fix the wrong error return value

### DIFF
--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -1771,8 +1771,8 @@ func (d *db) FindTruncationPoint(ctx context.Context, until time.Time) (*schema.
 			break
 		}
 
-		if ctx.Err() != nil {
-			return nil, err
+		if errC := ctx.Err(); errC != nil {
+			return nil, errC
 		}
 
 		hdr, err = d.st.ReadTxHeader(hdr.ID-1, false, false)


### PR DESCRIPTION
Since we have already checked err == nil , so  err must be nil here. In fact, it should return `ctx.Err()`.