### PR TITLE
fix: display actual config file path in startup logs

### DIFF
--- a/cmd/immudb/command/init.go
+++ b/cmd/immudb/command/init.go
@@ -45,6 +45,7 @@ func (cl *Commandline) setupFlags(cmd *cobra.Command, options *server.Options) {
 	cmd.Flags().Bool("replication-skip-integrity-check", options.ReplicationOptions.SkipIntegrityCheck, "disable integrity check when reading data during replication")
 	cmd.Flags().Bool("replication-wait-for-indexing", options.ReplicationOptions.WaitForIndexing, "wait for indexing to be up to date during replication")
 	cmd.Flags().Int("max-active-databases", options.MaxActiveDatabases, "the maximum number of databases that can be active simultaneously")
+	cmd.Flags().String("config", "", "config file (default path are configs or $HOME. Default filename is immudb.toml)")
 
 	cmd.PersistentFlags().StringVar(&cl.config.CfgFn, "config", "", "config file (default path are configs or $HOME. Default filename is immudb.toml)")
 	cmd.Flags().String("pidfile", options.Pidfile, "pid path with filename e.g. /var/run/immudb.pid")
@@ -117,6 +118,7 @@ func (cl *Commandline) setupFlags(cmd *cobra.Command, options *server.Options) {
 
 func setupDefaults(options *server.Options) {
 	viper.SetDefault("dir", options.Dir)
+	viper.SetDefault("config", options.Config)
 	viper.SetDefault("port", options.Port)
 	viper.SetDefault("address", options.Address)
 	viper.SetDefault("replica", false)

--- a/cmd/immudb/command/parse_options.go
+++ b/cmd/immudb/command/parse_options.go
@@ -24,6 +24,7 @@ import (
 
 func parseOptions() (options *server.Options, err error) {
 	dir := viper.GetString("dir")
+	config := viper.GetString("config")
 
 	address := viper.GetString("address")
 	port := viper.GetInt("port")
@@ -134,6 +135,7 @@ func parseOptions() (options *server.Options, err error) {
 	options = server.
 		DefaultOptions().
 		WithDir(dir).
+		WithConfig(config).
 		WithPort(port).
 		WithAddress(address).
 		WithReplicationOptions(replicationOptions).


### PR DESCRIPTION
## What
The 'Config file:' line in immudb startup logs always showed the hardcoded default value `configs/immudb.toml` regardless of which config file was actually loaded via the `--config` flag or `IMMUDB_CONFIG` env var.

## Testing
Tested on my local minikube cluster, the actual path is reflected in immudb logs on startup now.