### PR TITLE
Clarify ScanRequest.sinceTx=0 read-latest semantics (fixes #2082)

### DIFF
--- a/pkg/api/schema/docs.md
+++ b/pkg/api/schema/docs.md
@@ -1717,8 +1717,8 @@ Only succeed if given key was not modified after given transaction
 | prefix | [bytes](#bytes) |  | search for entries with this prefix only |
 | desc | [bool](#bool) |  | If set to true, sort items in descending order |
 | limit | [uint64](#uint64) |  | maximum number of entries to get, if not specified, the default value is used |
-| sinceTx | [uint64](#uint64) |  | If non-zero, only require transactions up to this transaction to be indexed, newer transaction may still be pending |
-| noWait | [bool](#bool) |  | Deprecated: If set to true, do not wait for indexing to be done before finishing this call |
+| sinceTx | [uint64](#uint64) |  | Controls the visibility lower bound of the scan. - If 0 (default): the server captures the latest committed transaction id at call-reception time and blocks until the indexer has processed at least that transaction before taking the snapshot. This gives "read-latest" / read-your-writes semantics without the caller needing to know the latest tx id (useful when multiple client processes write concurrently, see issue #2082). - If &gt; 0: the server only requires transactions up to sinceTx to be indexed; transactions committed after sinceTx may still be pending and may or may not appear in the result. |
+| noWait | [bool](#bool) |  | Deprecated and currently ignored by Scan: the server always waits for the tx id resolved from sinceTx (see above) to be indexed before returning. |
 | inclusiveSeek | [bool](#bool) |  | If set to true, results will include seekKey |
 | inclusiveEnd | [bool](#bool) |  | If set to true, results will include endKey if needed |
 | offset | [uint64](#uint64) |  | Specify the initial entry to be returned by excluding the initial set of entries |

--- a/pkg/api/schema/schema.pb.go
+++ b/pkg/api/schema/schema.pb.go
@@ -1724,10 +1724,19 @@ type ScanRequest struct {
 	Desc bool `protobuf:"varint,3,opt,name=desc,proto3" json:"desc,omitempty"`
 	// maximum number of entries to get, if not specified, the default value is used
 	Limit uint64 `protobuf:"varint,4,opt,name=limit,proto3" json:"limit,omitempty"`
-	// If non-zero, only require transactions up to this transaction to be
-	// indexed, newer transaction may still be pending
+	// Controls the visibility lower bound of the scan.
+	//   - If 0 (default): the server captures the latest committed transaction
+	//     id at call-reception time and blocks until the indexer has processed
+	//     at least that transaction before taking the snapshot. This gives
+	//     "read-latest" / read-your-writes semantics without the caller needing
+	//     to know the latest tx id (useful when multiple client processes write
+	//     concurrently, see issue #2082).
+	//   - If > 0: the server only requires transactions up to sinceTx to be
+	//     indexed; transactions committed after sinceTx may still be pending
+	//     and may or may not appear in the result.
 	SinceTx uint64 `protobuf:"varint,5,opt,name=sinceTx,proto3" json:"sinceTx,omitempty"`
-	// Deprecated: If set to true, do not wait for indexing to be done before finishing this call
+	// Deprecated and currently ignored by Scan: the server always waits for the
+	// tx id resolved from sinceTx (see above) to be indexed before returning.
 	NoWait bool `protobuf:"varint,6,opt,name=noWait,proto3" json:"noWait,omitempty"`
 	// If set to true, results will include seekKey
 	InclusiveSeek bool `protobuf:"varint,8,opt,name=inclusiveSeek,proto3" json:"inclusiveSeek,omitempty"`

--- a/pkg/api/schema/schema.proto
+++ b/pkg/api/schema/schema.proto
@@ -314,11 +314,20 @@ message ScanRequest {
   // maximum number of entries to get, if not specified, the default value is used
   uint64 limit = 4;
 
-  // If non-zero, only require transactions up to this transaction to be
-  // indexed, newer transaction may still be pending
+  // Controls the visibility lower bound of the scan.
+  //   - If 0 (default): the server captures the latest committed transaction
+  //     id at call-reception time and blocks until the indexer has processed
+  //     at least that transaction before taking the snapshot. This gives
+  //     "read-latest" / read-your-writes semantics without the caller needing
+  //     to know the latest tx id (useful when multiple client processes write
+  //     concurrently, see issue #2082).
+  //   - If > 0: the server only requires transactions up to sinceTx to be
+  //     indexed; transactions committed after sinceTx may still be pending
+  //     and may or may not appear in the result.
   uint64 sinceTx = 5;
 
-  // Deprecated: If set to true, do not wait for indexing to be done before finishing this call
+  // Deprecated and currently ignored by Scan: the server always waits for the
+  // tx id resolved from sinceTx (see above) to be indexed before returning.
   bool noWait = 6;
 
   // If set to true, results will include seekKey

--- a/pkg/api/schema/schema.swagger.json
+++ b/pkg/api/schema/schema.swagger.json
@@ -3433,11 +3433,11 @@
         "sinceTx": {
           "type": "string",
           "format": "uint64",
-          "title": "If non-zero, only require transactions up to this transaction to be\nindexed, newer transaction may still be pending"
+          "title": "Controls the visibility lower bound of the scan.\n  - If 0 (default): the server captures the latest committed transaction\n    id at call-reception time and blocks until the indexer has processed\n    at least that transaction before taking the snapshot. This gives\n    \"read-latest\" / read-your-writes semantics without the caller needing\n    to know the latest tx id (useful when multiple client processes write\n    concurrently, see issue #2082).\n  - If \u003e 0: the server only requires transactions up to sinceTx to be\n    indexed; transactions committed after sinceTx may still be pending\n    and may or may not appear in the result."
         },
         "noWait": {
           "type": "boolean",
-          "title": "Deprecated: If set to true, do not wait for indexing to be done before finishing this call"
+          "title": "Deprecated and currently ignored by Scan: the server always waits for the\ntx id resolved from sinceTx (see above) to be indexed before returning."
         },
         "inclusiveSeek": {
           "type": "boolean",

--- a/pkg/database/scan_latest_test.go
+++ b/pkg/database/scan_latest_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2025 Codenotary Inc. All rights reserved.
+
+SPDX-License-Identifier: BUSL-1.1
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://mariadb.com/bsl11/
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package database
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/codenotary/immudb/pkg/api/schema"
+	"github.com/stretchr/testify/require"
+)
+
+// TestScanSinceTxZeroSeesLatestCommitted guards the contract documented on
+// ScanRequest.sinceTx: when sinceTx == 0, Scan must resolve to the latest
+// committed transaction at call-reception time and wait for it to be indexed
+// before taking the snapshot. Issue #2082.
+func TestScanSinceTxZeroSeesLatestCommitted(t *testing.T) {
+	db := makeDb(t)
+
+	ctx := context.Background()
+	prefix := []byte("scan-latest:")
+
+	const n = 50
+	for i := 0; i < n; i++ {
+		key := []byte(fmt.Sprintf("scan-latest:%03d", i))
+		val := []byte(fmt.Sprintf("v-%03d", i))
+
+		_, err := db.Set(ctx, &schema.SetRequest{
+			KVs: []*schema.KeyValue{{Key: key, Value: val}},
+		})
+		require.NoError(t, err)
+
+		// SinceTx: 0 must expose the just-committed key without the caller
+		// needing to thread through the tx id from Set's response.
+		list, err := db.Scan(ctx, &schema.ScanRequest{
+			Prefix:  prefix,
+			SinceTx: 0,
+		})
+		require.NoError(t, err)
+		require.Len(t, list.Entries, i+1,
+			"Scan(sinceTx=0) did not observe the just-committed write at iteration %d", i)
+		require.Equal(t, key, list.Entries[i].Key)
+		require.Equal(t, val, list.Entries[i].Value)
+	}
+}


### PR DESCRIPTION
## Summary

- The server already provides the behavior requested in #2082: `Scan(sinceTx=0)` captures the latest committed tx at call-reception time and waits for indexing before taking the snapshot (`pkg/database/database.go` `snapshotSince` → `SnapshotMustIncludeTxID` → `WaitForIndexingUpto`).
- The existing proto comments didn't document this and the deprecated `noWait` field read like a "get a fresher result" toggle even though `Scan` ignores it. This PR makes the behavior discoverable from the API docs and adds a guard test.

## Changes

- `pkg/api/schema/schema.proto`: spell out both branches of `ScanRequest.sinceTx` (0 = read-latest with indexer wait; >0 = require only that tx), reference #2082, and note `noWait` is deprecated **and** currently ignored by `Scan`.
- `pkg/api/schema/{schema.pb.go, docs.md, schema.swagger.json}`: mirror the comment change by hand. Full `make build/codegen` was intentionally **not** run because the locally installed `protoc-gen-go` (v1.36) differs from the version used to produce the checked-in `schema.pb.go` (v1.32) and produces large unrelated churn. Only the `ScanRequest.sinceTx` / `ScanRequest.noWait` docstrings change.
- `pkg/database/scan_latest_test.go` (new): 50-iteration loop that `Set`s a key and immediately calls `Scan(sinceTx=0)`, asserting the write is visible. Guards the contract against regressions.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./pkg/api/schema/... ./pkg/database/...`
- [x] `go test ./pkg/database/ -run '^TestScanSinceTxZeroSeesLatestCommitted$|^TestStoreScan$' -count=1`
- [ ] CI green on master-targeted PR