### PR TITLE
Make indexing more robust to "key not found" errors

### DIFF
--- a/embedded/store/indexer.go
+++ b/embedded/store/indexer.go
@@ -482,8 +482,12 @@ func (idx *indexer) doIndexing() {
 		}
 
 		if err != nil && !errors.Is(err, ErrWriteStalling) {
-			idx.store.logger.Errorf("indexing failed at '%s' due to error: %v", idx.store.path, err)
-			time.Sleep(60 * time.Second)
+			if errors.Is(err, tbtree.ErrKeyNotFound) {
+				idx.store.logger.Warningf("indexing failed at '%s' due to error: %v", idx.store.path, err)
+			} else {
+				idx.store.logger.Errorf("indexing failed at '%s' due to error: %v", idx.store.path, err)
+				time.Sleep(60 * time.Second)
+			}
 		}
 
 		if err := idx.handleWriteStalling(err); err != nil {


### PR DESCRIPTION
The indexing process in `embedded/store/indexer.go` was previously treating `tbtree.ErrKeyNotFound` as a fatal error. This would cause the entire indexing process to halt for 60 seconds before retrying.

However, `tbtree.ErrKeyNotFound` is a standard error that can occur during normal operation, for example, when trying to index an entry that has been deleted. This is not a critical failure and should not stop the indexer.

This commit modifies the error handling in the `doIndexing` function to specifically check for `tbtree.ErrKeyNotFound`. When this error is encountered, it is now logged as a warning, and the indexer continues to the next entry without any delay. Other, unexpected errors are still treated as critical and will cause the indexer to pause.

This change makes the indexing process more resilient and prevents unnecessary delays caused by non-critical "key not found" errors.