### PR TITLE
perf(s3): wave 1-4 remote-storage performance + sql index-only COUNT + hot-path fixes

### DIFF
--- a/docs/perf/s3-read-perf.md
+++ b/docs/perf/s3-read-perf.md
@@ -1,0 +1,220 @@
+# immudb S3 performance — `feat/s3performance`
+
+This branch ships four sets of changes against the S3-backed appendable
+path (`embedded/appendable/remoteapp/`, `embedded/appendable/multiapp/`,
+`embedded/remotestorage/s3/`). Each landed as its own commit; this
+document headlines the per-change wins measured against a real
+S3-compatible backend (`rustfs/rustfs:1.0.0-beta.1` running locally
+in Docker), with a simulated 50 ms WAN RTT injected on top to model
+production cross-region S3 latency.
+
+## Headline numbers (real rustfs)
+
+| Change | Metric | Before | After | Win |
+| ------ | ------ | ------ | ----- | --- |
+| **#3** drop post-upload verification (Exists + verify-Get round trips) | wall-clock per upload, loopback | 7.8 ms | 5.3 ms | **–32 %** (2 RTTs/chunk eliminated) |
+| **#1** parallel multi-chunk prefetch on the multiapp layer (singleflight-coalesced) | wall-clock for sequential 16-chunk read, 50 ms WAN RTT | 1530 ms | 1009 ms | **–34 %**, same Get count |
+| **#2** end-to-end compression (per-Append-frame, flate/gzip/zlib) | wire-bytes for 256 KiB compressible payload | 262 KiB | ≈640 B | **–99.7 %** wire (410× ratio) |
+| **range-fetch reader + LRU window cache + sequential prefetch** (Waves 1–3 of the per-reader path, already on `master`) | per-reader resident memory ceiling | unbounded (chunk-size) | bounded (4 × 1 MiB by default) | constant, regardless of chunk size |
+
+#3 and #1 are RTT-amplified — a 100 ms cross-region link doubles the
+absolute saving each delivers. #2 saves bytes, which on a slow upload
+pipe translates directly to upload-time speedup; the wall-clock
+improvement is proportional to the link bandwidth.
+
+## What each change does
+
+### #3 — drop post-upload verification
+
+`embedded/appendable/remoteapp/remote_app.go` :: `uploadChunk` previously
+followed every `Put` with two more retryable round trips:
+
+1. `Exists(remotePath+appName)` — confirm the chunk is visible.
+2. `openRemoteAppendableReader(appName)` — open a fresh remote reader
+   (which itself does at least one window-sized `Get`) to validate
+   readability before swapping the cached appendable.
+
+Modern S3 has been read-after-write consistent since 2020, so the
+verification is no longer load-bearing. Wave-4 default behaviour:
+skip the `Exists` round trip and substitute a `lazyRemoteReader` (new
+file `lazy_remote_reader.go`) into the multiapp cache. The lazy
+wrapper opens the inner remote reader only on the first subsequent
+`ReadAt` — most uploaded chunks are never read again, so the open
+cost is usually deferred forever.
+
+The legacy two-round-trip path is still available behind
+`WithVerifyUploads(true)`. Existing `TestRemoteStorageUploadRetry` /
+`TestRemoteStorageUploadCancel/{Get,Exists}` opt back into it.
+
+### #1 — parallel multi-chunk prefetch on the multiapp layer
+
+`embedded/appendable/multiapp/multi_app.go` :: `appendableFor` now
+detects sequential read patterns (`appID == prevAppID + 1`) and
+spawns up to `prefetchAheadDepth` background opens for the next K
+chunks. Background opens snapshot the per-`currApp` compression info
+under the multiapp mutex, then **drop the mutex** for the slow
+`OpenAppendable` call so foreground readers don't block on a
+background network I/O.
+
+Foreground misses route through the same `singleflight.Group` as
+the prefetch goroutine, keyed by appID, so a foreground read on a
+chunk that's currently being prefetched waits on the in-flight
+goroutine instead of issuing a duplicate `Get`. The benchmark
+confirms this: same 16 Gets with or without prefetch, wall-clock
+drops by a third because 15 of those Gets now overlap with consumer
+time.
+
+`remoteapp.DefaultOptions()` sets `prefetchAheadDepth = 4`
+(`DefaultPrefetchAheadDepth`); local-only multiapps default to 0
+(opens are cheap, no win to chase).
+
+### #2 — end-to-end compression through remoteapp
+
+The per-Append framed-compression model `singleapp` already
+implemented for local appendables now flows through `remoteapp`
+unchanged. Three things changed to enable it:
+
+1. `RemoteStorageAppendable.OpenAppendable` no longer rejects
+   non-default `CompressionFormat`. The local writer compresses
+   each `Append` into a length-prefixed frame as before; the chunk
+   file is uploaded verbatim.
+2. `singleapp.MetaCompressionFormat` is exported so downstream
+   readers can pull the format out of a chunk's metadata header
+   without depending on unexported singleapp internals.
+3. `remoteStorageReader` now parses the format on open (defensive:
+   `parseCompressionFormat` recovers from `appendable.NewMetadata`
+   panics on non-singleapp test fixtures, defaulting to
+   `NoCompression`) and a new `readAtCompressedFrame` reproduces the
+   same `[4-byte length][N compressed bytes]` per-Append protocol on
+   top of the existing range-cache path, supporting flate, gzip,
+   lzw, zlib.
+
+`CompressionFormat()` / `CompressionLevel()` are now real
+accessors — required by the multiapp prefetch snapshot and by the
+chunk-level decompress path. A new `TestOpenRemoteStorageAppendableCompression`
+does an end-to-end round-trip: write compressed → upload → flush →
+read back → byte-equal to the original payload.
+
+## Methodology
+
+The Wave-4 benchmark suite (`embedded/appendable/remoteapp/`) has
+two mirrored sets:
+
+- `wave3_bench_test.go` — synthetic in-memory backend with a
+  configurable per-Get sleep that simulates S3 RTT. Cheap, fully
+  deterministic, runs in CI without external deps. Used for
+  iterating on the implementation.
+- `rustfs_bench_test.go` — real `rustfs/rustfs:1.0.0-beta.1`
+  container (S3-compatible, written in Rust). Skipped automatically
+  if rustfs isn't reachable at `$RUSTFS_ENDPOINT` (default
+  `127.0.0.1:9100`). The 50 ms-WAN variants wrap the rustfs storage
+  in an `rttInjector` that adds a fixed sleep on every Get/Put/
+  Exists, modelling a cross-region S3 hop.
+
+Reproduce the rustfs benchmarks:
+
+```
+docker run -d --name rustfs-bench -p 9100:9000 \
+    -e RUSTFS_ROOT_USER=rustfsadmin \
+    -e RUSTFS_ROOT_PASSWORD=rustfsadmin \
+    -v /tmp/rustfs-data:/data \
+    rustfs/rustfs:latest
+
+AWS_ACCESS_KEY_ID=rustfsadmin AWS_SECRET_ACCESS_KEY=rustfsadmin \
+AWS_DEFAULT_REGION=us-east-1 \
+    aws --endpoint-url http://127.0.0.1:9100 s3 mb s3://immudb-bench
+
+cd embedded/appendable/remoteapp
+go test -bench='^BenchmarkRustFS_' -benchtime=3x -run=^$ -timeout=10m
+```
+
+The synthetic benches still run as part of the standard
+`embedded/appendable/remoteapp/...` test target; the rustfs ones
+are gated on the container being reachable.
+
+## Raw numbers
+
+### #3 — upload-path round-trip elimination, real rustfs (loopback)
+
+```
+BenchmarkRustFS_Upload_Legacy-32   3   7818488 ns/op   1.143 puts/chunk   1.143 exists/chunk   1.143 gets/chunk
+BenchmarkRustFS_Upload_Fast-32     3   5298163 ns/op   1.143 puts/chunk   0     exists/chunk   0     gets/chunk
+```
+
+### #1 — parallel multi-chunk prefetch (rustfs + 50 ms injected RTT)
+
+```
+BenchmarkRustFS_MultiChunkRead_NoPrefetch_50msRTT-32   3   1530486419 ns/op   16.00 gets/op
+BenchmarkRustFS_MultiChunkRead_Prefetch4_50msRTT-32    3   1008864759 ns/op   16.00 gets/op
+```
+
+Loopback-only (no injected RTT) for completeness — the prefetch's
+overlap window collapses to ~1 ms loopback latency, so the win
+shrinks to noise:
+
+```
+BenchmarkRustFS_MultiChunkRead_NoPrefetch-32   3   655297338 ns/op   16.00 gets/op
+BenchmarkRustFS_MultiChunkRead_Prefetch4-32    3   648818425 ns/op   16.00 gets/op
+```
+
+### #2 — end-to-end compression on real rustfs wire
+
+256 KiB highly-compressible payload, single chunk:
+
+```
+BenchmarkRustFS_Compress_None-32    3   4471951 ns/op   0.9993 ratio   262333 wire-bytes
+BenchmarkRustFS_Compress_Flate-32   3   3666167 ns/op    410.2 ratio      639 wire-bytes
+BenchmarkRustFS_Compress_GZip-32    3   3463025 ns/op    399.0 ratio      657 wire-bytes
+BenchmarkRustFS_Compress_ZLib-32    3   3929791 ns/op    406.4 ratio      645 wire-bytes
+```
+
+Real production payloads (SQL rows, JSON, protobuf) compress 2–8×,
+not 400×, but the wire-bytes reduction is proportional to the data's
+entropy and translates 1:1 into upload-time speedup on a
+bandwidth-constrained link.
+
+## Caveats
+
+- **Loopback rustfs has ~1 ms RTT.** All benches that don't inject
+  artificial latency under-report the win for #1 and #3 — the
+  RTT-amplified savings disappear when there's no RTT to amplify.
+  The headline numbers use the WAN-injection variant for #1 to
+  expose the architecture's actual value; #3 still measures
+  meaningfully on loopback because it's eliminating *operations*,
+  not just latency.
+- **Compression's wall-clock win is workload-dependent.** On a fast
+  link the 400× wire reduction shows up as a small (~20 %)
+  wall-clock improvement; on a slow link (cross-region, mobile
+  uplink) the same wire reduction can translate into 5–20× wall-clock
+  improvement.
+- **Multi-chunk + compression is single-chunk-Append only at the
+  moment.** singleapp's per-Append-frame model means one Append must
+  fit in one chunk; benchmarks that try to span chunk boundaries
+  with a compressed Append hang. Out of scope for this branch.
+- **Prefetch fires only on *sequential* reads.** Random / sparse
+  read patterns deliberately don't trigger prefetch (the sentinel
+  `prefetchPrevAppID < 0 || != appID-1` check), so the bandwidth
+  cost is bounded by what foreground would have read anyway.
+- **Resident memory ceiling.** Per-reader memory is bounded at
+  `DefaultReaderCacheWindows * DefaultReaderRangeCacheSize` (4 ×
+  1 MiB by default) regardless of chunk size. The pre-Wave-1 reader
+  pinned the entire chunk in `dataCache []byte`; on 64 MiB chunks
+  with 1000 concurrent readers that was 64 GiB resident vs the
+  current 4 GiB. Not measurable in microbenchmark, but a real
+  operational win at high reader concurrency on large chunks.
+
+## Recommendations
+
+Default configurations are tuned for the common case:
+
+- `WithVerifyUploads = false` (#3 enabled by default)
+- `WithPrefetchAheadDepth = 4` for remoteapp; `0` for plain multiapp (#1)
+- `WithCompressionFormat = NoCompression` (opt-in per workload — #2
+  is available but not on by default to avoid behavioural surprise on
+  existing deployments)
+- `WithReaderRangeCacheSize = 1 MiB`, `WithReaderCacheWindows = 4`
+  (range-fetch reader, already on master)
+
+Operators on slow / metered S3 links: enable compression with
+`WithCompressionFormat(appendable.FlateCompression)` or `GZip` on a
+per-database basis via the existing multiapp options surface.

--- a/embedded/appendable/multiapp/multi_app.go
+++ b/embedded/appendable/multiapp/multi_app.go
@@ -17,6 +17,7 @@ limitations under the License.
 package multiapp
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -31,6 +32,8 @@ import (
 	"github.com/codenotary/immudb/embedded/appendable/fileutils"
 	"github.com/codenotary/immudb/embedded/appendable/singleapp"
 	"github.com/codenotary/immudb/embedded/cache"
+
+	"golang.org/x/sync/singleflight"
 )
 
 var ErrorPathIsNotADirectory = errors.New("multiapp: path is not a directory")
@@ -116,6 +119,18 @@ type MultiFileAppendable struct {
 	hooks MultiFileAppendableHooks
 
 	mutex sync.Mutex
+
+	// Sequential read-ahead state. Background goroutines open the
+	// next prefetchAheadDepth chunks whenever ReadAt advances into a
+	// new chunk in monotonically increasing order. singleflight keys
+	// each open by appID so concurrent foreground+prefetch attempts
+	// for the same chunk do at most one OpenAppendable. Cancelled on
+	// Close via prefetchCancel.
+	prefetchAheadDepth int
+	prefetchCtx        context.Context
+	prefetchCancel     context.CancelFunc
+	prefetchSf         singleflight.Group
+	prefetchPrevAppID  int64 // -1 sentinel = no previous read
 }
 
 func Open(path string, opts *Options) (*MultiFileAppendable, error) {
@@ -187,22 +202,27 @@ func OpenWithHooks(path string, hooks MultiFileAppendableHooks, opts *Options) (
 
 	fileSize, _ := appendable.NewMetadata(currApp.Metadata()).GetInt(metaFileSize)
 
+	pCtx, pCancel := context.WithCancel(context.Background())
 	return &MultiFileAppendable{
-		appendables:    appendableCache{cache: cache},
-		currAppID:      currAppID,
-		currApp:        currApp,
-		path:           path,
-		readOnly:       opts.readOnly,
-		retryableSync:  opts.retryableSync,
-		autoSync:       opts.autoSync,
-		fileMode:       opts.fileMode,
-		fileSize:       fileSize,
-		fileExt:        opts.fileExt,
-		readBufferSize: opts.readBufferSize,
-		prealloc:       opts.prealloc,
-		writeBuffer:    writeBuffer,
-		closed:         false,
-		hooks:          hooks,
+		appendables:        appendableCache{cache: cache},
+		currAppID:          currAppID,
+		currApp:            currApp,
+		path:               path,
+		readOnly:           opts.readOnly,
+		retryableSync:      opts.retryableSync,
+		autoSync:           opts.autoSync,
+		fileMode:           opts.fileMode,
+		fileSize:           fileSize,
+		fileExt:            opts.fileExt,
+		readBufferSize:     opts.readBufferSize,
+		prealloc:           opts.prealloc,
+		writeBuffer:        writeBuffer,
+		closed:             false,
+		hooks:              hooks,
+		prefetchAheadDepth: opts.prefetchAheadDepth,
+		prefetchCtx:        pCtx,
+		prefetchCancel:     pCancel,
+		prefetchPrevAppID:  -1,
 	}, nil
 }
 
@@ -532,9 +552,9 @@ func (mf *MultiFileAppendable) DiscardUpto(off int64) error {
 
 func (mf *MultiFileAppendable) appendableFor(off int64) (appendable.Appendable, error) {
 	mf.mutex.Lock()
-	defer mf.mutex.Unlock()
 
 	if mf.closed {
+		mf.mutex.Unlock()
 		return nil, ErrAlreadyClosed
 	}
 
@@ -542,50 +562,247 @@ func (mf *MultiFileAppendable) appendableFor(off int64) (appendable.Appendable, 
 
 	if appID == mf.currAppID {
 		metricsCacheHit.Inc()
+		mf.maybePrefetchAheadLocked(appID)
+		mf.mutex.Unlock()
 		return mf.currApp, nil
 	}
 
-	app, err := mf.appendables.Get(appID)
-
-	if err != nil {
-		if !errors.Is(err, cache.ErrKeyNotFound) {
-			return nil, err
-		}
-
-		metricsCacheMiss.Inc()
-
-		raw, err := mf.openAppendable(appendableName(appID, mf.fileExt), false, false)
-		if err != nil {
-			return nil, err
-		}
-
-		_, ejectedApp, err := mf.appendables.Put(appID, raw)
-		if err != nil {
-			return nil, err
-		}
-
-		if ejectedApp != nil {
-			metricsCacheEvicted.Inc()
-			err = ejectedApp.Close()
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		// Re-fetch via Get so the caller gets the refcounted wrapper
-		// (with one ref already taken). Returning the raw pointer
-		// from openAppendable would bypass the refcount and reproduce
-		// the close-while-reading race that this whole machinery
-		// exists to prevent.
-		app, err = mf.appendables.Get(appID)
-		if err != nil {
-			return nil, err
-		}
-	} else {
+	// Cache hit fast path.
+	if app, gerr := mf.appendables.Get(appID); gerr == nil {
 		metricsCacheHit.Inc()
+		mf.maybePrefetchAheadLocked(appID)
+		mf.mutex.Unlock()
+		return app, nil
+	} else if !errors.Is(gerr, cache.ErrKeyNotFound) {
+		mf.mutex.Unlock()
+		return nil, gerr
 	}
 
+	metricsCacheMiss.Inc()
+
+	// Snapshot the writer-mutable bits the open path needs, then
+	// drop the mutex so the slow openAppendable can run in parallel
+	// with other readers and (more importantly) with any in-flight
+	// background prefetch for the same appID. Foreground and
+	// prefetch coalesce on mf.prefetchSf so a single Get covers both.
+	snap := openAppendableSnapshot{
+		compressionFormat: mf.currApp.CompressionFormat(),
+		compressionLevel:  mf.currApp.CompressionLevel(),
+		metadata:          mf.currApp.Metadata(),
+	}
+	mf.mutex.Unlock()
+
+	key := strconv.FormatInt(appID, 10)
+	_, err, _ := mf.prefetchSf.Do(key, func() (interface{}, error) {
+		// Race check: someone may have inserted while we were
+		// waiting for the singleflight slot.
+		mf.mutex.Lock()
+		if mf.closed {
+			mf.mutex.Unlock()
+			return nil, ErrAlreadyClosed
+		}
+		if v, gerr := mf.appendables.Get(appID); gerr == nil {
+			mf.mutex.Unlock()
+			if rc, ok := v.(*refCountedApp); ok {
+				_ = rc.Release()
+			}
+			return nil, nil
+		}
+		mf.mutex.Unlock()
+
+		raw, err := mf.openAppendableFromSnapshot(snap, appendableName(appID, mf.fileExt), false, false)
+		if err != nil {
+			return nil, err
+		}
+
+		mf.mutex.Lock()
+		defer mf.mutex.Unlock()
+		if mf.closed {
+			_ = raw.Close()
+			return nil, ErrAlreadyClosed
+		}
+		// One last cache check: another opener might have raced us
+		// while our open was outstanding.
+		if v, gerr := mf.appendables.Get(appID); gerr == nil {
+			if rc, ok := v.(*refCountedApp); ok {
+				_ = rc.Release()
+			}
+			_ = raw.Close()
+			return nil, nil
+		}
+		_, ejected, perr := mf.appendables.Put(appID, raw)
+		if perr != nil {
+			_ = raw.Close()
+			return nil, perr
+		}
+		if ejected != nil {
+			metricsCacheEvicted.Inc()
+			_ = ejected.Close()
+		}
+		return nil, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	mf.mutex.Lock()
+	defer mf.mutex.Unlock()
+
+	if mf.closed {
+		return nil, ErrAlreadyClosed
+	}
+
+	app, err := mf.appendables.Get(appID)
+	if err != nil {
+		return nil, err
+	}
+
+	mf.maybePrefetchAheadLocked(appID)
 	return app, nil
+}
+
+// openAppendableSnapshot is a snapshot of the bits that openAppendable
+// reads from mutable struct fields. Captured under mf.mutex by
+// maybePrefetchAheadLocked so the spawned prefetch goroutine can call
+// the per-singleapp open path without taking the multiapp mutex (and
+// thus without serializing on the writer's chunk-rotation update of
+// currApp).
+type openAppendableSnapshot struct {
+	compressionFormat int
+	compressionLevel  int
+	metadata          []byte
+}
+
+// maybePrefetchAheadLocked spawns background opens for the next
+// prefetchAheadDepth chunks when the read pattern is sequential
+// (current appID == previous appID + 1). For remoteapp-backed
+// multiapps, each open downloads ~rangeCacheSize bytes — running
+// them in parallel with the consumer overlaps per-chunk RTT with
+// per-chunk decode work. Uses singleflight so a foreground miss on
+// the same appID coalesces with an in-flight prefetch instead of
+// duplicating the open.
+//
+// Caller must hold mf.mutex. The spawned goroutines do NOT take
+// mf.mutex during their open call (they take it briefly only to
+// insert into the cache), so foreground readers don't block on a
+// background network I/O.
+func (mf *MultiFileAppendable) maybePrefetchAheadLocked(appID int64) {
+	if mf.prefetchAheadDepth <= 0 {
+		mf.prefetchPrevAppID = appID
+		return
+	}
+	if mf.closed {
+		return
+	}
+	if mf.prefetchPrevAppID < 0 || mf.prefetchPrevAppID != appID-1 {
+		// Not sequential — could be a random-access workload, or
+		// the very first read (prefetchPrevAppID = -1 sentinel).
+		// Reset and skip prefetch; we don't want to download
+		// speculative chunks for random patterns or when we
+		// haven't yet established a sequential trend.
+		mf.prefetchPrevAppID = appID
+		return
+	}
+	mf.prefetchPrevAppID = appID
+
+	// Snapshot the per-currApp bits under the mutex so the goroutine
+	// doesn't read mf.currApp concurrently with the writer's
+	// chunk-rotation. CompressionFormat/Level/Metadata are themselves
+	// stable across an appendable's lifetime, but mf.currApp is a
+	// pointer that the writer reassigns when rotating to the next
+	// chunk — that pointer reassignment is the race we're avoiding.
+	snap := openAppendableSnapshot{
+		compressionFormat: mf.currApp.CompressionFormat(),
+		compressionLevel:  mf.currApp.CompressionLevel(),
+		metadata:          mf.currApp.Metadata(),
+	}
+
+	ctx := mf.prefetchCtx
+	for i := int64(1); i <= int64(mf.prefetchAheadDepth); i++ {
+		nextID := appID + i
+		// Don't prefetch the writer's currently active chunk or
+		// anything beyond it. For remoteapp the OpenAppendable
+		// hook would extend chunkInfos for nonexistent IDs and
+		// leave intermediate slots in chunkState_Invalid, which
+		// the writer then trips on with ErrInvalidChunkState.
+		if nextID >= mf.currAppID {
+			break
+		}
+		// Already cached?
+		if v, err := mf.appendables.Get(nextID); err == nil {
+			if rc, ok := v.(*refCountedApp); ok {
+				_ = rc.Release()
+			}
+			continue
+		}
+
+		key := strconv.FormatInt(nextID, 10)
+		go mf.prefetchOne(ctx, nextID, key, snap)
+	}
+}
+
+// prefetchOne is the worker that actually issues an open for the
+// pre-warmed chunk. Runs in its own goroutine; coalesces concurrent
+// callers via singleflight; bails on context cancellation.
+func (mf *MultiFileAppendable) prefetchOne(ctx context.Context, appID int64, key string, snap openAppendableSnapshot) {
+	_, _, _ = mf.prefetchSf.Do(key, func() (interface{}, error) {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		raw, err := mf.openAppendableFromSnapshot(snap, appendableName(appID, mf.fileExt), false, false)
+		if err != nil {
+			return nil, err
+		}
+
+		mf.mutex.Lock()
+		defer mf.mutex.Unlock()
+
+		if mf.closed {
+			_ = raw.Close()
+			return nil, ErrAlreadyClosed
+		}
+		// Lost the race against another opener? Drop our raw, keep
+		// what's already cached.
+		if existing, gerr := mf.appendables.Get(appID); gerr == nil {
+			if rc, ok := existing.(*refCountedApp); ok {
+				_ = rc.Release()
+			}
+			_ = raw.Close()
+			return nil, nil
+		}
+		_, ejected, perr := mf.appendables.Put(appID, raw)
+		if perr != nil {
+			_ = raw.Close()
+			return nil, perr
+		}
+		if ejected != nil {
+			_ = ejected.Close()
+		}
+		return nil, nil
+	})
+}
+
+// openAppendableFromSnapshot is the lock-free variant of
+// openAppendable used by the prefetch goroutine. It reads only
+// invariant struct fields (set once at construction) plus the
+// caller-supplied snapshot of the writer-mutable currApp bits.
+func (mf *MultiFileAppendable) openAppendableFromSnapshot(snap openAppendableSnapshot, appname string, createIfNotExists, activeChunk bool) (appendable.Appendable, error) {
+	appendableOpts := singleapp.DefaultOptions().
+		WithReadOnly(mf.readOnly).
+		WithRetryableSync(mf.retryableSync).
+		WithAutoSync(mf.autoSync).
+		WithFileMode(mf.fileMode).
+		WithCreateIfNotExists(createIfNotExists).
+		WithReadBufferSize(mf.readBufferSize).
+		WithCompressionFormat(snap.compressionFormat).
+		WithCompresionLevel(snap.compressionLevel).
+		WithMetadata(snap.metadata)
+
+	if mf.prealloc {
+		appendableOpts.WithPreallocSize(mf.fileSize)
+	}
+
+	return mf.hooks.OpenAppendable(appendableOpts, appname, activeChunk)
 }
 
 func (mf *MultiFileAppendable) ReadAt(bs []byte, off int64) (int, error) {
@@ -714,6 +931,11 @@ func (mf *MultiFileAppendable) Close() error {
 	}
 
 	mf.closed = true
+	if mf.prefetchCancel != nil {
+		// Stop accepting new prefetch starts; in-flight ones will
+		// notice mf.closed when they reach the cache-insert step.
+		mf.prefetchCancel()
+	}
 
 	err := mf.appendables.Apply(func(k int64, v appendable.Appendable) error {
 		return v.Close()

--- a/embedded/appendable/multiapp/options.go
+++ b/embedded/appendable/multiapp/options.go
@@ -47,6 +47,15 @@ type Options struct {
 	maxOpenedFiles    int
 	compressionFormat int
 	compressionLevel  int
+
+	// prefetchAheadDepth, if > 0, kicks off background opens of the
+	// next K chunks whenever a sequential ReadAt advances into a new
+	// chunk. Default 0 (off) — local FS opens are cheap and the
+	// inline open path already handles them. Remote-storage backed
+	// multiapps (remoteapp) bump this to 4 by default so each chunk's
+	// network-bound open overlaps with the consumer's per-chunk work
+	// instead of serializing on the Get RTT.
+	prefetchAheadDepth int
 }
 
 func DefaultOptions() *Options {
@@ -156,6 +165,15 @@ func (opts *Options) WithWriteBufferSize(size int) *Options {
 func (opts *Options) WithPrealloc(prealloc bool) *Options {
 	opts.prealloc = prealloc
 	return opts
+}
+
+func (opts *Options) WithPrefetchAheadDepth(depth int) *Options {
+	opts.prefetchAheadDepth = depth
+	return opts
+}
+
+func (opts *Options) GetPrefetchAheadDepth() int {
+	return opts.prefetchAheadDepth
 }
 
 func (opt *Options) GetFileExt() string {

--- a/embedded/appendable/remoteapp/lazy_remote_reader.go
+++ b/embedded/appendable/remoteapp/lazy_remote_reader.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2026 Codenotary Inc. All rights reserved.
+
+SPDX-License-Identifier: BUSL-1.1
+*/
+
+package remoteapp
+
+import (
+	"sync"
+
+	"github.com/codenotary/immudb/embedded/appendable"
+)
+
+// lazyRemoteReader is an Appendable that defers opening its inner
+// remote-storage reader until the first ReadAt call. It exists so the
+// post-upload cache swap in RemoteStorageAppendable.uploadChunk can
+// hand the multiapp cache a placeholder without paying a chunk-window
+// download right after the Put — most uploaded chunks are never read
+// again, and on those the deferred open is a pure savings.
+//
+// On first ReadAt, `open` runs once (sync.Once); the result is
+// cached. Close is safe whether or not the inner has been opened.
+//
+// All write- and metadata-side methods panic with "unimplemented",
+// matching the behaviour of remoteStorageReader (the type that `open`
+// returns). The lazy wrapper never claims to support anything the
+// underlying remote reader doesn't.
+type lazyRemoteReader struct {
+	open func() (appendable.Appendable, error)
+
+	once  sync.Once
+	inner appendable.Appendable
+	err   error
+}
+
+func newLazyRemoteReader(open func() (appendable.Appendable, error)) *lazyRemoteReader {
+	return &lazyRemoteReader{open: open}
+}
+
+func (l *lazyRemoteReader) ensure() (appendable.Appendable, error) {
+	l.once.Do(func() {
+		l.inner, l.err = l.open()
+	})
+	return l.inner, l.err
+}
+
+func (l *lazyRemoteReader) ReadAt(bs []byte, off int64) (int, error) {
+	inner, err := l.ensure()
+	if err != nil {
+		return 0, err
+	}
+	return inner.ReadAt(bs, off)
+}
+
+func (l *lazyRemoteReader) Close() error {
+	if l.inner != nil {
+		return l.inner.Close()
+	}
+	return nil
+}
+
+func (l *lazyRemoteReader) Flush() error                  { return nil }
+func (l *lazyRemoteReader) Sync() error                   { return nil }
+func (l *lazyRemoteReader) SwitchToReadOnlyMode() error   { return nil }
+func (l *lazyRemoteReader) Metadata() []byte              { panic("unimplemented") }
+func (l *lazyRemoteReader) Size() (int64, error)          { panic("unimplemented") }
+func (l *lazyRemoteReader) Offset() int64                 { panic("unimplemented") }
+func (l *lazyRemoteReader) SetOffset(off int64) error     { panic("unimplemented") }
+func (l *lazyRemoteReader) DiscardUpto(off int64) error   { panic("unimplemented") }
+func (l *lazyRemoteReader) Append(bs []byte) (int64, int, error) {
+	panic("unimplemented")
+}
+func (l *lazyRemoteReader) CompressionFormat() int { panic("unimplemented") }
+func (l *lazyRemoteReader) CompressionLevel() int  { panic("unimplemented") }
+func (l *lazyRemoteReader) Copy(dstPath string) error {
+	panic("unimplemented")
+}
+
+var _ appendable.Appendable = (*lazyRemoteReader)(nil)

--- a/embedded/appendable/remoteapp/lazy_remote_reader_test.go
+++ b/embedded/appendable/remoteapp/lazy_remote_reader_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2026 Codenotary Inc. All rights reserved.
+
+SPDX-License-Identifier: BUSL-1.1
+*/
+
+package remoteapp
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/codenotary/immudb/embedded/appendable"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeAppendable struct {
+	closeErr  error
+	closeCnt  int
+	readAtErr error
+}
+
+func (f *fakeAppendable) Close() error                         { f.closeCnt++; return f.closeErr }
+func (f *fakeAppendable) ReadAt(bs []byte, off int64) (int, error) {
+	if f.readAtErr != nil {
+		return 0, f.readAtErr
+	}
+	return len(bs), nil
+}
+func (f *fakeAppendable) Flush() error                         { return nil }
+func (f *fakeAppendable) Sync() error                          { return nil }
+func (f *fakeAppendable) SwitchToReadOnlyMode() error          { return nil }
+func (f *fakeAppendable) Metadata() []byte                     { return nil }
+func (f *fakeAppendable) Size() (int64, error)                 { return 0, nil }
+func (f *fakeAppendable) Offset() int64                        { return 0 }
+func (f *fakeAppendable) SetOffset(off int64) error            { return nil }
+func (f *fakeAppendable) DiscardUpto(off int64) error          { return nil }
+func (f *fakeAppendable) Append(bs []byte) (int64, int, error) { return 0, 0, nil }
+func (f *fakeAppendable) CompressionFormat() int               { return 0 }
+func (f *fakeAppendable) CompressionLevel() int                { return 0 }
+func (f *fakeAppendable) Copy(dstPath string) error            { return nil }
+
+func TestLazyRemoteReader_ReadAtOpenError(t *testing.T) {
+	openErr := errors.New("open failed")
+	l := newLazyRemoteReader(func() (appendable.Appendable, error) {
+		return nil, openErr
+	})
+
+	n, err := l.ReadAt(make([]byte, 4), 0)
+	require.ErrorIs(t, err, openErr)
+	require.Zero(t, n)
+
+	// second call should hit the same cached error without reopening
+	n, err = l.ReadAt(make([]byte, 4), 0)
+	require.ErrorIs(t, err, openErr)
+	require.Zero(t, n)
+
+	// Close before any successful open is a no-op
+	require.NoError(t, l.Close())
+}
+
+func TestLazyRemoteReader_ReadAtOpensOnce(t *testing.T) {
+	calls := 0
+	inner := &fakeAppendable{}
+	l := newLazyRemoteReader(func() (appendable.Appendable, error) {
+		calls++
+		return inner, nil
+	})
+
+	for i := 0; i < 3; i++ {
+		n, err := l.ReadAt(make([]byte, 8), int64(i))
+		require.NoError(t, err)
+		require.Equal(t, 8, n)
+	}
+	require.Equal(t, 1, calls, "open should be invoked exactly once")
+
+	require.NoError(t, l.Close())
+	require.Equal(t, 1, inner.closeCnt)
+}
+
+func TestLazyRemoteReader_NoOpAndPanicStubs(t *testing.T) {
+	l := newLazyRemoteReader(func() (appendable.Appendable, error) {
+		return &fakeAppendable{}, nil
+	})
+
+	// no-ops return nil regardless of inner state
+	require.NoError(t, l.Flush())
+	require.NoError(t, l.Sync())
+	require.NoError(t, l.SwitchToReadOnlyMode())
+
+	// every metadata/write-side method is unimplemented for the lazy reader
+	require.Panics(t, func() { l.Metadata() })
+	require.Panics(t, func() { _, _ = l.Size() })
+	require.Panics(t, func() { l.Offset() })
+	require.Panics(t, func() { _ = l.SetOffset(0) })
+	require.Panics(t, func() { _ = l.DiscardUpto(0) })
+	require.Panics(t, func() { _, _, _ = l.Append(nil) })
+	require.Panics(t, func() { l.CompressionFormat() })
+	require.Panics(t, func() { l.CompressionLevel() })
+	require.Panics(t, func() { _ = l.Copy("/tmp/whatever") })
+}

--- a/embedded/appendable/remoteapp/options.go
+++ b/embedded/appendable/remoteapp/options.go
@@ -38,11 +38,33 @@ type Options struct {
 	// range-fetch ReadAt against the remote storage. 0 means "use
 	// DefaultReaderRangeCacheSize".
 	readerRangeCacheSize int
+
+	// verifyUploads, when true, retains the legacy post-upload
+	// behaviour: after Put, do an Exists round trip and then a fresh
+	// remote-reader open (which downloads at least one cache window
+	// of bytes) to confirm the chunk is readable, then swap the
+	// cache. False (default) skips Exists and substitutes a lazy
+	// reader that opens the chunk on the first subsequent ReadAt —
+	// most uploaded chunks are never read again, so this saves one
+	// RTT plus a window-sized download per upload on the common
+	// path. Modern S3 is read-after-write consistent, so the
+	// verification is no longer load-bearing.
+	verifyUploads bool
 }
 
+// DefaultPrefetchAheadDepth is how many chunks the multiapp layer
+// pre-warms on a sequential read. Each pre-warm is one S3 GET of
+// roughly DefaultReaderRangeCacheSize bytes, so the worst-case
+// extra in-flight bandwidth is depth × cache window. 4 is enough
+// to hide up to ~4 × RTT of consumer compute behind a single open;
+// at 50 ms S3 RTT that's 200 ms of latency overlapped with replay.
+const DefaultPrefetchAheadDepth = 4
+
 func DefaultOptions() *Options {
+	mopts := *multiapp.DefaultOptions()
+	mopts.WithPrefetchAheadDepth(DefaultPrefetchAheadDepth)
 	return &Options{
-		Options:              *multiapp.DefaultOptions(),
+		Options:              mopts,
 		parallelUploads:      10,
 		retryMinDelay:        time.Second,
 		retryMaxDelay:        2 * time.Minute,
@@ -125,5 +147,13 @@ func (opts *Options) WithRetryDelayJitter(retryDelayJitter float64) *Options {
 // default (DefaultReaderRangeCacheSize).
 func (opts *Options) WithReaderRangeCacheSize(size int) *Options {
 	opts.readerRangeCacheSize = size
+	return opts
+}
+
+// WithVerifyUploads toggles the legacy post-upload verification path
+// (Exists round trip + fresh remote-reader open). Defaults to false;
+// pass true to opt back into the legacy behaviour.
+func (opts *Options) WithVerifyUploads(verify bool) *Options {
+	opts.verifyUploads = verify
 	return opts
 }

--- a/embedded/appendable/remoteapp/options.go
+++ b/embedded/appendable/remoteapp/options.go
@@ -33,16 +33,22 @@ type Options struct {
 	retryMaxDelay    time.Duration
 	retryDelayExp    float64
 	retryDelayJitter float64
+
+	// readerRangeCacheSize is the per-reader sliding-window size for
+	// range-fetch ReadAt against the remote storage. 0 means "use
+	// DefaultReaderRangeCacheSize".
+	readerRangeCacheSize int
 }
 
 func DefaultOptions() *Options {
 	return &Options{
-		Options:          *multiapp.DefaultOptions(),
-		parallelUploads:  10,
-		retryMinDelay:    time.Second,
-		retryMaxDelay:    2 * time.Minute,
-		retryDelayExp:    2,
-		retryDelayJitter: 0.1,
+		Options:              *multiapp.DefaultOptions(),
+		parallelUploads:      10,
+		retryMinDelay:        time.Second,
+		retryMaxDelay:        2 * time.Minute,
+		retryDelayExp:        2,
+		retryDelayJitter:     0.1,
+		readerRangeCacheSize: DefaultReaderRangeCacheSize,
 	}
 }
 
@@ -110,5 +116,14 @@ func (opts *Options) WithRetryDelayExp(retryDelayExp float64) *Options {
 
 func (opts *Options) WithRetryDelayJitter(retryDelayJitter float64) *Options {
 	opts.retryDelayJitter = retryDelayJitter
+	return opts
+}
+
+// WithReaderRangeCacheSize sets the per-reader sliding-window cache size
+// used by the remote-storage reader to absorb sequential ReadAt calls
+// without re-issuing a Range GET each time. Pass 0 to keep the package
+// default (DefaultReaderRangeCacheSize).
+func (opts *Options) WithReaderRangeCacheSize(size int) *Options {
+	opts.readerRangeCacheSize = size
 	return opts
 }

--- a/embedded/appendable/remoteapp/remote_app.go
+++ b/embedded/appendable/remoteapp/remote_app.go
@@ -64,6 +64,7 @@ type RemoteStorageAppendable struct {
 	retryJitter   float64
 
 	readerRangeCacheSize int
+	verifyUploads        bool
 
 	mainContext           context.Context
 	mainCancelFunc        context.CancelFunc
@@ -104,6 +105,7 @@ func Open(path string, remotePath string, storage remotestorage.Storage, opts *O
 		retryDelayExp:        opts.retryDelayExp,
 		retryJitter:          opts.retryDelayJitter,
 		readerRangeCacheSize: opts.readerRangeCacheSize,
+		verifyUploads:        opts.verifyUploads,
 		mainContext:          mainContext,
 		mainCancelFunc:       mainCancelFunc,
 		uploadThrottler:      make(chan struct{}, opts.parallelUploads),
@@ -218,28 +220,41 @@ func (r *RemoteStorageAppendable) uploadChunk(chunkID int64, dontRemoveFile bool
 			return true, nil
 		})
 
-		// Wait for the chunk to become ready
-		cp.RetryableStep(func(retries int, delay time.Duration) (bool, error) {
-			exists, err := r.rStorage.Exists(ctx, r.remotePath+appName)
-			if err == nil && exists {
-				return false, nil
-			}
+		if r.verifyUploads {
+			// Legacy behaviour: confirm Exists then open a fresh
+			// remote reader (which downloads at least one window of
+			// bytes) before swapping the cache.
+			cp.RetryableStep(func(retries int, delay time.Duration) (bool, error) {
+				exists, err := r.rStorage.Exists(ctx, r.remotePath+appName)
+				if err == nil && exists {
+					return false, nil
+				}
 
-			metricsUploadRetried.Inc()
-			return true, nil
-		})
+				metricsUploadRetried.Inc()
+				return true, nil
+			})
 
-		// Open new appendable from the remote storage
-		cp.RetryableStep(func(retries int, delay time.Duration) (bool, error) {
-			app, err := r.openRemoteAppendableReader(appName)
-			if err == nil {
-				newApp = app
-				return false, nil
-			}
+			cp.RetryableStep(func(retries int, delay time.Duration) (bool, error) {
+				app, err := r.openRemoteAppendableReader(appName)
+				if err == nil {
+					newApp = app
+					return false, nil
+				}
 
-			metricsUploadRetried.Inc()
-			return true, nil
-		})
+				metricsUploadRetried.Inc()
+				return true, nil
+			})
+		} else {
+			// Fast path: trust S3's read-after-write consistency,
+			// skip the Exists round trip and the verification
+			// download. Hand the cache a lazy wrapper that opens
+			// the remote reader on first ReadAt — most uploaded
+			// chunks are never read again, so the open cost is
+			// usually deferred forever.
+			newApp = newLazyRemoteReader(func() (appendable.Appendable, error) {
+				return r.openRemoteAppendableReader(appName)
+			})
+		}
 
 		// Replace the cached instance of appendable for the chunk
 		cp.Step(func() error {
@@ -416,9 +431,12 @@ func (r *RemoteStorageAppendable) Close() error {
 }
 
 func (r *RemoteStorageAppendable) OpenAppendable(options *singleapp.Options, appname string, activeChunk bool) (appendable.Appendable, error) {
-	if options.GetCompressionFormat() != appendable.NoCompression {
-		return nil, ErrCompressionNotSupported
-	}
+	// Compression is now supported end-to-end. The local writer (the
+	// active chunk) compresses each Append into a length-prefixed
+	// frame; on upload the chunk file is uploaded as-is; on read,
+	// remoteStorageReader detects the compression format from the
+	// chunk's metadata header and reproduces the same per-frame
+	// decompress protocol that singleapp uses locally.
 
 	r.mutex.Lock()
 	defer r.mutex.Unlock()

--- a/embedded/appendable/remoteapp/remote_app.go
+++ b/embedded/appendable/remoteapp/remote_app.go
@@ -63,6 +63,8 @@ type RemoteStorageAppendable struct {
 	retryDelayExp float64
 	retryJitter   float64
 
+	readerRangeCacheSize int
+
 	mainContext           context.Context
 	mainCancelFunc        context.CancelFunc
 	uploadThrottler       chan struct{}
@@ -97,13 +99,14 @@ func Open(path string, remotePath string, storage remotestorage.Storage, opts *O
 		fileExt:         opts.GetFileExt(),
 		fileMode:        opts.GetFileMode(),
 		remotePath:      remotePath,
-		retryMinDelay:   opts.retryMinDelay,
-		retryMaxDelay:   opts.retryMaxDelay,
-		retryDelayExp:   opts.retryDelayExp,
-		retryJitter:     opts.retryDelayJitter,
-		mainContext:     mainContext,
-		mainCancelFunc:  mainCancelFunc,
-		uploadThrottler: make(chan struct{}, opts.parallelUploads),
+		retryMinDelay:        opts.retryMinDelay,
+		retryMaxDelay:        opts.retryMaxDelay,
+		retryDelayExp:        opts.retryDelayExp,
+		retryJitter:          opts.retryDelayJitter,
+		readerRangeCacheSize: opts.readerRangeCacheSize,
+		mainContext:          mainContext,
+		mainCancelFunc:       mainCancelFunc,
+		uploadThrottler:      make(chan struct{}, opts.parallelUploads),
 	}
 	ret.chunkUploadFinished = sync.NewCond(&ret.mutex)
 	ret.chunkDownloadFinished = sync.NewCond(&ret.mutex)
@@ -619,6 +622,7 @@ func (r *RemoteStorageAppendable) openRemoteAppendableReader(name string) (appen
 	return openRemoteStorageReader(
 		r.rStorage,
 		r.remotePath+name,
+		r.readerRangeCacheSize,
 	)
 }
 

--- a/embedded/appendable/remoteapp/remote_app_test.go
+++ b/embedded/appendable/remoteapp/remote_app_test.go
@@ -83,13 +83,33 @@ func TestOpenRemoteStorageAppendable(t *testing.T) {
 }
 
 func TestOpenRemoteStorageAppendableCompression(t *testing.T) {
+	// Compression is now supported end-to-end through remoteapp.
+	// Open should succeed; a round-trip Append + ReadAt must
+	// return the original bytes after going via the remote
+	// storage and through the per-frame decompress path.
 	opts := DefaultOptions()
 	opts.WithCompressionFormat(appendable.FlateCompression).
-		WithCompresionLevel(appendable.BestCompression)
+		WithCompresionLevel(appendable.BestCompression).
+		WithFileSize(64).
+		WithFileExt("aof")
 
-	app, err := Open(t.TempDir(), "", memory.Open(), opts)
-	require.ErrorIs(t, err, ErrCompressionNotSupported)
-	require.Nil(t, app)
+	mem := memory.Open()
+	app, err := Open(t.TempDir(), "", mem, opts)
+	require.NoError(t, err)
+	defer app.Close()
+
+	payload := []byte("compressible compressible compressible compressible payload")
+	off, n, err := app.Append(payload)
+	require.NoError(t, err)
+	require.EqualValues(t, len(payload), n)
+
+	require.NoError(t, app.Flush())
+
+	got := make([]byte, len(payload))
+	rn, err := app.ReadAt(got, off)
+	require.NoError(t, err)
+	require.EqualValues(t, len(payload), rn)
+	require.Equal(t, payload, got)
 }
 
 func TestRemoteStorageOpenAppendableInvalidName(t *testing.T) {
@@ -479,7 +499,13 @@ func TestRemoteStorageUploadRetry(t *testing.T) {
 		},
 	}
 
-	opts := DefaultOptions().WithRetryMinDelay(time.Microsecond).WithRetryMaxDelay(time.Microsecond)
+	// Opt into the legacy verification path so the Get + Exists
+	// retry counters this test cares about are still on. The default
+	// fast path skips both round trips.
+	opts := DefaultOptions().
+		WithRetryMinDelay(time.Microsecond).
+		WithRetryMaxDelay(time.Microsecond).
+		WithVerifyUploads(true)
 	opts.WithFileExt("tst").WithFileSize(10)
 	app, err := Open(path, "", mem, opts)
 	require.NoError(t, err)
@@ -544,7 +570,11 @@ func TestRemoteStorageUploadCancel(t *testing.T) {
 
 			}
 
-			opts := DefaultOptions()
+			// Get / Exists error injections fire only on the legacy
+			// post-upload verification path. Opt back into it for
+			// this test so the cancel-during-retry semantics stay
+			// observable.
+			opts := DefaultOptions().WithVerifyUploads(true)
 			opts.WithFileExt("tst").WithFileSize(10)
 			app, err := Open(path, "", mem, opts)
 			require.NoError(t, err)

--- a/embedded/appendable/remoteapp/remote_storage_reader.go
+++ b/embedded/appendable/remoteapp/remote_storage_reader.go
@@ -5,26 +5,56 @@ import (
 	"encoding/binary"
 	"io"
 	"io/ioutil"
+	"sync"
 
 	"github.com/codenotary/immudb/embedded/appendable"
 	"github.com/codenotary/immudb/embedded/remotestorage"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+// DefaultReaderRangeCacheSize is the per-reader sliding window used to
+// service ReadAt without re-issuing an S3 GET on every call. It also
+// caps the open-time header download — the open path does one GET of
+// this size, parses the metadata length prefix from the first 4 bytes,
+// keeps the trailing payload bytes as the initial cache, and (when the
+// response was strictly shorter than the request) pins the payload size
+// so subsequent ReadAt past EOF can short-circuit without an S3 round
+// trip.
+//
+// 256 KiB is large enough that hot-restore replay and SQL scans fall
+// almost entirely inside the cache while sequentially walking a chunk,
+// and small enough that random-access patterns don't drag a megabyte
+// per ReadAt call. Tunable via WithReaderRangeCacheSize on the
+// remoteapp options.
+const DefaultReaderRangeCacheSize = 256 * 1024
+
 type remoteStorageReader struct {
-	r          remotestorage.Storage
-	name       string
-	baseOffset int64
-	dataCache  []byte // Initially we read the whole object into data cache
+	r              remotestorage.Storage
+	name           string
+	baseOffset     int64
+	rangeCacheSize int
+
+	mu          sync.Mutex
+	cache       []byte // payload bytes [cacheOffs, cacheOffs+len(cache))
+	cacheOffs   int64
+	sizeKnown   bool
+	payloadSize int64 // valid only when sizeKnown
 }
 
-func openRemoteStorageReader(r remotestorage.Storage, name string) (*remoteStorageReader, error) {
+func openRemoteStorageReader(r remotestorage.Storage, name string, rangeCacheSize int) (*remoteStorageReader, error) {
 	defer prometheus.NewTimer(metricsOpenTime).ObserveDuration()
+
+	if rangeCacheSize <= 0 {
+		rangeCacheSize = DefaultReaderRangeCacheSize
+	}
 
 	ctx := context.Background()
 
-	// Read header
-	reader, err := r.Get(ctx, name, 0, -1)
+	// Read header + as much of the leading payload as fits in one window.
+	// A short response (len < rangeCacheSize) means we've seen the whole
+	// object, in which case pin payloadSize so out-of-range ReadAt calls
+	// don't issue a wasted GET.
+	reader, err := r.Get(ctx, name, 0, int64(rangeCacheSize))
 	if err != nil {
 		metricsUncachedReadErrors.Inc()
 		return nil, err
@@ -42,20 +72,25 @@ func openRemoteStorageReader(r remotestorage.Storage, name string) (*remoteStora
 		return nil, ErrCorruptedMetadata
 	}
 
-	// TODO: Read the metadata and validate it
-
 	baseOffset := int64(4 + binary.BigEndian.Uint32(data[:4]))
 	if baseOffset > int64(len(data)) {
 		metricsCorruptedMetadata.Inc()
 		return nil, ErrCorruptedMetadata
 	}
 
-	return &remoteStorageReader{
-		r:          r,
-		name:       name,
-		baseOffset: baseOffset,
-		dataCache:  data[baseOffset:],
-	}, nil
+	sr := &remoteStorageReader{
+		r:              r,
+		name:           name,
+		baseOffset:     baseOffset,
+		rangeCacheSize: rangeCacheSize,
+		cache:          data[baseOffset:],
+		cacheOffs:      0,
+	}
+	if int64(len(data)) < int64(rangeCacheSize) {
+		sr.sizeKnown = true
+		sr.payloadSize = int64(len(sr.cache))
+	}
+	return sr, nil
 }
 
 func (r *remoteStorageReader) Metadata() []byte {
@@ -106,31 +141,79 @@ func (r *remoteStorageReader) ReadAt(bs []byte, off int64) (int, error) {
 	if off < 0 {
 		return 0, ErrIllegalArguments
 	}
+	if len(bs) == 0 {
+		return 0, nil
+	}
 
-	if off > int64(len(r.dataCache)) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.sizeKnown && off >= r.payloadSize {
 		return 0, io.EOF
 	}
 
-	readBytes := copy(bs, r.dataCache[off:])
-	metricsReads.Inc()
-	metricsReadBytes.Add(float64(readBytes))
-	if readBytes < len(bs) {
-		return readBytes, io.EOF
-	}
-	return readBytes, nil
+	// Fast path: requested range starts inside the cache.
+	if off >= r.cacheOffs && off < r.cacheOffs+int64(len(r.cache)) {
+		rel := off - r.cacheOffs
+		n := copy(bs, r.cache[rel:])
+		metricsReads.Inc()
+		metricsReadBytes.Add(float64(n))
 
-	// reader, err := r.r.Get(context.Background(), r.name, off+r.baseOffset, int64(len(bs)))
-	// if err != nil {
-	// 	return 0, err
-	// }
-	// n, err := return io.ReadAtLeast(reader, bs, 1)
-	// if err != nil {
-	// 	return n, err
-	// }
-	// if n < len(bs) {
-	//	return n, io.EOF
-	// }
-	// return n, nil
+		if n == len(bs) {
+			return n, nil
+		}
+		// Cache covered the prefix but not the tail. Either we ran off the
+		// end of the cache window (need another GET) or off the end of the
+		// object (return EOF without one).
+		if r.sizeKnown && off+int64(n) >= r.payloadSize {
+			return n, io.EOF
+		}
+		more, err := r.fetchAndCopyLocked(bs[n:], off+int64(n))
+		return n + more, err
+	}
+
+	// Cache miss — fetch a fresh window centered on `off`.
+	return r.fetchAndCopyLocked(bs, off)
+}
+
+// fetchAndCopyLocked issues a Range GET starting at payload offset `off`
+// big enough to cover the request, refreshes the per-reader cache with
+// the result, and copies into bs. Caller must hold r.mu.
+func (r *remoteStorageReader) fetchAndCopyLocked(bs []byte, off int64) (int, error) {
+	fetchLen := int64(r.rangeCacheSize)
+	if int64(len(bs)) > fetchLen {
+		fetchLen = int64(len(bs))
+	}
+
+	ctx := context.Background()
+	reader, err := r.r.Get(ctx, r.name, off+r.baseOffset, fetchLen)
+	if err != nil {
+		metricsUncachedReadErrors.Inc()
+		return 0, err
+	}
+	data, err := ioutil.ReadAll(reader)
+	reader.Close()
+	if err != nil {
+		metricsUncachedReadErrors.Inc()
+		return 0, err
+	}
+	metricsUncachedReads.Inc()
+	metricsUncachedReadBytes.Add(float64(len(data)))
+
+	r.cache = data
+	r.cacheOffs = off
+	if int64(len(data)) < fetchLen {
+		r.sizeKnown = true
+		r.payloadSize = off + int64(len(data))
+	}
+
+	n := copy(bs, data)
+	metricsReads.Inc()
+	metricsReadBytes.Add(float64(n))
+	if n < len(bs) {
+		return n, io.EOF
+	}
+	return n, nil
 }
 
 func (r *remoteStorageReader) Close() error {

--- a/embedded/appendable/remoteapp/remote_storage_reader.go
+++ b/embedded/appendable/remoteapp/remote_storage_reader.go
@@ -1,6 +1,11 @@
 package remoteapp
 
 import (
+	"bytes"
+	"compress/flate"
+	"compress/gzip"
+	"compress/lzw"
+	"compress/zlib"
 	"context"
 	"encoding/binary"
 	"io"
@@ -8,25 +13,41 @@ import (
 	"sync"
 
 	"github.com/codenotary/immudb/embedded/appendable"
+	"github.com/codenotary/immudb/embedded/appendable/singleapp"
 	"github.com/codenotary/immudb/embedded/remotestorage"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// DefaultReaderRangeCacheSize is the per-reader sliding window used to
-// service ReadAt without re-issuing an S3 GET on every call. It also
-// caps the open-time header download — the open path does one GET of
-// this size, parses the metadata length prefix from the first 4 bytes,
-// keeps the trailing payload bytes as the initial cache, and (when the
-// response was strictly shorter than the request) pins the payload
-// size so subsequent ReadAt past EOF can short-circuit without an S3
-// round trip.
+// DefaultReaderRangeCacheSize is the per-window size used by the
+// remote-storage reader's LRU cache. Sized to match immudb's default
+// multiapp chunk size (`WithFileSize(1<<20)` = 1 MiB), so a sequential
+// full-chunk read on a default-configured deployment does **one** S3
+// GET on open — same as the pre-Wave-1 reader — while a partial read
+// of a large chunk still pays only the windows it actually touches.
 //
-// 256 KiB is large enough that hot-restore replay and SQL scans fall
-// almost entirely inside the cache while sequentially walking a chunk,
-// and small enough that random-access patterns don't drag a megabyte
-// per ReadAt call. Tunable via WithReaderRangeCacheSize on the
-// remoteapp options.
-const DefaultReaderRangeCacheSize = 256 * 1024
+// Tunable via WithReaderRangeCacheSize on the remoteapp options.
+const DefaultReaderRangeCacheSize = 1 * 1024 * 1024
+
+// openHeaderSlack is the extra bytes the open-time GET pulls beyond
+// `rangeCacheSize` so the first cached window covers a full aligned
+// payload region even after the variable-length metadata header is
+// stripped. Without this, baseOffset (4 + metadata length) eats into
+// the first window, the payload portion ends before the next aligned
+// window boundary, and the next read past it forces an extra GET to
+// fetch a window we'd otherwise have ended on. 4 KiB is large enough
+// for any plausible appendable metadata while staying tiny relative
+// to the cache window.
+const openHeaderSlack = 4096
+
+// DefaultReaderCacheWindows is the LRU depth of the per-reader cache.
+// Each cached window is up to DefaultReaderRangeCacheSize bytes, so
+// the worst-case resident memory per reader is
+// DefaultReaderCacheWindows * DefaultReaderRangeCacheSize.
+//
+// Depth 4 trades ~4 MiB per reader for an order-of-magnitude better
+// hit rate on sparse / random access patterns: revisiting a window
+// touched within the last 3 misses is a memcpy instead of an S3 GET.
+const DefaultReaderCacheWindows = 4
 
 // pendingFetch represents a single in-flight read-ahead Get. The
 // fetcher goroutine sets data/err and then closes done. Foreground
@@ -41,15 +62,33 @@ type pendingFetch struct {
 	err  error
 }
 
+// cachedWindow is one entry in the LRU. data holds payload bytes for
+// offsets [offs, offs+len(data)).
+type cachedWindow struct {
+	offs int64
+	data []byte
+}
+
 type remoteStorageReader struct {
 	r              remotestorage.Storage
 	name           string
 	baseOffset     int64
 	rangeCacheSize int
+	maxWindows     int
+
+	// compressionFormat is parsed from the chunk's metadata header
+	// at open time. When non-zero (i.e. anything other than
+	// appendable.NoCompression), ReadAt reproduces the per-entry
+	// length-prefix + decompress protocol that singleapp's writer
+	// uses, on top of the same range cache that handles raw byte
+	// fetches. compressionLevel is parsed alongside but only used
+	// for symmetry — the readers infer level from the compressed
+	// stream.
+	compressionFormat int
+	compressionLevel  int
 
 	mu          sync.Mutex
-	cache       []byte // payload bytes [cacheOffs, cacheOffs+len(cache))
-	cacheOffs   int64
+	windows     []cachedWindow // MRU at index 0, LRU at the tail
 	sizeKnown   bool
 	payloadSize int64 // valid only when sizeKnown
 
@@ -72,7 +111,8 @@ func openRemoteStorageReader(r remotestorage.Storage, name string, rangeCacheSiz
 	// window. A short response (len < rangeCacheSize) means we've
 	// seen the whole object, in which case pin payloadSize so
 	// out-of-range ReadAt calls don't issue a wasted GET.
-	reader, err := r.Get(ctx, name, 0, int64(rangeCacheSize))
+	openFetchSize := int64(rangeCacheSize) + openHeaderSlack
+	reader, err := r.Get(ctx, name, 0, openFetchSize)
 	if err != nil {
 		metricsUncachedReadErrors.Inc()
 		return nil, err
@@ -96,29 +136,45 @@ func openRemoteStorageReader(r remotestorage.Storage, name string, rangeCacheSiz
 		return nil, ErrCorruptedMetadata
 	}
 
+	// Parse the chunk metadata to find out whether the upstream
+	// writer used singleapp's per-entry compression. If yes, ReadAt
+	// reproduces the same length-prefix + decompress protocol;
+	// otherwise we serve raw bytes. Metadata key matches
+	// singleapp.MetaCompressionFormat (the on-disk format key).
+	//
+	// Defensive: NewMetadata panics on bytes that don't follow the
+	// expected TLV layout (some test fixtures + any non-singleapp
+	// producer). Recover and default to NoCompression rather than
+	// failing the whole open.
+	compressionFormat := appendable.NoCompression
+	if baseOffset > 4 {
+		compressionFormat = parseCompressionFormat(data[4:baseOffset])
+	}
+
 	pCtx, pCancel := context.WithCancel(context.Background())
 	sr := &remoteStorageReader{
-		r:              r,
-		name:           name,
-		baseOffset:     baseOffset,
-		rangeCacheSize: rangeCacheSize,
-		cache:          data[baseOffset:],
-		cacheOffs:      0,
+		r:                 r,
+		name:              name,
+		baseOffset:        baseOffset,
+		rangeCacheSize:    rangeCacheSize,
+		maxWindows:        DefaultReaderCacheWindows,
+		compressionFormat: compressionFormat,
+		windows: []cachedWindow{
+			{offs: 0, data: data[baseOffset:]},
+		},
 		prefetchCtx:    pCtx,
 		prefetchCancel: pCancel,
 	}
-	if int64(len(data)) < int64(rangeCacheSize) {
+	if int64(len(data)) < openFetchSize {
 		sr.sizeKnown = true
-		sr.payloadSize = int64(len(sr.cache))
-	} else {
-		// Pipeline the second window while the caller processes the
-		// first — Wave 2 read-ahead. Hot-restore replay, SQL scans,
-		// and replication catch-up all walk a chunk linearly, so this
-		// shaves one full RTT per window from the wall-clock.
-		sr.mu.Lock()
-		sr.maybeStartPrefetchLocked()
-		sr.mu.Unlock()
+		sr.payloadSize = int64(len(sr.windows[0].data))
 	}
+	// Wave 3: do NOT start a prefetch on open. If the consumer never
+	// issues a ReadAt past the initial window, no further GET fires.
+	// Prefetch is started lazily from fetchAndCopyLocked once we've
+	// observed an actual cache miss — that's evidence the consumer is
+	// reading sequentially past the cache and will benefit from the
+	// next window arriving in parallel.
 	return sr, nil
 }
 
@@ -147,11 +203,11 @@ func (r *remoteStorageReader) Append(bs []byte) (off int64, n int, err error) {
 }
 
 func (r *remoteStorageReader) CompressionFormat() int {
-	panic("unimplemented")
+	return r.compressionFormat
 }
 
 func (r *remoteStorageReader) CompressionLevel() int {
-	panic("unimplemented")
+	return r.compressionLevel
 }
 
 func (r *remoteStorageReader) Flush() error {
@@ -166,6 +222,11 @@ func (r *remoteStorageReader) SwitchToReadOnlyMode() error {
 	return nil
 }
 
+// ReadAt is the public entry. For uncompressed chunks it delegates
+// straight to the raw range-cache path. For compressed chunks it
+// reproduces singleapp's per-entry frame protocol on top of the raw
+// reader: read the 4-byte length prefix at off, fetch that many
+// compressed bytes at off+4, decompress in memory, then copy.
 func (r *remoteStorageReader) ReadAt(bs []byte, off int64) (int, error) {
 	if off < 0 {
 		return 0, ErrIllegalArguments
@@ -174,6 +235,16 @@ func (r *remoteStorageReader) ReadAt(bs []byte, off int64) (int, error) {
 		return 0, nil
 	}
 
+	if r.compressionFormat == appendable.NoCompression {
+		return r.readAtRaw(bs, off)
+	}
+	return r.readAtCompressedFrame(bs, off)
+}
+
+// readAtRaw is the uncompressed range-cache + prefetch path. Also
+// used by readAtCompressedFrame to fetch the underlying compressed
+// bytes (length prefix + compressed payload) before decompressing.
+func (r *remoteStorageReader) readAtRaw(bs []byte, off int64) (int, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -181,16 +252,16 @@ func (r *remoteStorageReader) ReadAt(bs []byte, off int64) (int, error) {
 		return 0, io.EOF
 	}
 
-	// Fast path: requested range starts inside the cache.
-	if off >= r.cacheOffs && off < r.cacheOffs+int64(len(r.cache)) {
-		return r.serveFromCacheLocked(bs, off)
+	// Cache hit: any of the LRU windows covers this offset?
+	if w, ok := r.lookupWindowLocked(off); ok {
+		return r.serveFromWindowLocked(bs, off, w)
 	}
 
-	// Cache miss. If the in-flight prefetch matches the requested
-	// offset, wait on it instead of issuing a fresh GET. The fetcher
-	// goroutine doesn't take r.mu, so dropping the lock while we wait
-	// is safe and lets other state (e.g. an unrelated Close) progress.
-	if r.pf != nil && r.pf.offs == off {
+	// Cache miss. If an in-flight prefetch is fetching the
+	// window-sized region containing this offset, wait on it instead
+	// of issuing a fresh GET. The fetcher goroutine doesn't take
+	// r.mu, so dropping the lock while we wait is safe.
+	if r.pf != nil && off >= r.pf.offs && off < r.pf.offs+int64(r.rangeCacheSize) {
 		pf := r.pf
 		r.mu.Unlock()
 		<-pf.done
@@ -200,17 +271,20 @@ func (r *remoteStorageReader) ReadAt(bs []byte, off int64) (int, error) {
 		if r.pf == pf {
 			r.pf = nil
 			if pf.err == nil {
-				r.cache = pf.data
-				r.cacheOffs = off
+				r.insertWindowLocked(pf.offs, pf.data)
 				if int64(len(pf.data)) < int64(r.rangeCacheSize) {
 					r.sizeKnown = true
-					r.payloadSize = off + int64(len(pf.data))
+					r.payloadSize = pf.offs + int64(len(pf.data))
 				}
+				// Keep the pipeline primed for the next window — without
+				// this, every adoption would stall the next sequential
+				// miss for a full RTT instead of overlapping.
+				r.maybeStartPrefetchLocked()
 			}
 		}
 
-		if off >= r.cacheOffs && off < r.cacheOffs+int64(len(r.cache)) {
-			return r.serveFromCacheLocked(bs, off)
+		if w, ok := r.lookupWindowLocked(off); ok {
+			return r.serveFromWindowLocked(bs, off, w)
 		}
 		// Prefetch errored or was preempted; fall through to direct fetch.
 	}
@@ -218,18 +292,45 @@ func (r *remoteStorageReader) ReadAt(bs []byte, off int64) (int, error) {
 	return r.fetchAndCopyLocked(bs, off)
 }
 
-// serveFromCacheLocked copies from the in-memory cache into bs and
-// handles partial reads (cache window boundary or end of object). On
-// a partial read it either returns io.EOF (if the object is exhausted)
-// or recursively fetches the next window. Caller must hold r.mu.
-func (r *remoteStorageReader) serveFromCacheLocked(bs []byte, off int64) (int, error) {
-	rel := off - r.cacheOffs
-	n := copy(bs, r.cache[rel:])
+// lookupWindowLocked returns the window covering off, moving it to
+// MRU position on hit. Caller must hold r.mu.
+func (r *remoteStorageReader) lookupWindowLocked(off int64) (cachedWindow, bool) {
+	for i, w := range r.windows {
+		if off >= w.offs && off < w.offs+int64(len(w.data)) {
+			if i > 0 {
+				// Move w to MRU (index 0); shift the prefix right.
+				copy(r.windows[1:i+1], r.windows[0:i])
+				r.windows[0] = w
+			}
+			return w, true
+		}
+	}
+	return cachedWindow{}, false
+}
+
+// insertWindowLocked installs a freshly-fetched window at MRU,
+// evicting the LRU entry if we're at capacity. Caller must hold r.mu.
+func (r *remoteStorageReader) insertWindowLocked(offs int64, data []byte) {
+	nw := cachedWindow{offs: offs, data: data}
+	if len(r.windows) < r.maxWindows {
+		// Grow by one and shift everything right by one slot.
+		r.windows = append(r.windows, cachedWindow{})
+	}
+	copy(r.windows[1:], r.windows[:len(r.windows)-1])
+	r.windows[0] = nw
+}
+
+// serveFromWindowLocked copies from `w` into bs and handles partial
+// reads (cache window boundary or end of object). On a partial read
+// it either returns io.EOF (object exhausted) or recursively fetches
+// the next window. Caller must hold r.mu.
+func (r *remoteStorageReader) serveFromWindowLocked(bs []byte, off int64, w cachedWindow) (int, error) {
+	rel := off - w.offs
+	n := copy(bs, w.data[rel:])
 	metricsReads.Inc()
 	metricsReadBytes.Add(float64(n))
 
 	if n == len(bs) {
-		r.maybeStartPrefetchLocked()
 		return n, nil
 	}
 	if r.sizeKnown && off+int64(n) >= r.payloadSize {
@@ -239,17 +340,24 @@ func (r *remoteStorageReader) serveFromCacheLocked(bs []byte, off int64) (int, e
 	return n + more, err
 }
 
-// fetchAndCopyLocked issues a Range GET starting at payload offset
-// `off` big enough to cover the request, refreshes the per-reader
-// cache with the result, and copies into bs. Caller must hold r.mu.
+// fetchAndCopyLocked issues a Range GET aligned to a fixed window
+// boundary that contains `off`, inserts the result as the new MRU
+// cache window, and copies into bs. Aligning to fixed boundaries
+// (rather than starting the GET at the random caller offset) means
+// subsequent reads near the same region land in the same cached
+// window — without alignment, two sparse reads that fall in the
+// "same logical 1 MiB region" but at different offsets would each
+// fetch their own overlapping window and the cache would thrash.
+//
+// If the request straddles two windows, this fetches the first one
+// and recurses for the remainder. Caller must hold r.mu.
 func (r *remoteStorageReader) fetchAndCopyLocked(bs []byte, off int64) (int, error) {
-	fetchLen := int64(r.rangeCacheSize)
-	if int64(len(bs)) > fetchLen {
-		fetchLen = int64(len(bs))
-	}
+	windowSize := int64(r.rangeCacheSize)
+	windowOffs := (off / windowSize) * windowSize
+	fetchLen := windowSize
 
 	ctx := context.Background()
-	reader, err := r.r.Get(ctx, r.name, off+r.baseOffset, fetchLen)
+	reader, err := r.r.Get(ctx, r.name, windowOffs+r.baseOffset, fetchLen)
 	if err != nil {
 		metricsUncachedReadErrors.Inc()
 		return 0, err
@@ -263,37 +371,71 @@ func (r *remoteStorageReader) fetchAndCopyLocked(bs []byte, off int64) (int, err
 	metricsUncachedReads.Inc()
 	metricsUncachedReadBytes.Add(float64(len(data)))
 
-	r.cache = data
-	r.cacheOffs = off
+	r.insertWindowLocked(windowOffs, data)
 	if int64(len(data)) < fetchLen {
 		r.sizeKnown = true
-		r.payloadSize = off + int64(len(data))
+		r.payloadSize = windowOffs + int64(len(data))
 	}
 
-	n := copy(bs, data)
+	rel := off - windowOffs
+	if rel >= int64(len(data)) {
+		// Window doesn't actually contain off (object ended inside
+		// the aligned window before this offset). EOF.
+		return 0, io.EOF
+	}
+	n := copy(bs, data[rel:])
 	metricsReads.Inc()
 	metricsReadBytes.Add(float64(n))
 	if n < len(bs) {
-		return n, io.EOF
+		// Request straddles a window boundary or extends past EOF.
+		if r.sizeKnown && off+int64(n) >= r.payloadSize {
+			return n, io.EOF
+		}
+		more, err := r.fetchAndCopyLocked(bs[n:], off+int64(n))
+		return n + more, err
 	}
+	// Wave 3: only kick a prefetch from the cache-miss path. Cache
+	// hits don't fire one because every hit on a random pattern would
+	// otherwise queue a wasted GET — and on a sequential pattern the
+	// next miss will fire it just as effectively.
 	r.maybeStartPrefetchLocked()
 	return n, nil
 }
 
 // maybeStartPrefetchLocked spawns one background Get for the window
-// immediately after the current cache, if and only if no prefetch is
-// already in flight and we don't already know the payload ends inside
-// the current cache. Caller must hold r.mu.
+// immediately after the current MRU cache entry, if and only if (a)
+// no useful prefetch is already in flight and (b) we don't already
+// know the payload ends inside the cached prefix. A completed but
+// stale prefetch (offs no longer matches the next-after-MRU we want)
+// is dropped first so a new one can start. Caller must hold r.mu.
 func (r *remoteStorageReader) maybeStartPrefetchLocked() {
-	if r.pf != nil {
-		return
-	}
 	if r.sizeKnown {
 		return
 	}
-	nextOffs := r.cacheOffs + int64(len(r.cache))
+	if len(r.windows) == 0 {
+		return
+	}
+	mru := r.windows[0]
+	nextOffs := mru.offs + int64(len(mru.data))
 	if nextOffs <= 0 {
 		return
+	}
+
+	// Existing prefetch already lined up correctly? Leave it.
+	if r.pf != nil && r.pf.offs == nextOffs {
+		return
+	}
+	// Existing prefetch in flight for a different offset? Don't start
+	// a second concurrent fetch; let the in-flight one drain first.
+	// If it's already completed but stale, drop it so we can issue
+	// the right one.
+	if r.pf != nil {
+		select {
+		case <-r.pf.done:
+			r.pf = nil
+		default:
+			return
+		}
 	}
 
 	pf := &pendingFetch{
@@ -317,6 +459,83 @@ func (r *remoteStorageReader) maybeStartPrefetchLocked() {
 		}
 		pf.data = data
 	}()
+}
+
+// readAtCompressedFrame implements singleapp's per-Append frame
+// protocol on top of readAtRaw:
+//
+//	[ 4-byte big-endian length N ][ N bytes of compressed payload ]
+//
+// The frame at `off` decompresses to one Append's payload. We copy
+// up to len(bs) bytes of that payload into bs and return io.EOF if
+// the decoded payload was shorter than the request.
+func (r *remoteStorageReader) readAtCompressedFrame(bs []byte, off int64) (int, error) {
+	var lenBuf [4]byte
+	if _, err := r.readAtRaw(lenBuf[:], off); err != nil {
+		return 0, err
+	}
+	clen := binary.BigEndian.Uint32(lenBuf[:])
+	if clen == 0 {
+		return 0, io.EOF
+	}
+
+	cBs := make([]byte, clen)
+	if _, err := r.readAtRaw(cBs, off+4); err != nil {
+		return 0, err
+	}
+
+	dec, err := newDecompressReader(r.compressionFormat, bytes.NewReader(cBs))
+	if err != nil {
+		return 0, err
+	}
+	defer dec.Close()
+
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(dec); err != nil {
+		return 0, err
+	}
+	rbs := buf.Bytes()
+
+	n := copy(bs, rbs)
+	if n < len(bs) {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+// parseCompressionFormat extracts singleapp's MetaCompressionFormat
+// from a chunk's TLV metadata bytes. Returns NoCompression on any
+// parse failure — the metadata is owned by the writer and may legally
+// be in formats this package doesn't understand.
+func parseCompressionFormat(metaBytes []byte) (cf int) {
+	defer func() {
+		if r := recover(); r != nil {
+			cf = appendable.NoCompression
+		}
+	}()
+	md := appendable.NewMetadata(metaBytes)
+	if v, ok := md.GetInt(singleapp.MetaCompressionFormat); ok {
+		return v
+	}
+	return appendable.NoCompression
+}
+
+// newDecompressReader returns a decoder for the given compression
+// format. Mirrors singleapp.AppendableFile.reader so the on-disk
+// frame format stays identical between local and remote chunks.
+func newDecompressReader(format int, src io.Reader) (io.ReadCloser, error) {
+	switch format {
+	case appendable.FlateCompression:
+		return flate.NewReader(src), nil
+	case appendable.GZipCompression:
+		return gzip.NewReader(src)
+	case appendable.LZWCompression:
+		return lzw.NewReader(src, lzw.MSB, 8), nil
+	case appendable.ZLibCompression:
+		return zlib.NewReader(src)
+	default:
+		return nil, ErrCorruptedMetadata
+	}
 }
 
 func (r *remoteStorageReader) Close() error {

--- a/embedded/appendable/remoteapp/remote_storage_reader.go
+++ b/embedded/appendable/remoteapp/remote_storage_reader.go
@@ -17,9 +17,9 @@ import (
 // caps the open-time header download — the open path does one GET of
 // this size, parses the metadata length prefix from the first 4 bytes,
 // keeps the trailing payload bytes as the initial cache, and (when the
-// response was strictly shorter than the request) pins the payload size
-// so subsequent ReadAt past EOF can short-circuit without an S3 round
-// trip.
+// response was strictly shorter than the request) pins the payload
+// size so subsequent ReadAt past EOF can short-circuit without an S3
+// round trip.
 //
 // 256 KiB is large enough that hot-restore replay and SQL scans fall
 // almost entirely inside the cache while sequentially walking a chunk,
@@ -27,6 +27,19 @@ import (
 // per ReadAt call. Tunable via WithReaderRangeCacheSize on the
 // remoteapp options.
 const DefaultReaderRangeCacheSize = 256 * 1024
+
+// pendingFetch represents a single in-flight read-ahead Get. The
+// fetcher goroutine sets data/err and then closes done. Foreground
+// ReadAt callers find the matching pendingFetch (by offs) and wait on
+// done to overlap the per-window RTT with whatever they were doing
+// while consuming the previous window.
+type pendingFetch struct {
+	offs int64
+	done chan struct{}
+
+	data []byte
+	err  error
+}
 
 type remoteStorageReader struct {
 	r              remotestorage.Storage
@@ -39,6 +52,11 @@ type remoteStorageReader struct {
 	cacheOffs   int64
 	sizeKnown   bool
 	payloadSize int64 // valid only when sizeKnown
+
+	pf *pendingFetch // at most one prefetch in flight, guarded by mu
+
+	prefetchCtx    context.Context
+	prefetchCancel context.CancelFunc
 }
 
 func openRemoteStorageReader(r remotestorage.Storage, name string, rangeCacheSize int) (*remoteStorageReader, error) {
@@ -50,10 +68,10 @@ func openRemoteStorageReader(r remotestorage.Storage, name string, rangeCacheSiz
 
 	ctx := context.Background()
 
-	// Read header + as much of the leading payload as fits in one window.
-	// A short response (len < rangeCacheSize) means we've seen the whole
-	// object, in which case pin payloadSize so out-of-range ReadAt calls
-	// don't issue a wasted GET.
+	// Read header + as much of the leading payload as fits in one
+	// window. A short response (len < rangeCacheSize) means we've
+	// seen the whole object, in which case pin payloadSize so
+	// out-of-range ReadAt calls don't issue a wasted GET.
 	reader, err := r.Get(ctx, name, 0, int64(rangeCacheSize))
 	if err != nil {
 		metricsUncachedReadErrors.Inc()
@@ -78,6 +96,7 @@ func openRemoteStorageReader(r remotestorage.Storage, name string, rangeCacheSiz
 		return nil, ErrCorruptedMetadata
 	}
 
+	pCtx, pCancel := context.WithCancel(context.Background())
 	sr := &remoteStorageReader{
 		r:              r,
 		name:           name,
@@ -85,10 +104,20 @@ func openRemoteStorageReader(r remotestorage.Storage, name string, rangeCacheSiz
 		rangeCacheSize: rangeCacheSize,
 		cache:          data[baseOffset:],
 		cacheOffs:      0,
+		prefetchCtx:    pCtx,
+		prefetchCancel: pCancel,
 	}
 	if int64(len(data)) < int64(rangeCacheSize) {
 		sr.sizeKnown = true
 		sr.payloadSize = int64(len(sr.cache))
+	} else {
+		// Pipeline the second window while the caller processes the
+		// first — Wave 2 read-ahead. Hot-restore replay, SQL scans,
+		// and replication catch-up all walk a chunk linearly, so this
+		// shaves one full RTT per window from the wall-clock.
+		sr.mu.Lock()
+		sr.maybeStartPrefetchLocked()
+		sr.mu.Unlock()
 	}
 	return sr, nil
 }
@@ -154,31 +183,65 @@ func (r *remoteStorageReader) ReadAt(bs []byte, off int64) (int, error) {
 
 	// Fast path: requested range starts inside the cache.
 	if off >= r.cacheOffs && off < r.cacheOffs+int64(len(r.cache)) {
-		rel := off - r.cacheOffs
-		n := copy(bs, r.cache[rel:])
-		metricsReads.Inc()
-		metricsReadBytes.Add(float64(n))
-
-		if n == len(bs) {
-			return n, nil
-		}
-		// Cache covered the prefix but not the tail. Either we ran off the
-		// end of the cache window (need another GET) or off the end of the
-		// object (return EOF without one).
-		if r.sizeKnown && off+int64(n) >= r.payloadSize {
-			return n, io.EOF
-		}
-		more, err := r.fetchAndCopyLocked(bs[n:], off+int64(n))
-		return n + more, err
+		return r.serveFromCacheLocked(bs, off)
 	}
 
-	// Cache miss — fetch a fresh window centered on `off`.
+	// Cache miss. If the in-flight prefetch matches the requested
+	// offset, wait on it instead of issuing a fresh GET. The fetcher
+	// goroutine doesn't take r.mu, so dropping the lock while we wait
+	// is safe and lets other state (e.g. an unrelated Close) progress.
+	if r.pf != nil && r.pf.offs == off {
+		pf := r.pf
+		r.mu.Unlock()
+		<-pf.done
+		r.mu.Lock()
+
+		// Adopt the prefetched data (if it's still the current pf).
+		if r.pf == pf {
+			r.pf = nil
+			if pf.err == nil {
+				r.cache = pf.data
+				r.cacheOffs = off
+				if int64(len(pf.data)) < int64(r.rangeCacheSize) {
+					r.sizeKnown = true
+					r.payloadSize = off + int64(len(pf.data))
+				}
+			}
+		}
+
+		if off >= r.cacheOffs && off < r.cacheOffs+int64(len(r.cache)) {
+			return r.serveFromCacheLocked(bs, off)
+		}
+		// Prefetch errored or was preempted; fall through to direct fetch.
+	}
+
 	return r.fetchAndCopyLocked(bs, off)
 }
 
-// fetchAndCopyLocked issues a Range GET starting at payload offset `off`
-// big enough to cover the request, refreshes the per-reader cache with
-// the result, and copies into bs. Caller must hold r.mu.
+// serveFromCacheLocked copies from the in-memory cache into bs and
+// handles partial reads (cache window boundary or end of object). On
+// a partial read it either returns io.EOF (if the object is exhausted)
+// or recursively fetches the next window. Caller must hold r.mu.
+func (r *remoteStorageReader) serveFromCacheLocked(bs []byte, off int64) (int, error) {
+	rel := off - r.cacheOffs
+	n := copy(bs, r.cache[rel:])
+	metricsReads.Inc()
+	metricsReadBytes.Add(float64(n))
+
+	if n == len(bs) {
+		r.maybeStartPrefetchLocked()
+		return n, nil
+	}
+	if r.sizeKnown && off+int64(n) >= r.payloadSize {
+		return n, io.EOF
+	}
+	more, err := r.fetchAndCopyLocked(bs[n:], off+int64(n))
+	return n + more, err
+}
+
+// fetchAndCopyLocked issues a Range GET starting at payload offset
+// `off` big enough to cover the request, refreshes the per-reader
+// cache with the result, and copies into bs. Caller must hold r.mu.
 func (r *remoteStorageReader) fetchAndCopyLocked(bs []byte, off int64) (int, error) {
 	fetchLen := int64(r.rangeCacheSize)
 	if int64(len(bs)) > fetchLen {
@@ -213,10 +276,57 @@ func (r *remoteStorageReader) fetchAndCopyLocked(bs []byte, off int64) (int, err
 	if n < len(bs) {
 		return n, io.EOF
 	}
+	r.maybeStartPrefetchLocked()
 	return n, nil
 }
 
+// maybeStartPrefetchLocked spawns one background Get for the window
+// immediately after the current cache, if and only if no prefetch is
+// already in flight and we don't already know the payload ends inside
+// the current cache. Caller must hold r.mu.
+func (r *remoteStorageReader) maybeStartPrefetchLocked() {
+	if r.pf != nil {
+		return
+	}
+	if r.sizeKnown {
+		return
+	}
+	nextOffs := r.cacheOffs + int64(len(r.cache))
+	if nextOffs <= 0 {
+		return
+	}
+
+	pf := &pendingFetch{
+		offs: nextOffs,
+		done: make(chan struct{}),
+	}
+	r.pf = pf
+
+	go func() {
+		defer close(pf.done)
+		reader, err := r.r.Get(r.prefetchCtx, r.name, nextOffs+r.baseOffset, int64(r.rangeCacheSize))
+		if err != nil {
+			pf.err = err
+			return
+		}
+		data, errRead := ioutil.ReadAll(reader)
+		reader.Close()
+		if errRead != nil {
+			pf.err = errRead
+			return
+		}
+		pf.data = data
+	}()
+}
+
 func (r *remoteStorageReader) Close() error {
+	// Cancel any in-flight prefetch; the goroutine drains itself
+	// promptly because the underlying Storage.Get respects the
+	// context. We don't wait — Close is called from the cache
+	// eviction path and shouldn't block on network I/O.
+	if r.prefetchCancel != nil {
+		r.prefetchCancel()
+	}
 	return nil
 }
 

--- a/embedded/appendable/remoteapp/remote_storage_reader_bench_test.go
+++ b/embedded/appendable/remoteapp/remote_storage_reader_bench_test.go
@@ -1,0 +1,268 @@
+/*
+Copyright 2026 Codenotary Inc. All rights reserved.
+
+SPDX-License-Identifier: BUSL-1.1
+*/
+
+package remoteapp
+
+import (
+	"context"
+	"io"
+	"math/rand"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/codenotary/immudb/embedded/remotestorage"
+	"github.com/codenotary/immudb/embedded/remotestorage/memory"
+)
+
+// latencyStorage wraps any remotestorage.Storage and adds a fixed
+// per-Get sleep on the calling goroutine, simulating S3 round-trip
+// time. Lets benchmarks measure how well the reader amortizes
+// network round trips without needing a real S3 / minio process.
+//
+// Only Get is delayed — the cost we're trying to amortize is the
+// per-request HTTP latency on the read path. getCount counts the
+// number of Get calls so benchmarks can verify the wire-cost
+// reduction from range caching / prefetch.
+type latencyStorage struct {
+	remotestorage.Storage
+	getDelay time.Duration
+	getCount int64
+}
+
+func (l *latencyStorage) Get(ctx context.Context, name string, offs, size int64) (io.ReadCloser, error) {
+	atomic.AddInt64(&l.getCount, 1)
+	if l.getDelay > 0 {
+		time.Sleep(l.getDelay)
+	}
+	return l.Storage.Get(ctx, name, offs, size)
+}
+
+func (l *latencyStorage) Gets() int64 {
+	return atomic.LoadInt64(&l.getCount)
+}
+
+// putRawTB uploads `data` directly to `s` under `name`. Mirrors the
+// *testing.T-only storeData helper in remote_storage_reader_test.go
+// but accepts testing.TB so benchmarks can reuse the same flow.
+func putRawTB(tb testing.TB, s remotestorage.Storage, name string, data []byte) {
+	tb.Helper()
+	fl, err := os.CreateTemp("", "")
+	if err != nil {
+		tb.Fatal(err)
+	}
+	if _, err := fl.Write(data); err != nil {
+		tb.Fatal(err)
+	}
+	if err := fl.Close(); err != nil {
+		tb.Fatal(err)
+	}
+	defer os.Remove(fl.Name())
+	if err := s.Put(context.Background(), name, fl.Name()); err != nil {
+		tb.Fatal(err)
+	}
+}
+
+// BenchmarkRemoteReader_SequentialRead measures the cost of opening
+// a chunk and reading it end-to-end in fixed-size pages. The Wave 1
+// range cache should keep the per-page cost down to a memcpy after
+// the first page in each cache window.
+//
+// Reports:
+//   - ns/op: wall-clock per full chunk read (open + N pages)
+//   - gets/op: number of S3 Get calls per iteration. Should be ~
+//     ceil(payloadBytes / rangeCacheSize) + 1 (the +1 is open).
+func BenchmarkRemoteReader_SequentialRead(b *testing.B) {
+	const (
+		payloadBytes = 4 * 1024 * 1024 // 4 MiB chunk
+		pageSize     = 8 * 1024        // 8 KiB read pages
+		rttSimulated = 2 * time.Millisecond
+	)
+
+	store := &latencyStorage{Storage: memory.Open(), getDelay: rttSimulated}
+	header := []byte{0, 0, 0, 0}
+	payload := make([]byte, payloadBytes)
+	rand.New(rand.NewSource(1)).Read(payload)
+	putRawTB(b, store, "fl", append(header, payload...))
+
+	buf := make([]byte, pageSize)
+
+	b.ResetTimer()
+	startGets := store.Gets()
+	for i := 0; i < b.N; i++ {
+		r, err := openRemoteStorageReader(store, "fl", DefaultReaderRangeCacheSize)
+		if err != nil {
+			b.Fatal(err)
+		}
+		var off int64
+		for off < int64(payloadBytes) {
+			n, err := r.ReadAt(buf, off)
+			if err != nil && err != io.EOF {
+				b.Fatal(err)
+			}
+			off += int64(n)
+			if err == io.EOF {
+				break
+			}
+		}
+		_ = r.Close()
+	}
+	b.StopTimer()
+	gets := store.Gets() - startGets
+	b.ReportMetric(float64(gets)/float64(b.N), "gets/op")
+}
+
+// BenchmarkRemoteReader_SequentialReadWithProcessing models the real
+// hot-restore consumer: per-page work (decode, validate, replay) that
+// dominates a memcpy. With Wave 2's read-ahead prefetch, the next
+// cache window's Get completes in parallel with this processing, so
+// the per-window RTT is hidden — wall clock should track
+// Σ(processing) + 1 RTT instead of Σ(processing) + N RTT.
+func BenchmarkRemoteReader_SequentialReadWithProcessing(b *testing.B) {
+	const (
+		payloadBytes  = 4 * 1024 * 1024
+		pageSize      = 8 * 1024
+		rttSimulated  = 2 * time.Millisecond
+		perPageWorkUs = 80 // ~10 ms per 256 KiB window — well above RTT
+	)
+
+	store := &latencyStorage{Storage: memory.Open(), getDelay: rttSimulated}
+	header := []byte{0, 0, 0, 0}
+	payload := make([]byte, payloadBytes)
+	rand.New(rand.NewSource(3)).Read(payload)
+	putRawTB(b, store, "fl", append(header, payload...))
+
+	buf := make([]byte, pageSize)
+
+	b.ResetTimer()
+	startGets := store.Gets()
+	for i := 0; i < b.N; i++ {
+		r, err := openRemoteStorageReader(store, "fl", DefaultReaderRangeCacheSize)
+		if err != nil {
+			b.Fatal(err)
+		}
+		var off int64
+		for off < int64(payloadBytes) {
+			n, err := r.ReadAt(buf, off)
+			if err != nil && err != io.EOF {
+				b.Fatal(err)
+			}
+			// Simulate per-page consumer work (protobuf decode etc).
+			time.Sleep(time.Duration(perPageWorkUs) * time.Microsecond)
+			off += int64(n)
+			if err == io.EOF {
+				break
+			}
+		}
+		_ = r.Close()
+	}
+	b.StopTimer()
+	gets := store.Gets() - startGets
+	b.ReportMetric(float64(gets)/float64(b.N), "gets/op")
+}
+
+// BenchmarkRemoteReader_SparseRead measures cost of N small random
+// reads on a single chunk. Without range caching this is N full-chunk
+// downloads; with Wave 1 it's at most N bounded-window Gets, and for
+// reads that happen to land in the most-recent window, zero extra Gets.
+func BenchmarkRemoteReader_SparseRead(b *testing.B) {
+	const (
+		payloadBytes = 4 * 1024 * 1024
+		readSize     = 256
+		readsPerIter = 100
+		rttSimulated = 2 * time.Millisecond
+	)
+
+	store := &latencyStorage{Storage: memory.Open(), getDelay: rttSimulated}
+	header := []byte{0, 0, 0, 0}
+	payload := make([]byte, payloadBytes)
+	rand.New(rand.NewSource(2)).Read(payload)
+	putRawTB(b, store, "fl", append(header, payload...))
+
+	rng := rand.New(rand.NewSource(99))
+	offsets := make([]int64, readsPerIter)
+	for i := range offsets {
+		offsets[i] = rng.Int63n(int64(payloadBytes - readSize))
+	}
+	buf := make([]byte, readSize)
+
+	b.ResetTimer()
+	startGets := store.Gets()
+	for i := 0; i < b.N; i++ {
+		r, err := openRemoteStorageReader(store, "fl", DefaultReaderRangeCacheSize)
+		if err != nil {
+			b.Fatal(err)
+		}
+		for _, off := range offsets {
+			if _, err := r.ReadAt(buf, off); err != nil && err != io.EOF {
+				b.Fatal(err)
+			}
+		}
+		_ = r.Close()
+	}
+	b.StopTimer()
+	gets := store.Gets() - startGets
+	b.ReportMetric(float64(gets)/float64(b.N), "gets/op")
+}
+
+// BenchmarkRemoteReader_HotRestoreReplay mirrors the dominant
+// hot-restore / replication catch-up workload: open many adjacent
+// chunks and read each fully in order. This is the path Wave 2's
+// sequential prefetch is meant to accelerate by overlapping the
+// per-window Get RTT with the ReadAt copy.
+func BenchmarkRemoteReader_HotRestoreReplay(b *testing.B) {
+	const (
+		chunks       = 8
+		payloadBytes = 1 * 1024 * 1024 // 1 MiB per chunk (default WithFileSize)
+		pageSize     = 8 * 1024
+		rttSimulated = 2 * time.Millisecond
+	)
+
+	store := &latencyStorage{Storage: memory.Open(), getDelay: rttSimulated}
+	header := []byte{0, 0, 0, 0}
+	for c := 0; c < chunks; c++ {
+		payload := make([]byte, payloadBytes)
+		rand.New(rand.NewSource(int64(c))).Read(payload)
+		putRawTB(b, store, chunkName(c), append(header, payload...))
+	}
+
+	buf := make([]byte, pageSize)
+
+	b.ResetTimer()
+	startGets := store.Gets()
+	for i := 0; i < b.N; i++ {
+		for c := 0; c < chunks; c++ {
+			r, err := openRemoteStorageReader(store, chunkName(c), DefaultReaderRangeCacheSize)
+			if err != nil {
+				b.Fatal(err)
+			}
+			var off int64
+			for off < int64(payloadBytes) {
+				n, err := r.ReadAt(buf, off)
+				if err != nil && err != io.EOF {
+					b.Fatal(err)
+				}
+				// Lightweight per-page work — enough that the
+				// next-window prefetch RTT can overlap with consumer
+				// time, mirroring real replay.
+				time.Sleep(50 * time.Microsecond)
+				off += int64(n)
+				if err == io.EOF {
+					break
+				}
+			}
+			_ = r.Close()
+		}
+	}
+	b.StopTimer()
+	gets := store.Gets() - startGets
+	b.ReportMetric(float64(gets)/float64(b.N), "gets/op")
+}
+
+func chunkName(i int) string {
+	return "chunk_" + string(rune('a'+i))
+}

--- a/embedded/appendable/remoteapp/remote_storage_reader_compare_test.go
+++ b/embedded/appendable/remoteapp/remote_storage_reader_compare_test.go
@@ -1,0 +1,579 @@
+/*
+Copyright 2026 Codenotary Inc. All rights reserved.
+
+SPDX-License-Identifier: BUSL-1.1
+*/
+
+package remoteapp
+
+import (
+	"context"
+	"encoding/binary"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/codenotary/immudb/embedded/remotestorage"
+	"github.com/codenotary/immudb/embedded/remotestorage/memory"
+)
+
+// oldStyleReader is the pre-Wave-1 implementation of the remote-storage
+// reader — it eagerly downloads the entire chunk on open and slices the
+// resulting buffer for ReadAt. Embedded here verbatim so the
+// side-by-side benchmarks below run both code paths in one go test
+// invocation without checkout-dancing across commits.
+//
+// This is the v1.11.0 baseline reproduced from
+// embedded/appendable/remoteapp/remote_storage_reader.go before
+// commit b65a7c10 ("perf(remoteapp): range-fetch ReadAt").
+type oldStyleReader struct {
+	r          remotestorage.Storage
+	name       string
+	baseOffset int64
+	dataCache  []byte
+}
+
+func openOldStyleReader(r remotestorage.Storage, name string) (*oldStyleReader, error) {
+	reader, err := r.Get(context.Background(), name, 0, -1)
+	if err != nil {
+		return nil, err
+	}
+	data, err := ioutil.ReadAll(reader)
+	reader.Close()
+	if err != nil {
+		return nil, err
+	}
+	if len(data) < 4 {
+		return nil, ErrCorruptedMetadata
+	}
+	baseOffset := int64(4 + binary.BigEndian.Uint32(data[:4]))
+	if baseOffset > int64(len(data)) {
+		return nil, ErrCorruptedMetadata
+	}
+	return &oldStyleReader{
+		r:          r,
+		name:       name,
+		baseOffset: baseOffset,
+		dataCache:  data[baseOffset:],
+	}, nil
+}
+
+func (r *oldStyleReader) ReadAt(bs []byte, off int64) (int, error) {
+	if off < 0 {
+		return 0, ErrIllegalArguments
+	}
+	if off > int64(len(r.dataCache)) {
+		return 0, io.EOF
+	}
+	n := copy(bs, r.dataCache[off:])
+	if n < len(bs) {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+func (r *oldStyleReader) Close() error { return nil }
+
+// byteCountingStorage wraps a Storage and counts both Get calls and the
+// total number of payload bytes returned. Used to report the actual
+// over-the-wire cost the two readers pay.
+type byteCountingStorage struct {
+	remotestorage.Storage
+	getDelay time.Duration
+	gets     int64
+	bytes    int64
+}
+
+func (b *byteCountingStorage) Get(ctx context.Context, name string, offs, size int64) (io.ReadCloser, error) {
+	atomic.AddInt64(&b.gets, 1)
+	if b.getDelay > 0 {
+		time.Sleep(b.getDelay)
+	}
+	rc, err := b.Storage.Get(ctx, name, offs, size)
+	if err != nil {
+		return nil, err
+	}
+	return &byteCountingReadCloser{rc: rc, parent: b}, nil
+}
+
+func (b *byteCountingStorage) reset() {
+	atomic.StoreInt64(&b.gets, 0)
+	atomic.StoreInt64(&b.bytes, 0)
+}
+
+type byteCountingReadCloser struct {
+	rc     io.ReadCloser
+	parent *byteCountingStorage
+}
+
+func (b *byteCountingReadCloser) Read(p []byte) (int, error) {
+	n, err := b.rc.Read(p)
+	if n > 0 {
+		atomic.AddInt64(&b.parent.bytes, int64(n))
+	}
+	return n, err
+}
+
+func (b *byteCountingReadCloser) Close() error { return b.rc.Close() }
+
+// --- shared workload setup ---
+
+const (
+	cmpPayloadBytes = 4 * 1024 * 1024 // 4 MiB chunk
+	cmpPageSize     = 8 * 1024        // 8 KiB read pages
+	cmpReadSize     = 256             // sparse read window
+	cmpReads        = 100             // sparse reads per iter
+	cmpChunks       = 8               // hot-restore chunk count
+	cmpChunkBytes   = 1 * 1024 * 1024 // hot-restore per-chunk size
+)
+
+func cmpSeed(b *testing.B, rttMs int) (*byteCountingStorage, []byte) {
+	b.Helper()
+	store := &byteCountingStorage{
+		Storage:  memory.Open(),
+		getDelay: time.Duration(rttMs) * time.Millisecond,
+	}
+	header := []byte{0, 0, 0, 0}
+	payload := make([]byte, cmpPayloadBytes)
+	rand.New(rand.NewSource(7)).Read(payload)
+	putRawTB(b, store, "fl", append(header, payload...))
+	return store, payload
+}
+
+func cmpSeedMulti(b *testing.B, rttMs int) *byteCountingStorage {
+	b.Helper()
+	store := &byteCountingStorage{
+		Storage:  memory.Open(),
+		getDelay: time.Duration(rttMs) * time.Millisecond,
+	}
+	header := []byte{0, 0, 0, 0}
+	for c := 0; c < cmpChunks; c++ {
+		payload := make([]byte, cmpChunkBytes)
+		rand.New(rand.NewSource(int64(c) + 11)).Read(payload)
+		putRawTB(b, store, chunkName(c), append(header, payload...))
+	}
+	return store
+}
+
+func cmpReportLocked(b *testing.B, store *byteCountingStorage) {
+	b.Helper()
+	b.ReportMetric(float64(atomic.LoadInt64(&store.gets))/float64(b.N), "gets/op")
+	b.ReportMetric(float64(atomic.LoadInt64(&store.bytes))/float64(b.N), "wire-bytes/op")
+}
+
+// --- sequential, no per-page work ---
+
+func BenchmarkCompare_Old_SequentialRead(b *testing.B) {
+	store, _ := cmpSeed(b, 2)
+	buf := make([]byte, cmpPageSize)
+	store.reset()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r, err := openOldStyleReader(store, "fl")
+		if err != nil {
+			b.Fatal(err)
+		}
+		var off int64
+		for off < int64(cmpPayloadBytes) {
+			n, err := r.ReadAt(buf, off)
+			if err != nil && err != io.EOF {
+				b.Fatal(err)
+			}
+			off += int64(n)
+			if err == io.EOF {
+				break
+			}
+		}
+		_ = r.Close()
+	}
+	b.StopTimer()
+	cmpReportLocked(b, store)
+}
+
+func BenchmarkCompare_New_SequentialRead(b *testing.B) {
+	store, _ := cmpSeed(b, 2)
+	buf := make([]byte, cmpPageSize)
+	store.reset()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r, err := openRemoteStorageReader(store, "fl", DefaultReaderRangeCacheSize)
+		if err != nil {
+			b.Fatal(err)
+		}
+		var off int64
+		for off < int64(cmpPayloadBytes) {
+			n, err := r.ReadAt(buf, off)
+			if err != nil && err != io.EOF {
+				b.Fatal(err)
+			}
+			off += int64(n)
+			if err == io.EOF {
+				break
+			}
+		}
+		_ = r.Close()
+	}
+	b.StopTimer()
+	cmpReportLocked(b, store)
+}
+
+// --- sequential WITH per-page consumer work (where prefetch shines) ---
+
+const cmpPerPageWork = 80 * time.Microsecond
+
+func BenchmarkCompare_Old_SequentialReadWithProcessing(b *testing.B) {
+	store, _ := cmpSeed(b, 2)
+	buf := make([]byte, cmpPageSize)
+	store.reset()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r, err := openOldStyleReader(store, "fl")
+		if err != nil {
+			b.Fatal(err)
+		}
+		var off int64
+		for off < int64(cmpPayloadBytes) {
+			n, err := r.ReadAt(buf, off)
+			if err != nil && err != io.EOF {
+				b.Fatal(err)
+			}
+			time.Sleep(cmpPerPageWork)
+			off += int64(n)
+			if err == io.EOF {
+				break
+			}
+		}
+		_ = r.Close()
+	}
+	b.StopTimer()
+	cmpReportLocked(b, store)
+}
+
+func BenchmarkCompare_New_SequentialReadWithProcessing(b *testing.B) {
+	store, _ := cmpSeed(b, 2)
+	buf := make([]byte, cmpPageSize)
+	store.reset()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r, err := openRemoteStorageReader(store, "fl", DefaultReaderRangeCacheSize)
+		if err != nil {
+			b.Fatal(err)
+		}
+		var off int64
+		for off < int64(cmpPayloadBytes) {
+			n, err := r.ReadAt(buf, off)
+			if err != nil && err != io.EOF {
+				b.Fatal(err)
+			}
+			time.Sleep(cmpPerPageWork)
+			off += int64(n)
+			if err == io.EOF {
+				break
+			}
+		}
+		_ = r.Close()
+	}
+	b.StopTimer()
+	cmpReportLocked(b, store)
+}
+
+// --- sparse random reads (the read-amplification killer) ---
+
+func BenchmarkCompare_Old_SparseRead(b *testing.B) {
+	store, _ := cmpSeed(b, 2)
+	rng := rand.New(rand.NewSource(99))
+	offsets := make([]int64, cmpReads)
+	for i := range offsets {
+		offsets[i] = rng.Int63n(int64(cmpPayloadBytes - cmpReadSize))
+	}
+	buf := make([]byte, cmpReadSize)
+	store.reset()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r, err := openOldStyleReader(store, "fl")
+		if err != nil {
+			b.Fatal(err)
+		}
+		for _, off := range offsets {
+			if _, err := r.ReadAt(buf, off); err != nil && err != io.EOF {
+				b.Fatal(err)
+			}
+		}
+		_ = r.Close()
+	}
+	b.StopTimer()
+	cmpReportLocked(b, store)
+}
+
+func BenchmarkCompare_New_SparseRead(b *testing.B) {
+	store, _ := cmpSeed(b, 2)
+	rng := rand.New(rand.NewSource(99))
+	offsets := make([]int64, cmpReads)
+	for i := range offsets {
+		offsets[i] = rng.Int63n(int64(cmpPayloadBytes - cmpReadSize))
+	}
+	buf := make([]byte, cmpReadSize)
+	store.reset()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r, err := openRemoteStorageReader(store, "fl", DefaultReaderRangeCacheSize)
+		if err != nil {
+			b.Fatal(err)
+		}
+		for _, off := range offsets {
+			if _, err := r.ReadAt(buf, off); err != nil && err != io.EOF {
+				b.Fatal(err)
+			}
+		}
+		_ = r.Close()
+	}
+	b.StopTimer()
+	cmpReportLocked(b, store)
+}
+
+// --- partial-chunk read (open N chunks but only touch the first ~32 KB) ---
+// This is the dominant pattern for "read header / first record / early
+// abort" workloads — the old reader pays full-chunk download per open
+// regardless; the new reader pays only the bytes it touches.
+
+const cmpPartialReadBytes = 32 * 1024
+
+func BenchmarkCompare_Old_PartialChunkRead(b *testing.B) {
+	store := cmpSeedMulti(b, 2)
+	buf := make([]byte, cmpPageSize)
+	store.reset()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for c := 0; c < cmpChunks; c++ {
+			r, err := openOldStyleReader(store, chunkName(c))
+			if err != nil {
+				b.Fatal(err)
+			}
+			var off int64
+			for off < int64(cmpPartialReadBytes) {
+				n, err := r.ReadAt(buf, off)
+				if err != nil && err != io.EOF {
+					b.Fatal(err)
+				}
+				off += int64(n)
+				if err == io.EOF {
+					break
+				}
+			}
+			_ = r.Close()
+		}
+	}
+	b.StopTimer()
+	cmpReportLocked(b, store)
+}
+
+func BenchmarkCompare_New_PartialChunkRead(b *testing.B) {
+	store := cmpSeedMulti(b, 2)
+	buf := make([]byte, cmpPageSize)
+	store.reset()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for c := 0; c < cmpChunks; c++ {
+			r, err := openRemoteStorageReader(store, chunkName(c), DefaultReaderRangeCacheSize)
+			if err != nil {
+				b.Fatal(err)
+			}
+			var off int64
+			for off < int64(cmpPartialReadBytes) {
+				n, err := r.ReadAt(buf, off)
+				if err != nil && err != io.EOF {
+					b.Fatal(err)
+				}
+				off += int64(n)
+				if err == io.EOF {
+					break
+				}
+			}
+			_ = r.Close()
+		}
+	}
+	b.StopTimer()
+	cmpReportLocked(b, store)
+}
+
+// --- high-RTT sweep: 50 ms simulated round trip, where prefetch
+//     overlap actually moves the wall-clock needle ---
+
+func BenchmarkCompare_Old_SequentialReadWithProcessing_HighRTT(b *testing.B) {
+	store, _ := cmpSeed(b, 50)
+	buf := make([]byte, cmpPageSize)
+	store.reset()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r, err := openOldStyleReader(store, "fl")
+		if err != nil {
+			b.Fatal(err)
+		}
+		var off int64
+		for off < int64(cmpPayloadBytes) {
+			n, err := r.ReadAt(buf, off)
+			if err != nil && err != io.EOF {
+				b.Fatal(err)
+			}
+			time.Sleep(cmpPerPageWork)
+			off += int64(n)
+			if err == io.EOF {
+				break
+			}
+		}
+		_ = r.Close()
+	}
+	b.StopTimer()
+	cmpReportLocked(b, store)
+}
+
+func BenchmarkCompare_New_SequentialReadWithProcessing_HighRTT(b *testing.B) {
+	store, _ := cmpSeed(b, 50)
+	buf := make([]byte, cmpPageSize)
+	store.reset()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r, err := openRemoteStorageReader(store, "fl", DefaultReaderRangeCacheSize)
+		if err != nil {
+			b.Fatal(err)
+		}
+		var off int64
+		for off < int64(cmpPayloadBytes) {
+			n, err := r.ReadAt(buf, off)
+			if err != nil && err != io.EOF {
+				b.Fatal(err)
+			}
+			time.Sleep(cmpPerPageWork)
+			off += int64(n)
+			if err == io.EOF {
+				break
+			}
+		}
+		_ = r.Close()
+	}
+	b.StopTimer()
+	cmpReportLocked(b, store)
+}
+
+func BenchmarkCompare_Old_PartialChunkRead_HighRTT(b *testing.B) {
+	store := cmpSeedMulti(b, 50)
+	buf := make([]byte, cmpPageSize)
+	store.reset()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for c := 0; c < cmpChunks; c++ {
+			r, err := openOldStyleReader(store, chunkName(c))
+			if err != nil {
+				b.Fatal(err)
+			}
+			var off int64
+			for off < int64(cmpPartialReadBytes) {
+				n, err := r.ReadAt(buf, off)
+				if err != nil && err != io.EOF {
+					b.Fatal(err)
+				}
+				off += int64(n)
+				if err == io.EOF {
+					break
+				}
+			}
+			_ = r.Close()
+		}
+	}
+	b.StopTimer()
+	cmpReportLocked(b, store)
+}
+
+func BenchmarkCompare_New_PartialChunkRead_HighRTT(b *testing.B) {
+	store := cmpSeedMulti(b, 50)
+	buf := make([]byte, cmpPageSize)
+	store.reset()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for c := 0; c < cmpChunks; c++ {
+			r, err := openRemoteStorageReader(store, chunkName(c), DefaultReaderRangeCacheSize)
+			if err != nil {
+				b.Fatal(err)
+			}
+			var off int64
+			for off < int64(cmpPartialReadBytes) {
+				n, err := r.ReadAt(buf, off)
+				if err != nil && err != io.EOF {
+					b.Fatal(err)
+				}
+				off += int64(n)
+				if err == io.EOF {
+					break
+				}
+			}
+			_ = r.Close()
+		}
+	}
+	b.StopTimer()
+	cmpReportLocked(b, store)
+}
+
+// --- hot-restore replay (open N adjacent chunks, walk each) ---
+
+func BenchmarkCompare_Old_HotRestoreReplay(b *testing.B) {
+	store := cmpSeedMulti(b, 2)
+	buf := make([]byte, cmpPageSize)
+	store.reset()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for c := 0; c < cmpChunks; c++ {
+			r, err := openOldStyleReader(store, chunkName(c))
+			if err != nil {
+				b.Fatal(err)
+			}
+			var off int64
+			for off < int64(cmpChunkBytes) {
+				n, err := r.ReadAt(buf, off)
+				if err != nil && err != io.EOF {
+					b.Fatal(err)
+				}
+				time.Sleep(50 * time.Microsecond)
+				off += int64(n)
+				if err == io.EOF {
+					break
+				}
+			}
+			_ = r.Close()
+		}
+	}
+	b.StopTimer()
+	cmpReportLocked(b, store)
+}
+
+func BenchmarkCompare_New_HotRestoreReplay(b *testing.B) {
+	store := cmpSeedMulti(b, 2)
+	buf := make([]byte, cmpPageSize)
+	store.reset()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for c := 0; c < cmpChunks; c++ {
+			r, err := openRemoteStorageReader(store, chunkName(c), DefaultReaderRangeCacheSize)
+			if err != nil {
+				b.Fatal(err)
+			}
+			var off int64
+			for off < int64(cmpChunkBytes) {
+				n, err := r.ReadAt(buf, off)
+				if err != nil && err != io.EOF {
+					b.Fatal(err)
+				}
+				time.Sleep(50 * time.Microsecond)
+				off += int64(n)
+				if err == io.EOF {
+					break
+				}
+			}
+			_ = r.Close()
+		}
+	}
+	b.StopTimer()
+	cmpReportLocked(b, store)
+}

--- a/embedded/appendable/remoteapp/remote_storage_reader_test.go
+++ b/embedded/appendable/remoteapp/remote_storage_reader_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"sync"
 	"testing"
 
 	"github.com/codenotary/immudb/embedded/remotestorage"
@@ -70,7 +71,7 @@ func TestRemoteStorageReadAt(t *testing.T) {
 		1, 2, 3, 4, // Data, 4 bytes
 	})
 
-	r, err := openRemoteStorageReader(m, "fl")
+	r, err := openRemoteStorageReader(m, "fl", 0)
 	require.NoError(t, err)
 
 	b := make([]byte, 4)
@@ -112,7 +113,7 @@ func TestRemoteStorageCorruptedHeader(t *testing.T) {
 			m := memory.Open()
 			storeData(t, m, "fl", d.bytes)
 
-			r, err := openRemoteStorageReader(m, "fl")
+			r, err := openRemoteStorageReader(m, "fl", 0)
 			require.ErrorIs(t, err, ErrCorruptedMetadata)
 			require.Nil(t, r)
 		})
@@ -132,6 +133,98 @@ func (r *remoteStorageErrorInjector) Get(ctx context.Context, name string, offs,
 	return nil, r.err
 }
 
+// rangeRecordingStorage wraps an inner Storage and records (offs, size)
+// for every Get call. Used by TestReaderRangeFetch_DoesNotDownloadEntireChunk
+// to assert the reader actually issues bounded Range GETs after open
+// rather than dragging the whole object on every ReadAt.
+type rangeRecordingStorage struct {
+	remotestorage.Storage
+	mu   sync.Mutex
+	gets []rangeGet
+}
+
+type rangeGet struct {
+	offs int64
+	size int64
+}
+
+func (r *rangeRecordingStorage) Get(ctx context.Context, name string, offs, size int64) (io.ReadCloser, error) {
+	r.mu.Lock()
+	r.gets = append(r.gets, rangeGet{offs, size})
+	r.mu.Unlock()
+	return r.Storage.Get(ctx, name, offs, size)
+}
+
+func (r *rangeRecordingStorage) snapshot() []rangeGet {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]rangeGet, len(r.gets))
+	copy(out, r.gets)
+	return out
+}
+
+func TestReaderRangeFetch_DoesNotDownloadEntireChunk(t *testing.T) {
+	// Build a payload large enough that one full-object download would
+	// dominate any range-aware path. 4 MiB payload + tiny metadata
+	// header. Default reader range cache size is 256 KiB, so a single
+	// random 64 B ReadAt should fetch ~256 KiB, not 4 MiB.
+	const (
+		payloadSize     = 4 * 1024 * 1024
+		rangeCacheSize  = 256 * 1024
+		readerWindowMax = rangeCacheSize + 4096 // small slack for header bytes
+	)
+
+	header := []byte{0, 0, 0, 0} // 0-byte metadata
+	payload := make([]byte, payloadSize)
+	for i := range payload {
+		payload[i] = byte(i & 0xff)
+	}
+
+	m := &rangeRecordingStorage{Storage: memory.Open()}
+	storeData(t, m, "fl", append(header, payload...))
+
+	r, err := openRemoteStorageReader(m, "fl", rangeCacheSize)
+	require.NoError(t, err)
+
+	// Open issues exactly one Get sized to rangeCacheSize.
+	gets := m.snapshot()
+	require.Len(t, gets, 1, "open should issue exactly one Get")
+	require.Equal(t, int64(0), gets[0].offs, "open Get should start at byte 0")
+	require.Equal(t, int64(rangeCacheSize), gets[0].size,
+		"open Get should request the configured cache window, not -1 (full object)")
+
+	// Read 64 bytes near the END of the payload — guaranteed cache miss.
+	const tailReadOff = payloadSize - 100
+	buf := make([]byte, 64)
+	n, err := r.ReadAt(buf, tailReadOff)
+	require.NoError(t, err)
+	require.Equal(t, 64, n)
+	require.Equal(t, payload[tailReadOff:tailReadOff+64], buf,
+		"ranged read must return the right bytes from the right offset")
+
+	// That cache-miss read must have issued exactly ONE additional Get
+	// with a bounded size (not -1, not payloadSize).
+	gets = m.snapshot()
+	require.Len(t, gets, 2,
+		"cache-miss ReadAt should add exactly one Get on top of the open Get")
+	missGet := gets[1]
+	require.NotEqual(t, int64(-1), missGet.size,
+		"ranged read must not request -1 (whole object)")
+	require.LessOrEqual(t, missGet.size, int64(readerWindowMax),
+		"ranged read must request a bounded window, not the whole chunk")
+	require.GreaterOrEqual(t, missGet.size, int64(64),
+		"ranged read must at least cover the requested length")
+
+	// Sequential read inside the now-cached window must NOT issue another Get.
+	buf2 := make([]byte, 32)
+	n, err = r.ReadAt(buf2, tailReadOff+64)
+	require.NoError(t, err)
+	require.Equal(t, 32, n)
+	require.Equal(t, payload[tailReadOff+64:tailReadOff+96], buf2)
+	require.Len(t, m.snapshot(), 2,
+		"adjacent ReadAt inside the cache window must not trigger a new Get")
+}
+
 func TestRemoteStorageOpenError(t *testing.T) {
 	for _, duringRead := range []bool{false, true} {
 		m := &remoteStorageErrorInjector{
@@ -145,7 +238,7 @@ func TestRemoteStorageOpenError(t *testing.T) {
 			1, 2, 3, 4, // Data, 4 bytes
 		})
 
-		r, err := openRemoteStorageReader(m, "fl")
+		r, err := openRemoteStorageReader(m, "fl", 0)
 		require.Equal(t, m.err, err)
 		require.Nil(t, r)
 	}

--- a/embedded/appendable/remoteapp/remote_storage_reader_test.go
+++ b/embedded/appendable/remoteapp/remote_storage_reader_test.go
@@ -166,8 +166,9 @@ func (r *rangeRecordingStorage) snapshot() []rangeGet {
 func TestReaderRangeFetch_DoesNotDownloadEntireChunk(t *testing.T) {
 	// Build a payload large enough that one full-object download would
 	// dominate any range-aware path. 4 MiB payload + tiny metadata
-	// header. Default reader range cache size is 256 KiB, so a single
-	// random 64 B ReadAt should fetch ~256 KiB, not 4 MiB.
+	// header. Default reader range cache size is 256 KiB, so any
+	// reachable Get should be ~256 KiB, never 4 MiB and never `-1`
+	// (whole object).
 	const (
 		payloadSize     = 4 * 1024 * 1024
 		rangeCacheSize  = 256 * 1024
@@ -186,9 +187,9 @@ func TestReaderRangeFetch_DoesNotDownloadEntireChunk(t *testing.T) {
 	r, err := openRemoteStorageReader(m, "fl", rangeCacheSize)
 	require.NoError(t, err)
 
-	// Open issues exactly one Get sized to rangeCacheSize.
+	// Open issues a Get sized to rangeCacheSize (not -1).
 	gets := m.snapshot()
-	require.Len(t, gets, 1, "open should issue exactly one Get")
+	require.GreaterOrEqual(t, len(gets), 1, "open should issue at least one Get")
 	require.Equal(t, int64(0), gets[0].offs, "open Get should start at byte 0")
 	require.Equal(t, int64(rangeCacheSize), gets[0].size,
 		"open Get should request the configured cache window, not -1 (full object)")
@@ -202,27 +203,30 @@ func TestReaderRangeFetch_DoesNotDownloadEntireChunk(t *testing.T) {
 	require.Equal(t, payload[tailReadOff:tailReadOff+64], buf,
 		"ranged read must return the right bytes from the right offset")
 
-	// That cache-miss read must have issued exactly ONE additional Get
-	// with a bounded size (not -1, not payloadSize).
-	gets = m.snapshot()
-	require.Len(t, gets, 2,
-		"cache-miss ReadAt should add exactly one Get on top of the open Get")
-	missGet := gets[1]
-	require.NotEqual(t, int64(-1), missGet.size,
-		"ranged read must not request -1 (whole object)")
-	require.LessOrEqual(t, missGet.size, int64(readerWindowMax),
-		"ranged read must request a bounded window, not the whole chunk")
-	require.GreaterOrEqual(t, missGet.size, int64(64),
-		"ranged read must at least cover the requested length")
-
-	// Sequential read inside the now-cached window must NOT issue another Get.
+	// Sequential read inside the now-cached window returns the right
+	// bytes. We can't pin "no new Get here" because Wave 2's
+	// background read-ahead prefetch may legitimately fire between
+	// snapshots — the bounded-size invariant below catches the actual
+	// regression we care about (no full-chunk download).
 	buf2 := make([]byte, 32)
 	n, err = r.ReadAt(buf2, tailReadOff+64)
 	require.NoError(t, err)
 	require.Equal(t, 32, n)
 	require.Equal(t, payload[tailReadOff+64:tailReadOff+96], buf2)
-	require.Len(t, m.snapshot(), 2,
-		"adjacent ReadAt inside the cache window must not trigger a new Get")
+
+	// Every Get issued so far must have requested a bounded window —
+	// never -1 (whole object) and never larger than ~rangeCacheSize.
+	// This is the load-bearing invariant: full-chunk downloads are
+	// gone for good. Wave 2 may add a read-ahead prefetch on top, so
+	// we don't pin the exact Get count, only the per-Get size cap.
+	for i, g := range m.snapshot() {
+		require.NotEqual(t, int64(-1), g.size,
+			"Get #%d must not request -1 (whole object): %+v", i, g)
+		require.LessOrEqual(t, g.size, int64(readerWindowMax),
+			"Get #%d must request a bounded window, not the whole chunk: %+v", i, g)
+		require.Greater(t, g.size, int64(0),
+			"Get #%d size must be positive: %+v", i, g)
+	}
 }
 
 func TestRemoteStorageOpenError(t *testing.T) {

--- a/embedded/appendable/remoteapp/remote_storage_reader_test.go
+++ b/embedded/appendable/remoteapp/remote_storage_reader_test.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/codenotary/immudb/embedded/appendable"
 	"github.com/codenotary/immudb/embedded/remotestorage"
 	"github.com/codenotary/immudb/embedded/remotestorage/memory"
 	"github.com/stretchr/testify/require"
@@ -43,9 +44,14 @@ func TestRemoteStorageReaderUnsupportedMethods(t *testing.T) {
 	require.Panics(t, func() { r.SetOffset(0) })
 	require.Panics(t, func() { r.Append([]byte{0}) })
 	require.Panics(t, func() { r.DiscardUpto(0) })
-	require.Panics(t, func() { r.CompressionFormat() })
-	require.Panics(t, func() { r.CompressionLevel() })
 	require.Panics(t, func() { r.Copy("/tmp") })
+
+	// CompressionFormat/Level used to panic but are now real
+	// accessors — required for the multiapp prefetch snapshot to
+	// work and for the chunk-level decompress path. A zero-value
+	// reader reports NoCompression / level 0.
+	require.Equal(t, appendable.NoCompression, r.CompressionFormat())
+	require.Equal(t, 0, r.CompressionLevel())
 }
 
 func TestRemoteStorageFlush(t *testing.T) {
@@ -187,12 +193,19 @@ func TestReaderRangeFetch_DoesNotDownloadEntireChunk(t *testing.T) {
 	r, err := openRemoteStorageReader(m, "fl", rangeCacheSize)
 	require.NoError(t, err)
 
-	// Open issues a Get sized to rangeCacheSize (not -1).
+	// Open issues a Get sized close to rangeCacheSize (not -1).
+	// Wave 3 over-fetches by openHeaderSlack so the first cached
+	// payload window covers a full aligned region after stripping
+	// the metadata header — assert bounded, not exact.
 	gets := m.snapshot()
 	require.GreaterOrEqual(t, len(gets), 1, "open should issue at least one Get")
 	require.Equal(t, int64(0), gets[0].offs, "open Get should start at byte 0")
-	require.Equal(t, int64(rangeCacheSize), gets[0].size,
-		"open Get should request the configured cache window, not -1 (full object)")
+	require.NotEqual(t, int64(-1), gets[0].size,
+		"open Get must not request -1 (full object)")
+	require.LessOrEqual(t, gets[0].size, int64(rangeCacheSize+openHeaderSlack),
+		"open Get must be bounded by rangeCacheSize + openHeaderSlack")
+	require.GreaterOrEqual(t, gets[0].size, int64(rangeCacheSize),
+		"open Get must cover at least rangeCacheSize")
 
 	// Read 64 bytes near the END of the payload — guaranteed cache miss.
 	const tailReadOff = payloadSize - 100

--- a/embedded/appendable/remoteapp/rustfs_bench_test.go
+++ b/embedded/appendable/remoteapp/rustfs_bench_test.go
@@ -1,0 +1,409 @@
+/*
+Copyright 2026 Codenotary Inc. All rights reserved.
+
+SPDX-License-Identifier: BUSL-1.1
+*/
+
+package remoteapp
+
+import (
+	"context"
+	"io"
+	"math/rand"
+	"os"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/codenotary/immudb/embedded/appendable"
+	"github.com/codenotary/immudb/embedded/remotestorage"
+	"github.com/codenotary/immudb/embedded/remotestorage/s3"
+)
+
+// These benchmarks require a running rustfs (or any S3-compatible
+// service) reachable at $RUSTFS_ENDPOINT (default 127.0.0.1:9100)
+// with a pre-created bucket $RUSTFS_BUCKET (default "immudb-bench").
+// Skipped automatically when the endpoint isn't reachable.
+//
+// Spin up rustfs locally with:
+//   docker run -d --name rustfs-bench -p 9100:9000 \
+//     -e RUSTFS_ROOT_USER=rustfsadmin \
+//     -e RUSTFS_ROOT_PASSWORD=rustfsadmin \
+//     -v /tmp/rustfs-data:/data rustfs/rustfs:latest
+//   AWS_ACCESS_KEY_ID=rustfsadmin AWS_SECRET_ACCESS_KEY=rustfsadmin \
+//     aws --endpoint-url http://127.0.0.1:9100 s3 mb s3://immudb-bench
+
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func openRustFS(tb testing.TB, prefix string) remotestorage.Storage {
+	tb.Helper()
+	endpoint := "http://" + envOr("RUSTFS_ENDPOINT", "127.0.0.1:9100")
+	bucket := envOr("RUSTFS_BUCKET", "immudb-bench")
+	access := envOr("RUSTFS_ACCESS_KEY", "rustfsadmin")
+	secret := envOr("RUSTFS_SECRET_KEY", "rustfsadmin")
+
+	store, err := s3.Open(
+		endpoint,
+		false, "",
+		access, secret,
+		bucket,
+		"us-east-1",
+		prefix,
+		"http://169.254.169.254",
+		false,
+	)
+	if err != nil {
+		tb.Skipf("rustfs unavailable: %v", err)
+	}
+	return store
+}
+
+// countingS3 wraps the s3.Storage and counts each operation; lets us
+// report puts/gets/exists per chunk without needing to instrument the
+// upstream client.
+type countingS3 struct {
+	remotestorage.Storage
+	gets, puts, exists, removes int64
+}
+
+func (c *countingS3) Get(ctx context.Context, name string, offs, size int64) (io.ReadCloser, error) {
+	atomic.AddInt64(&c.gets, 1)
+	return c.Storage.Get(ctx, name, offs, size)
+}
+func (c *countingS3) Put(ctx context.Context, name, fileName string) error {
+	atomic.AddInt64(&c.puts, 1)
+	return c.Storage.Put(ctx, name, fileName)
+}
+func (c *countingS3) Exists(ctx context.Context, name string) (bool, error) {
+	atomic.AddInt64(&c.exists, 1)
+	return c.Storage.Exists(ctx, name)
+}
+func (c *countingS3) Remove(ctx context.Context, name string) error {
+	atomic.AddInt64(&c.removes, 1)
+	return c.Storage.Remove(ctx, name)
+}
+func (c *countingS3) RemoveAll(ctx context.Context, path string) error {
+	atomic.AddInt64(&c.removes, 1)
+	return c.Storage.RemoveAll(ctx, path)
+}
+
+// uniquePrefix returns a fresh per-bench-iter S3 path so concurrent
+// runs on the same bucket don't collide and prior runs don't pollute.
+func uniquePrefix(name string) string {
+	return name + "-" + strconv.FormatInt(time.Now().UnixNano(), 36) + "/"
+}
+
+// --- #3: drop post-upload verification (real rustfs) ---
+
+func benchRustFSUpload(b *testing.B, verifyUploads bool) {
+	const (
+		chunks  = 8
+		chunkSz = 8 * 1024
+	)
+	payload := make([]byte, chunkSz*chunks)
+	rand.New(rand.NewSource(11)).Read(payload)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		raw := openRustFS(b, uniquePrefix("upload"))
+		store := &countingS3{Storage: raw}
+		opts := DefaultOptions().
+			WithVerifyUploads(verifyUploads).
+			WithRetryMinDelay(50 * time.Millisecond).
+			WithRetryMaxDelay(time.Second)
+		opts.WithFileSize(chunkSz).WithFileExt("aof")
+		opts.WithPrefetchAheadDepth(0)
+
+		app, err := Open(b.TempDir(), "rustfs/", store, opts)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if _, _, err := app.Append(payload); err != nil {
+			b.Fatal(err)
+		}
+		if err := app.Flush(); err != nil {
+			b.Fatal(err)
+		}
+		for c := 0; c < chunks-1; c++ {
+			waitForChunkState(app, c, chunkState_Remote)
+		}
+		_ = app.Close()
+		b.StopTimer()
+		b.ReportMetric(float64(atomic.LoadInt64(&store.puts))/float64(chunks-1), "puts/chunk")
+		b.ReportMetric(float64(atomic.LoadInt64(&store.exists))/float64(chunks-1), "exists/chunk")
+		b.ReportMetric(float64(atomic.LoadInt64(&store.gets))/float64(chunks-1), "gets/chunk")
+		b.StartTimer()
+	}
+}
+
+func BenchmarkRustFS_Upload_Legacy(b *testing.B) { benchRustFSUpload(b, true) }
+func BenchmarkRustFS_Upload_Fast(b *testing.B)   { benchRustFSUpload(b, false) }
+
+// --- #1: parallel multi-chunk prefetch (real rustfs) ---
+
+func benchRustFSMultiChunkSequential(b *testing.B, prefetchDepth int) {
+	const (
+		chunks      = 16
+		chunkSz     = 8 * 1024
+		pageSz      = 1024
+		perPageWork = 5 * time.Millisecond
+	)
+	prefix := uniquePrefix("seqread")
+	store := openRustFS(b, prefix)
+	tmp := b.TempDir()
+
+	// Pre-populate the bucket with `chunks` worth of data.
+	writeOpts := DefaultOptions().
+		WithRetryMinDelay(50 * time.Millisecond).
+		WithRetryMaxDelay(time.Second)
+	writeOpts.WithFileSize(chunkSz).WithFileExt("aof")
+	writeOpts.WithPrefetchAheadDepth(0)
+
+	app, err := Open(tmp, "rustfs/", store, writeOpts)
+	if err != nil {
+		b.Fatal(err)
+	}
+	payload := make([]byte, chunkSz*chunks)
+	rand.New(rand.NewSource(12)).Read(payload)
+	if _, _, err := app.Append(payload); err != nil {
+		b.Fatal(err)
+	}
+	if err := app.Flush(); err != nil {
+		b.Fatal(err)
+	}
+	for c := 0; c < chunks-1; c++ {
+		waitForChunkState(app, c, chunkState_Remote)
+	}
+	_ = app.Close()
+	_ = os.RemoveAll(tmp)
+
+	buf := make([]byte, pageSz)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		readTmp := b.TempDir()
+		counted := &countingS3{Storage: store}
+		readOpts := DefaultOptions().
+			WithRetryMinDelay(50 * time.Millisecond).
+			WithRetryMaxDelay(time.Second)
+		readOpts.WithReadOnly(true).
+			WithFileSize(chunkSz).
+			WithFileExt("aof").
+			WithMaxOpenedFiles(chunks + 4)
+		readOpts.WithPrefetchAheadDepth(prefetchDepth)
+
+		readApp, err := Open(readTmp, "rustfs/", counted, readOpts)
+		if err != nil {
+			b.Fatal(err)
+		}
+		var off int64
+		end := int64(chunkSz * (chunks - 1))
+		for off < end {
+			n, err := readApp.ReadAt(buf, off)
+			if err != nil && err != io.EOF {
+				b.Fatal(err)
+			}
+			if n == 0 {
+				break
+			}
+			time.Sleep(perPageWork)
+			off += int64(n)
+		}
+		_ = readApp.Close()
+		b.StopTimer()
+		b.ReportMetric(float64(atomic.LoadInt64(&counted.gets)), "gets/op")
+		b.StartTimer()
+	}
+}
+
+func BenchmarkRustFS_MultiChunkRead_NoPrefetch(b *testing.B) {
+	benchRustFSMultiChunkSequential(b, 0)
+}
+func BenchmarkRustFS_MultiChunkRead_Prefetch4(b *testing.B) {
+	benchRustFSMultiChunkSequential(b, 4)
+}
+
+// rttInjector wraps a Storage and adds a fixed sleep on every Get,
+// Put and Exists. Models the wall-clock cost of a high-RTT WAN link
+// (e.g. cross-region S3) on top of an otherwise-fast local backend.
+type rttInjector struct {
+	remotestorage.Storage
+	rtt time.Duration
+}
+
+func (r *rttInjector) Get(ctx context.Context, name string, offs, size int64) (io.ReadCloser, error) {
+	if r.rtt > 0 {
+		time.Sleep(r.rtt)
+	}
+	return r.Storage.Get(ctx, name, offs, size)
+}
+func (r *rttInjector) Put(ctx context.Context, name, fileName string) error {
+	if r.rtt > 0 {
+		time.Sleep(r.rtt)
+	}
+	return r.Storage.Put(ctx, name, fileName)
+}
+func (r *rttInjector) Exists(ctx context.Context, name string) (bool, error) {
+	if r.rtt > 0 {
+		time.Sleep(r.rtt)
+	}
+	return r.Storage.Exists(ctx, name)
+}
+
+func benchRustFSMultiChunkSequentialWithRTT(b *testing.B, prefetchDepth int, rtt time.Duration) {
+	const (
+		chunks      = 16
+		chunkSz     = 8 * 1024
+		pageSz      = 1024
+		perPageWork = 5 * time.Millisecond
+	)
+	prefix := uniquePrefix("seqread-rtt")
+	rawStore := openRustFS(b, prefix)
+
+	// Pre-populate without injected latency (just real loopback).
+	tmp := b.TempDir()
+	writeOpts := DefaultOptions().
+		WithRetryMinDelay(50 * time.Millisecond).
+		WithRetryMaxDelay(time.Second)
+	writeOpts.WithFileSize(chunkSz).WithFileExt("aof")
+	writeOpts.WithPrefetchAheadDepth(0)
+
+	app, err := Open(tmp, "rustfs/", rawStore, writeOpts)
+	if err != nil {
+		b.Fatal(err)
+	}
+	payload := make([]byte, chunkSz*chunks)
+	rand.New(rand.NewSource(13)).Read(payload)
+	if _, _, err := app.Append(payload); err != nil {
+		b.Fatal(err)
+	}
+	if err := app.Flush(); err != nil {
+		b.Fatal(err)
+	}
+	for c := 0; c < chunks-1; c++ {
+		waitForChunkState(app, c, chunkState_Remote)
+	}
+	_ = app.Close()
+	_ = os.RemoveAll(tmp)
+
+	// Reads go through the rttInjector so each Get pays the
+	// simulated WAN round trip.
+	store := &rttInjector{Storage: rawStore, rtt: rtt}
+	buf := make([]byte, pageSz)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		readTmp := b.TempDir()
+		counted := &countingS3{Storage: store}
+		readOpts := DefaultOptions().
+			WithRetryMinDelay(50 * time.Millisecond).
+			WithRetryMaxDelay(time.Second)
+		readOpts.WithReadOnly(true).
+			WithFileSize(chunkSz).
+			WithFileExt("aof").
+			WithMaxOpenedFiles(chunks + 4)
+		readOpts.WithPrefetchAheadDepth(prefetchDepth)
+
+		readApp, err := Open(readTmp, "rustfs/", counted, readOpts)
+		if err != nil {
+			b.Fatal(err)
+		}
+		var off int64
+		end := int64(chunkSz * (chunks - 1))
+		for off < end {
+			n, err := readApp.ReadAt(buf, off)
+			if err != nil && err != io.EOF {
+				b.Fatal(err)
+			}
+			if n == 0 {
+				break
+			}
+			time.Sleep(perPageWork)
+			off += int64(n)
+		}
+		_ = readApp.Close()
+		b.StopTimer()
+		b.ReportMetric(float64(atomic.LoadInt64(&counted.gets)), "gets/op")
+		b.StartTimer()
+	}
+}
+
+func BenchmarkRustFS_MultiChunkRead_NoPrefetch_50msRTT(b *testing.B) {
+	benchRustFSMultiChunkSequentialWithRTT(b, 0, 50*time.Millisecond)
+}
+func BenchmarkRustFS_MultiChunkRead_Prefetch4_50msRTT(b *testing.B) {
+	benchRustFSMultiChunkSequentialWithRTT(b, 4, 50*time.Millisecond)
+}
+
+// --- #2: end-to-end compression on real S3 wire ---
+
+func benchRustFSCompression(b *testing.B, format int) {
+	const payloadSize = 256 * 1024
+	const chunkSz = 1024 * 1024
+
+	payload := make([]byte, payloadSize)
+	for i := range payload {
+		payload[i] = byte('A' + (i / 4096))
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		raw := openRustFS(b, uniquePrefix("compress"))
+		store := &countingS3{Storage: raw}
+		opts := DefaultOptions().
+			WithRetryMinDelay(50 * time.Millisecond).
+			WithRetryMaxDelay(time.Second)
+		opts.WithCompressionFormat(format).
+			WithCompresionLevel(appendable.BestSpeed).
+			WithFileSize(chunkSz).
+			WithFileExt("aof")
+		opts.WithPrefetchAheadDepth(0)
+
+		app, err := Open(b.TempDir(), "rustfs/", store, opts)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if _, _, err := app.Append(payload); err != nil {
+			b.Fatal(err)
+		}
+		if err := app.Flush(); err != nil {
+			b.Fatal(err)
+		}
+		_ = app.Close()
+
+		// Walk the bucket prefix to total wire bytes.
+		entries, _, err := raw.ListEntries(context.Background(), "rustfs/")
+		if err != nil {
+			b.Fatal(err)
+		}
+		var total int64
+		for _, e := range entries {
+			total += e.Size
+		}
+		b.StopTimer()
+		b.ReportMetric(float64(total), "wire-bytes")
+		if total > 0 {
+			b.ReportMetric(float64(len(payload))/float64(total), "compression-ratio")
+		}
+		b.StartTimer()
+	}
+}
+
+func BenchmarkRustFS_Compress_None(b *testing.B) {
+	benchRustFSCompression(b, appendable.NoCompression)
+}
+func BenchmarkRustFS_Compress_Flate(b *testing.B) {
+	benchRustFSCompression(b, appendable.FlateCompression)
+}
+func BenchmarkRustFS_Compress_GZip(b *testing.B) {
+	benchRustFSCompression(b, appendable.GZipCompression)
+}
+func BenchmarkRustFS_Compress_ZLib(b *testing.B) {
+	benchRustFSCompression(b, appendable.ZLibCompression)
+}

--- a/embedded/appendable/remoteapp/wave3_bench_test.go
+++ b/embedded/appendable/remoteapp/wave3_bench_test.go
@@ -1,0 +1,281 @@
+/*
+Copyright 2026 Codenotary Inc. All rights reserved.
+
+SPDX-License-Identifier: BUSL-1.1
+*/
+
+package remoteapp
+
+import (
+	"context"
+	"io"
+	"math/rand"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/codenotary/immudb/embedded/appendable"
+	"github.com/codenotary/immudb/embedded/remotestorage"
+	"github.com/codenotary/immudb/embedded/remotestorage/memory"
+)
+
+// rttStorage wraps any remotestorage.Storage and adds a configurable
+// per-Get + per-Put + per-Exists sleep so benchmarks can simulate S3
+// round-trip time on a fast local backend. Counts each operation so
+// we can report how many round trips a benchmark actually issues.
+type rttStorage struct {
+	remotestorage.Storage
+	rtt    time.Duration
+	gets   int64
+	puts   int64
+	exists int64
+}
+
+func (r *rttStorage) Get(ctx context.Context, name string, offs, size int64) (io.ReadCloser, error) {
+	atomic.AddInt64(&r.gets, 1)
+	if r.rtt > 0 {
+		time.Sleep(r.rtt)
+	}
+	return r.Storage.Get(ctx, name, offs, size)
+}
+
+func (r *rttStorage) Put(ctx context.Context, name, fileName string) error {
+	atomic.AddInt64(&r.puts, 1)
+	if r.rtt > 0 {
+		time.Sleep(r.rtt)
+	}
+	return r.Storage.Put(ctx, name, fileName)
+}
+
+func (r *rttStorage) Exists(ctx context.Context, name string) (bool, error) {
+	atomic.AddInt64(&r.exists, 1)
+	if r.rtt > 0 {
+		time.Sleep(r.rtt)
+	}
+	return r.Storage.Exists(ctx, name)
+}
+
+func (r *rttStorage) reset() {
+	atomic.StoreInt64(&r.gets, 0)
+	atomic.StoreInt64(&r.puts, 0)
+	atomic.StoreInt64(&r.exists, 0)
+}
+
+// --- #3: skip post-upload verification ---
+//
+// Compares the Append + Flush + chunk-rotation cost with the legacy
+// verification path (Put + Exists + remote-reader open) vs the new
+// fast path (just Put). Reports gets/puts/exists per chunk written.
+//
+// Workload: 8 chunks of 8 KiB each, simulated 50 ms RTT.
+
+func benchUpload(b *testing.B, verifyUploads bool) {
+	const (
+		chunks  = 8
+		chunkSz = 8 * 1024
+		rtt     = 50 * time.Millisecond
+	)
+	payload := make([]byte, chunkSz*chunks)
+	rand.New(rand.NewSource(1)).Read(payload)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		store := &rttStorage{Storage: memory.Open(), rtt: rtt}
+		opts := DefaultOptions().
+			WithVerifyUploads(verifyUploads).
+			WithRetryMinDelay(time.Microsecond).
+			WithRetryMaxDelay(time.Microsecond)
+		opts.WithFileSize(chunkSz).WithFileExt("aof")
+		// Disable the chunk-prefetch for this isolated upload bench.
+		opts.WithPrefetchAheadDepth(0)
+
+		app, err := Open(b.TempDir(), "", store, opts)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if _, _, err := app.Append(payload); err != nil {
+			b.Fatal(err)
+		}
+		if err := app.Flush(); err != nil {
+			b.Fatal(err)
+		}
+		// Wait for all chunks to actually upload before tearing down.
+		for c := int64(0); c < chunks-1; c++ {
+			waitForChunkState(app, int(c), chunkState_Remote)
+		}
+		_ = app.Close()
+		b.StopTimer()
+		b.ReportMetric(float64(atomic.LoadInt64(&store.gets))/float64(chunks-1), "gets/chunk")
+		b.ReportMetric(float64(atomic.LoadInt64(&store.puts))/float64(chunks-1), "puts/chunk")
+		b.ReportMetric(float64(atomic.LoadInt64(&store.exists))/float64(chunks-1), "exists/chunk")
+		b.StartTimer()
+	}
+}
+
+func BenchmarkWave3_Upload_Legacy(b *testing.B) { benchUpload(b, true) }
+func BenchmarkWave3_Upload_Fast(b *testing.B)   { benchUpload(b, false) }
+
+// --- #1: parallel multi-chunk prefetch on the multiapp layer ---
+//
+// Sequentially reads N adjacent chunks through the full remoteapp +
+// multiapp stack. With prefetchDepth=0, each chunk's open RTT
+// serializes with the consumer. With depth=4, the next 4 opens
+// overlap with consumer per-page processing — at 50 ms RTT this is
+// the wall-clock difference between (chunks × RTT) and (RTT + work).
+
+func benchMultiChunkSequential(b *testing.B, prefetchDepth int) {
+	const (
+		chunks      = 16
+		chunkSz     = 8 * 1024
+		pageSz      = 1024
+		perPageWork = 5 * time.Millisecond // realistic decode/replay
+		rtt         = 50 * time.Millisecond
+	)
+
+	store := &rttStorage{Storage: memory.Open(), rtt: rtt}
+	path := b.TempDir()
+
+	// Build a multiapp pre-populated with `chunks` worth of data.
+	writeOpts := DefaultOptions().
+		WithRetryMinDelay(time.Microsecond).
+		WithRetryMaxDelay(time.Microsecond)
+	writeOpts.WithFileSize(chunkSz).WithFileExt("aof")
+	writeOpts.WithPrefetchAheadDepth(0)
+
+	app, err := Open(path, "", store, writeOpts)
+	if err != nil {
+		b.Fatal(err)
+	}
+	payload := make([]byte, chunkSz*chunks)
+	rand.New(rand.NewSource(2)).Read(payload)
+	if _, _, err := app.Append(payload); err != nil {
+		b.Fatal(err)
+	}
+	if err := app.Flush(); err != nil {
+		b.Fatal(err)
+	}
+	for c := int64(0); c < chunks-1; c++ {
+		waitForChunkState(app, int(c), chunkState_Remote)
+	}
+	_ = app.Close()
+
+	store.reset()
+
+	buf := make([]byte, pageSz)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		readOpts := DefaultOptions().
+			WithRetryMinDelay(time.Microsecond).
+			WithRetryMaxDelay(time.Microsecond)
+		readOpts.WithReadOnly(true).
+			WithFileSize(chunkSz).
+			WithFileExt("aof").
+			WithMaxOpenedFiles(chunks + 4)
+		readOpts.WithPrefetchAheadDepth(prefetchDepth)
+		readApp, err := Open(path, "", store, readOpts)
+		if err != nil {
+			b.Fatal(err)
+		}
+		var off int64
+		end := int64(chunkSz * (chunks - 1))
+		for off < end {
+			n, err := readApp.ReadAt(buf, off)
+			if err != nil && err != io.EOF {
+				b.Fatal(err)
+			}
+			if n == 0 {
+				break
+			}
+			time.Sleep(perPageWork)
+			off += int64(n)
+		}
+		_ = readApp.Close()
+	}
+	b.StopTimer()
+	b.ReportMetric(float64(atomic.LoadInt64(&store.gets))/float64(b.N), "gets/op")
+}
+
+func BenchmarkWave1_MultiChunkRead_NoPrefetch(b *testing.B) {
+	benchMultiChunkSequential(b, 0)
+}
+func BenchmarkWave1_MultiChunkRead_Prefetch4(b *testing.B) {
+	benchMultiChunkSequential(b, 4)
+}
+
+// --- #2: compression on the wire ---
+//
+// Writes the same compressible payload with and without compression,
+// then measures (a) bytes uploaded to the remote storage and (b)
+// wall-clock for a sequential ReadAt-back of every byte. Reports the
+// upload size as `wire-bytes`.
+
+func benchCompression(b *testing.B, format int) {
+	// Single chunk, single Append, large enough that the
+	// compression ratio is meaningful and small enough that the
+	// per-Append frame fits in one chunk file.
+	const payloadSize = 256 * 1024
+	const chunkSz = 1024 * 1024 // generous chunk so the whole payload fits
+
+	// Highly compressible payload — long runs of repeating bytes.
+	payload := make([]byte, payloadSize)
+	for i := range payload {
+		payload[i] = byte('A' + (i / 4096))
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		store := &rttStorage{Storage: memory.Open()}
+		opts := DefaultOptions().
+			WithRetryMinDelay(time.Microsecond).
+			WithRetryMaxDelay(time.Microsecond)
+		opts.WithCompressionFormat(format).
+			WithCompresionLevel(appendable.BestSpeed).
+			WithFileSize(chunkSz).
+			WithFileExt("aof")
+		opts.WithPrefetchAheadDepth(0)
+
+		app, err := Open(b.TempDir(), "", store, opts)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if _, _, err := app.Append(payload); err != nil {
+			b.Fatal(err)
+		}
+		if err := app.Flush(); err != nil {
+			b.Fatal(err)
+		}
+		// Force the chunk to rotate and upload by closing the
+		// appendable. Close blocks until in-flight uploads drain.
+		_ = app.Close()
+
+		entries, _, err := store.ListEntries(context.Background(), "")
+		if err != nil {
+			b.Fatal(err)
+		}
+		var total int64
+		for _, e := range entries {
+			total += e.Size
+		}
+
+		b.StopTimer()
+		b.ReportMetric(float64(total), "wire-bytes")
+		if total > 0 {
+			b.ReportMetric(float64(len(payload))/float64(total), "compression-ratio")
+		}
+		b.StartTimer()
+	}
+}
+
+func BenchmarkWave2_Compress_None(b *testing.B) {
+	benchCompression(b, appendable.NoCompression)
+}
+func BenchmarkWave2_Compress_Flate(b *testing.B) {
+	benchCompression(b, appendable.FlateCompression)
+}
+func BenchmarkWave2_Compress_GZip(b *testing.B) {
+	benchCompression(b, appendable.GZipCompression)
+}
+func BenchmarkWave2_Compress_ZLib(b *testing.B) {
+	benchCompression(b, appendable.ZLibCompression)
+}

--- a/embedded/appendable/singleapp/single_app.go
+++ b/embedded/appendable/singleapp/single_app.go
@@ -51,6 +51,14 @@ const (
 	metaWrappedMeta       = "WRAPPED_METADATA"
 )
 
+// MetaCompressionFormat is the metadata key that records the
+// compression format used by an AppendableFile. Exported so
+// downstream readers (e.g. remoteapp) that operate on the raw
+// chunk file rather than going through this package's reader can
+// extract the format from the chunk header and reproduce the
+// per-entry decompression protocol.
+const MetaCompressionFormat = metaCompressionFormat
+
 var _ appendable.Appendable = (*AppendableFile)(nil)
 
 type AppendableFile struct {

--- a/embedded/sql/catalog.go
+++ b/embedded/sql/catalog.go
@@ -1548,6 +1548,135 @@ func EncodeRawValueAsKey(val interface{}, colType SQLValueType, maxLen int) ([]b
 	return nil, 0, ErrInvalidValue
 }
 
+// DecodeValueFromKey is the inverse of EncodeRawValueAsKey for the bytes that
+// follow the per-column tag in an index key. `buf` must start with the tag
+// byte (KeyValPrefixNull or KeyValPrefixNotNull). It returns the decoded
+// TypedValue and the number of bytes consumed from `buf`.
+//
+// The encoded form mirrors EncodeRawValueAsKey:
+//
+//	NULL:                 [tag]                                         (1 byte)
+//	NotNull, fixed-width: [tag][maxLen bytes]                           (1+maxLen bytes)
+//	NotNull, var-width:   [tag][maxLen bytes payload][len uint32 BE]    (1+maxLen+EncLenLen bytes)
+//
+// For Integer/Timestamp the lexical sign-flip is reversed; for Float64 the
+// lexical mangling is reversed; for Varchar/BLOB the trailing length suffix
+// trims the zero padding.
+func DecodeValueFromKey(buf []byte, colType SQLValueType, maxLen int) (TypedValue, int, error) {
+	if maxLen <= 0 {
+		return nil, 0, ErrInvalidValue
+	}
+	if len(buf) < 1 {
+		return nil, 0, ErrCorruptedData
+	}
+
+	switch buf[0] {
+	case KeyValPrefixNull:
+		return &NullValue{t: colType}, 1, nil
+	case KeyValPrefixNotNull:
+		// fall through to type-specific decode
+	default:
+		return nil, 0, ErrCorruptedData
+	}
+
+	switch colType {
+	case VarcharType:
+		need := 1 + maxLen + EncLenLen
+		if len(buf) < need {
+			return nil, 0, ErrCorruptedData
+		}
+		strLen := int(binary.BigEndian.Uint32(buf[1+maxLen:]))
+		if strLen < 0 || strLen > maxLen {
+			return nil, 0, ErrCorruptedData
+		}
+		return &Varchar{val: string(buf[1 : 1+strLen])}, need, nil
+
+	case IntegerType:
+		if maxLen != 8 {
+			return nil, 0, ErrCorruptedData
+		}
+		if len(buf) < 9 {
+			return nil, 0, ErrCorruptedData
+		}
+		var raw [8]byte
+		copy(raw[:], buf[1:9])
+		raw[0] ^= 0x80
+		return &Integer{val: int64(binary.BigEndian.Uint64(raw[:]))}, 9, nil
+
+	case BooleanType:
+		if maxLen != 1 {
+			return nil, 0, ErrCorruptedData
+		}
+		if len(buf) < 2 {
+			return nil, 0, ErrCorruptedData
+		}
+		return &Bool{val: buf[1] != 0}, 2, nil
+
+	case BLOBType:
+		need := 1 + maxLen + EncLenLen
+		if len(buf) < need {
+			return nil, 0, ErrCorruptedData
+		}
+		blobLen := int(binary.BigEndian.Uint32(buf[1+maxLen:]))
+		if blobLen < 0 || blobLen > maxLen {
+			return nil, 0, ErrCorruptedData
+		}
+		// copy out so the result is independent of the input buffer
+		out := make([]byte, blobLen)
+		copy(out, buf[1:1+blobLen])
+		return &Blob{val: out}, need, nil
+
+	case UUIDType:
+		if maxLen != 16 {
+			return nil, 0, ErrCorruptedData
+		}
+		if len(buf) < 17 {
+			return nil, 0, ErrCorruptedData
+		}
+		var u uuid.UUID
+		copy(u[:], buf[1:17])
+		return &UUID{val: u}, 17, nil
+
+	case TimestampType:
+		if maxLen != 8 {
+			return nil, 0, ErrCorruptedData
+		}
+		if len(buf) < 9 {
+			return nil, 0, ErrCorruptedData
+		}
+		var raw [8]byte
+		copy(raw[:], buf[1:9])
+		raw[0] ^= 0x80
+		nanos := int64(binary.BigEndian.Uint64(raw[:]))
+		return &Timestamp{val: time.Unix(0, nanos).UTC()}, 9, nil
+
+	case Float64Type:
+		if maxLen != 8 {
+			return nil, 0, ErrCorruptedData
+		}
+		if len(buf) < 9 {
+			return nil, 0, ErrCorruptedData
+		}
+		var raw [8]byte
+		copy(raw[:], buf[1:9])
+		// Reverse the encode-time mangling: positive numbers had only the
+		// leading sign bit flipped; negative numbers had every byte flipped.
+		if raw[0]&0x80 != 0 {
+			// originally positive: just flip the sign bit back
+			raw[0] ^= 0x80
+		} else {
+			// originally negative: flip all bytes
+			for i := range raw {
+				raw[i] = ^raw[i]
+			}
+		}
+		bits := binary.BigEndian.Uint64(raw[:])
+		return &Float64{val: math.Float64frombits(bits)}, 9, nil
+	}
+
+	return nil, 0, ErrInvalidValue
+}
+
 func getEncodeRawValue(val TypedValue, colType SQLValueType) (interface{}, error) {
 	if colType != JSONType || val.Type() == JSONType {
 		return val.RawValue(), nil

--- a/embedded/sql/catalog_test.go
+++ b/embedded/sql/catalog_test.go
@@ -18,10 +18,13 @@ package sql
 
 import (
 	"context"
+	"math"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/codenotary/immudb/embedded/store"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -145,6 +148,124 @@ func TestEncodeRawValueAsKey(t *testing.T) {
 
 			prevEncKey = encKey
 		}
+	})
+}
+
+func TestEncodeDecodeValueAsKeyRoundtrip(t *testing.T) {
+	t.Run("integer", func(t *testing.T) {
+		for _, v := range []int64{math.MinInt64, -1234567, -1, 0, 1, 1234567, math.MaxInt64} {
+			enc, _, err := EncodeValueAsKey(&Integer{val: v}, IntegerType, 8)
+			require.NoError(t, err)
+			got, n, err := DecodeValueFromKey(enc, IntegerType, 8)
+			require.NoError(t, err)
+			require.Equal(t, len(enc), n)
+			require.Equal(t, v, got.RawValue())
+		}
+	})
+
+	t.Run("varchar", func(t *testing.T) {
+		for _, v := range []string{"", "a", "key", "key2", "exactly-ten"[:10]} {
+			enc, _, err := EncodeValueAsKey(&Varchar{val: v}, VarcharType, 10)
+			require.NoError(t, err)
+			got, n, err := DecodeValueFromKey(enc, VarcharType, 10)
+			require.NoError(t, err)
+			require.Equal(t, len(enc), n)
+			require.Equal(t, v, got.RawValue())
+		}
+	})
+
+	t.Run("boolean", func(t *testing.T) {
+		for _, v := range []bool{false, true} {
+			enc, _, err := EncodeValueAsKey(&Bool{val: v}, BooleanType, 1)
+			require.NoError(t, err)
+			got, n, err := DecodeValueFromKey(enc, BooleanType, 1)
+			require.NoError(t, err)
+			require.Equal(t, len(enc), n)
+			require.Equal(t, v, got.RawValue())
+		}
+	})
+
+	t.Run("blob", func(t *testing.T) {
+		for _, v := range [][]byte{nil, {}, {0x00}, {0xFF, 0x00, 0xCA, 0xFE}} {
+			enc, _, err := EncodeValueAsKey(&Blob{val: v}, BLOBType, 8)
+			require.NoError(t, err)
+			got, n, err := DecodeValueFromKey(enc, BLOBType, 8)
+			require.NoError(t, err)
+			require.Equal(t, len(enc), n)
+			gotBytes, _ := got.RawValue().([]byte)
+			require.Equal(t, append([]byte{}, v...), gotBytes)
+		}
+	})
+
+	t.Run("uuid", func(t *testing.T) {
+		u := uuid.MustParse("12345678-1234-5678-1234-567812345678")
+		enc, _, err := EncodeValueAsKey(&UUID{val: u}, UUIDType, 16)
+		require.NoError(t, err)
+		got, n, err := DecodeValueFromKey(enc, UUIDType, 16)
+		require.NoError(t, err)
+		require.Equal(t, len(enc), n)
+		require.Equal(t, u, got.RawValue())
+	})
+
+	t.Run("timestamp", func(t *testing.T) {
+		for _, v := range []time.Time{
+			time.Unix(0, 0).UTC(),
+			time.Unix(1774990800, 123456789).UTC(),
+			time.Unix(-1, 0).UTC(),
+		} {
+			enc, _, err := EncodeValueAsKey(&Timestamp{val: v}, TimestampType, 8)
+			require.NoError(t, err)
+			got, n, err := DecodeValueFromKey(enc, TimestampType, 8)
+			require.NoError(t, err)
+			require.Equal(t, len(enc), n)
+			require.True(t, v.Equal(got.RawValue().(time.Time)),
+				"timestamp roundtrip mismatch: %v != %v", v, got.RawValue())
+		}
+	})
+
+	t.Run("float64", func(t *testing.T) {
+		for _, v := range []float64{
+			-math.MaxFloat64, -1.5, -0.0, 0.0, 0.5, 1.0, 3.14159, math.MaxFloat64,
+		} {
+			enc, _, err := EncodeValueAsKey(&Float64{val: v}, Float64Type, 8)
+			require.NoError(t, err)
+			got, n, err := DecodeValueFromKey(enc, Float64Type, 8)
+			require.NoError(t, err)
+			require.Equal(t, len(enc), n)
+			require.Equal(t, v, got.RawValue())
+		}
+	})
+
+	t.Run("null", func(t *testing.T) {
+		for _, ct := range []SQLValueType{IntegerType, VarcharType, BooleanType, BLOBType, UUIDType, TimestampType, Float64Type} {
+			maxLen := 8
+			switch ct {
+			case BooleanType:
+				maxLen = 1
+			case UUIDType:
+				maxLen = 16
+			case VarcharType, BLOBType:
+				maxLen = 10
+			}
+			enc, _, err := EncodeValueAsKey(&NullValue{t: ct}, ct, maxLen)
+			require.NoError(t, err)
+			got, n, err := DecodeValueFromKey(enc, ct, maxLen)
+			require.NoError(t, err)
+			require.Equal(t, 1, n)
+			require.True(t, got.IsNull())
+			require.Equal(t, ct, got.Type())
+		}
+	})
+
+	t.Run("corrupt input", func(t *testing.T) {
+		_, _, err := DecodeValueFromKey(nil, IntegerType, 8)
+		require.ErrorIs(t, err, ErrCorruptedData)
+
+		_, _, err = DecodeValueFromKey([]byte{0x00}, IntegerType, 8)
+		require.ErrorIs(t, err, ErrCorruptedData)
+
+		_, _, err = DecodeValueFromKey([]byte{KeyValPrefixNotNull, 1, 2}, IntegerType, 8)
+		require.ErrorIs(t, err, ErrCorruptedData)
 	})
 }
 

--- a/embedded/sql/count_indexed_where_test.go
+++ b/embedded/sql/count_indexed_where_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2026 Codenotary Inc. All rights reserved.
+
+SPDX-License-Identifier: BUSL-1.1
+
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://mariadb.com/bsl11/
+*/
+
+package sql
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCountStarIndexedWhere is the regression guard for issue #2093:
+// `SELECT COUNT(*) … WHERE …` over an index that covers every WHERE
+// column must take the index-only fast path (no row-payload decode) and
+// return the same result as the slow path.
+func TestCountStarIndexedWhere(t *testing.T) {
+	engine := setupCommonTest(t)
+	ctx := context.Background()
+
+	mustExec := func(stmt string, params map[string]interface{}) {
+		t.Helper()
+		_, _, err := engine.Exec(ctx, nil, stmt, params)
+		require.NoError(t, err, stmt)
+	}
+
+	mustExec(`CREATE TABLE logs (
+		id INTEGER NOT NULL AUTO_INCREMENT,
+		entity_name VARCHAR[255],
+		action VARCHAR[50],
+		partner_id VARCHAR[64],
+		created_at INTEGER,
+		PRIMARY KEY (id)
+	);`, nil)
+	mustExec(`CREATE INDEX ON logs(partner_id, created_at, action);`, nil)
+
+	// Insert enough rows to span multiple partner / action / time buckets.
+	// Layout (3 partners × 2 actions × 50 timestamps = 300 rows):
+	//   partner_id ∈ {p0, p1, p2}
+	//   action     ∈ {scan, view}
+	//   created_at ∈ [1000, 1050)
+	for partner := 0; partner < 3; partner++ {
+		for _, act := range []string{"scan", "view"} {
+			for ts := 1000; ts < 1050; ts++ {
+				mustExec(
+					`INSERT INTO logs (entity_name, action, partner_id, created_at) VALUES (@name, @act, @pid, @ts);`,
+					map[string]interface{}{
+						"name": fmt.Sprintf("e-%d-%d", partner, ts),
+						"act":  act,
+						"pid":  fmt.Sprintf("p%d", partner),
+						"ts":   ts,
+					})
+			}
+		}
+	}
+
+	t.Run("indexed WHERE — fast path matches slow path", func(t *testing.T) {
+		// Same WHERE shape the issue uses: equality on leading column,
+		// range on middle column, equality on trailing column. All three
+		// columns are part of the composite index → eligible for the
+		// index-only count.
+		rows, err := engine.queryAll(ctx, nil,
+			`SELECT COUNT(*) FROM logs WHERE partner_id = 'p1' AND created_at >= 1010 AND created_at < 1030 AND action = 'scan';`,
+			nil)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		require.EqualValues(t, 20, rows[0].ValuesByPosition[0].RawValue())
+
+		// Cross-check against the materialising slow path by issuing a
+		// shaped-equivalent SELECT and counting the returned rows.
+		ref, err := engine.queryAll(ctx, nil,
+			`SELECT id FROM logs WHERE partner_id = 'p1' AND created_at >= 1010 AND created_at < 1030 AND action = 'scan';`,
+			nil)
+		require.NoError(t, err)
+		require.Len(t, ref, 20)
+	})
+
+	t.Run("indexed WHERE — equality-only", func(t *testing.T) {
+		rows, err := engine.queryAll(ctx, nil,
+			`SELECT COUNT(*) FROM logs WHERE partner_id = 'p2' AND action = 'view';`,
+			nil)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		require.EqualValues(t, 50, rows[0].ValuesByPosition[0].RawValue())
+	})
+
+	t.Run("indexed WHERE — zero matches", func(t *testing.T) {
+		rows, err := engine.queryAll(ctx, nil,
+			`SELECT COUNT(*) FROM logs WHERE partner_id = 'no-such-partner' AND created_at >= 0;`,
+			nil)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		require.EqualValues(t, 0, rows[0].ValuesByPosition[0].RawValue())
+	})
+
+	t.Run("indexed WHERE — parameterised", func(t *testing.T) {
+		rows, err := engine.queryAll(ctx, nil,
+			`SELECT COUNT(*) FROM logs WHERE partner_id = @pid AND created_at >= @lo AND created_at < @hi;`,
+			map[string]interface{}{"pid": "p0", "lo": 1000, "hi": 1010})
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		// 10 timestamps × 2 actions
+		require.EqualValues(t, 20, rows[0].ValuesByPosition[0].RawValue())
+	})
+
+	t.Run("non-indexed WHERE column — falls back to slow path", func(t *testing.T) {
+		// entity_name is not part of any non-PK index here; the planner
+		// must take the existing materialising path. The result must
+		// still be correct — just not via the new fast path.
+		rows, err := engine.queryAll(ctx, nil,
+			`SELECT COUNT(*) FROM logs WHERE entity_name = 'e-0-1005';`,
+			nil)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		// Inserted once per action: 2 rows.
+		require.EqualValues(t, 2, rows[0].ValuesByPosition[0].RawValue())
+	})
+
+	t.Run("bare COUNT(*) still works", func(t *testing.T) {
+		rows, err := engine.queryAll(ctx, nil, `SELECT COUNT(*) FROM logs;`, nil)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		require.EqualValues(t, 300, rows[0].ValuesByPosition[0].RawValue())
+	})
+
+	t.Run("GROUP BY still uses standard aggregation", func(t *testing.T) {
+		// A regression guard: the index-only path must not be selected
+		// when GROUP BY is present, because per-group counting needs
+		// the grouped-aggregator pipeline.
+		rows, err := engine.queryAll(ctx, nil,
+			`SELECT partner_id, COUNT(*) FROM logs WHERE partner_id = 'p0' GROUP BY partner_id;`,
+			nil)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		require.EqualValues(t, 100, rows[1-1].ValuesByPosition[1].RawValue())
+	})
+
+	t.Run("PK-covered WHERE on primary index", func(t *testing.T) {
+		rows, err := engine.queryAll(ctx, nil,
+			`SELECT COUNT(*) FROM logs WHERE id >= 10 AND id < 20;`,
+			nil)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		require.EqualValues(t, 10, rows[0].ValuesByPosition[0].RawValue())
+	})
+
+	t.Run("IS NULL on indexed column", func(t *testing.T) {
+		// Insert one row with NULL action to verify NULL handling in the
+		// key-only path.
+		mustExec(
+			`INSERT INTO logs (entity_name, action, partner_id, created_at) VALUES ('null-action', NULL, 'p9', 9999);`,
+			nil)
+		rows, err := engine.queryAll(ctx, nil,
+			`SELECT COUNT(*) FROM logs WHERE partner_id = 'p9' AND action IS NULL;`,
+			nil)
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		require.EqualValues(t, 1, rows[0].ValuesByPosition[0].RawValue())
+	})
+}

--- a/embedded/sql/count_row_reader.go
+++ b/embedded/sql/count_row_reader.go
@@ -111,3 +111,39 @@ func (cr *countingRowReader) Read(ctx context.Context) (*Row, error) {
 func (cr *countingRowReader) Close() error {
 	return cr.rawReader.Close()
 }
+
+// keyFilterCountingRowReader extends the COUNT(*) fast-path to queries with a
+// WHERE clause whose columns are all part of the chosen index. The predicate
+// is evaluated against values decoded from the index key, so the row payload
+// is never resolved or decoded — see rawRowReader.CountAllWithKeyFilter.
+type keyFilterCountingRowReader struct {
+	*countingRowReader
+	where ValueExp
+}
+
+func newKeyFilterCountingRowReader(rawReader *rawRowReader, agg *AggColSelector, where ValueExp) *keyFilterCountingRowReader {
+	return &keyFilterCountingRowReader{
+		countingRowReader: newCountingRowReader(rawReader, agg),
+		where:             where,
+	}
+}
+
+// Read evaluates the index-only WHERE filter while counting entries, returning
+// a single Row with the resulting count. Subsequent calls return ErrNoMoreRows.
+func (cr *keyFilterCountingRowReader) Read(ctx context.Context) (*Row, error) {
+	if cr.done {
+		return nil, ErrNoMoreRows
+	}
+	cr.done = true
+
+	n, err := cr.rawReader.CountAllWithKeyFilter(ctx, cr.where)
+	if err != nil {
+		return nil, err
+	}
+
+	val := &Integer{val: n}
+	return &Row{
+		ValuesByPosition: []TypedValue{val},
+		ValuesBySelector: map[string]TypedValue{cr.encSel: val},
+	}, nil
+}

--- a/embedded/sql/count_row_reader_test.go
+++ b/embedded/sql/count_row_reader_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2026 Codenotary Inc. All rights reserved.
+
+SPDX-License-Identifier: BUSL-1.1
+*/
+
+package sql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/codenotary/immudb/embedded/store"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCountRowReader_StubGetters constructs a keyFilterCountingRowReader
+// directly and exercises the RowReader-interface methods that are otherwise
+// not on the planner-driven hot path: OrderBy / ScanSpecs / Columns /
+// InferParameters / colsBySelector / Tx / TableAlias / Parameters / onClose.
+// The Read path is already covered by TestCountStarIndexedWhere — this is
+// just to keep the interface surface tracked by coverage.
+func TestCountRowReader_StubGetters(t *testing.T) {
+	st, err := store.Open(t.TempDir(), store.DefaultOptions().WithMultiIndexing(true))
+	require.NoError(t, err)
+	defer st.Close()
+
+	engine, err := NewEngine(st, DefaultOptions().WithPrefix(sqlPrefix))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	tx, err := engine.NewTx(ctx, DefaultTxOptions())
+	require.NoError(t, err)
+
+	_, _, err = engine.Exec(ctx, tx, "CREATE TABLE t(id INTEGER, name VARCHAR[32], PRIMARY KEY id)", nil)
+	require.NoError(t, err)
+
+	tx, err = engine.NewTx(ctx, DefaultTxOptions())
+	require.NoError(t, err)
+	defer tx.Cancel()
+
+	table := tx.catalog.tables[0]
+
+	rawRdr, err := newRawRowReader(tx, nil, table, period{}, "", &ScanSpecs{Index: table.primaryIndex})
+	require.NoError(t, err)
+
+	agg := &AggColSelector{aggFn: COUNT, col: "*"}
+	bare := newCountingRowReader(rawRdr, agg)
+	require.NotNil(t, bare)
+
+	// Bare COUNT reader: no ordering, single COUNT column, scanSpecs forwarded.
+	require.Nil(t, bare.OrderBy())
+	require.Equal(t, rawRdr.ScanSpecs(), bare.ScanSpecs())
+
+	cols, err := bare.Columns(ctx)
+	require.NoError(t, err)
+	require.Len(t, cols, 1)
+	require.Equal(t, IntegerType, cols[0].Type)
+	require.Equal(t, string(COUNT), cols[0].AggFn)
+
+	colsBySel, err := bare.colsBySelector(ctx)
+	require.NoError(t, err)
+	require.Contains(t, colsBySel, bare.encSel)
+
+	require.Equal(t, rawRdr.Tx(), bare.Tx())
+	require.Equal(t, rawRdr.TableAlias(), bare.TableAlias())
+	require.Equal(t, rawRdr.Parameters(), bare.Parameters())
+
+	params := map[string]SQLValueType{}
+	require.NoError(t, bare.InferParameters(ctx, params))
+
+	closed := false
+	bare.onClose(func() { closed = true })
+
+	// Exercise the keyFilter variant: same surface, plus a where expression
+	// that the stubs don't touch.
+	rawRdr2, err := newRawRowReader(tx, nil, table, period{}, "", &ScanSpecs{Index: table.primaryIndex})
+	require.NoError(t, err)
+	where := &CmpBoolExp{op: EQ, left: &ColSelector{col: "id"}, right: &Integer{val: 1}}
+	kf := newKeyFilterCountingRowReader(rawRdr2, agg, where)
+	require.NotNil(t, kf)
+	require.Nil(t, kf.OrderBy())
+	require.Equal(t, rawRdr2.ScanSpecs(), kf.ScanSpecs())
+
+	kfCols, err := kf.Columns(ctx)
+	require.NoError(t, err)
+	require.Len(t, kfCols, 1)
+	require.NoError(t, kf.InferParameters(ctx, params))
+
+	require.NoError(t, bare.Close())
+	require.True(t, closed)
+	require.NoError(t, kf.Close())
+}

--- a/embedded/sql/row_reader.go
+++ b/embedded/sql/row_reader.go
@@ -619,6 +619,100 @@ func (r *rawRowReader) CountAll(ctx context.Context) (int64, error) {
 	}
 }
 
+// CountAllWithKeyFilter iterates the index scan and counts entries that
+// satisfy `where`, evaluating the predicate against values decoded from the
+// index key alone (no value-reference resolution, no row payload decode).
+//
+// The caller must guarantee that every column referenced by `where` belongs
+// to r.scanSpecs.Index.cols; see SelectStmt.canCountWithKeyOnly. The encoded
+// key layout is documented in unmapIndexEntry (catalog.go) — sqlPrefix +
+// MappedPrefix + tableID + indexID + (per-column tag+payload) + PK bytes.
+func (r *rawRowReader) CountAllWithKeyFilter(ctx context.Context, where ValueExp) (int64, error) {
+	if where == nil {
+		return r.CountAll(ctx)
+	}
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	if err := r.reduceTxRange(); errors.Is(err, store.ErrTxNotFound) {
+		return 0, nil
+	} else if err != nil {
+		return 0, err
+	}
+
+	index := r.scanSpecs.Index
+	// Bytes preceding the per-column data: sqlPrefix + MappedPrefix +
+	// tableID(4) + indexID(4). Anything after this offset is the ordered
+	// sequence of indexed-column tag+payload runs, terminated by the PK.
+	headerLen := len(r.tx.engine.prefix) + len(MappedPrefix) + 2*EncIDLen
+
+	// Reusable per-iteration buffers; sparse Row keyed only by index columns.
+	valuesBySelector := make(map[string]TypedValue, len(index.cols))
+	row := &Row{ValuesBySelector: valuesBySelector}
+
+	var n int64
+	for {
+		var (
+			mkey []byte
+			err  error
+		)
+		if r.txRange == nil {
+			mkey, _, err = r.reader.Read(ctx)
+		} else {
+			mkey, _, err = r.reader.ReadBetween(ctx, r.txRange.initialTxID, r.txRange.finalTxID)
+		}
+		if errors.Is(err, store.ErrNoMoreEntries) {
+			return n, nil
+		}
+		if err != nil {
+			return 0, err
+		}
+
+		if len(mkey) < headerLen {
+			return 0, ErrCorruptedData
+		}
+
+		off := headerLen
+		// Reset map entries from the previous iteration. Re-using the map
+		// avoids per-row allocation on a hot count loop.
+		for k := range valuesBySelector {
+			delete(valuesBySelector, k)
+		}
+
+		for _, col := range index.cols {
+			val, consumed, derr := DecodeValueFromKey(mkey[off:], col.colType, col.MaxLen())
+			if derr != nil {
+				return 0, derr
+			}
+			off += consumed
+
+			sel := EncodeSelector("", r.tableAlias, col.colName)
+			valuesBySelector[sel] = val
+		}
+
+		cond, err := where.substitute(r.params)
+		if err != nil {
+			return 0, fmt.Errorf("%w: when evaluating WHERE clause", err)
+		}
+
+		res, err := cond.reduce(r.tx, row, r.tableAlias)
+		if err != nil {
+			return 0, fmt.Errorf("%w: when evaluating WHERE clause", err)
+		}
+
+		if nv, isNull := res.(*NullValue); isNull && nv.Type() == BooleanType {
+			continue
+		}
+		bv, isBool := res.(*Bool)
+		if !isBool {
+			return 0, fmt.Errorf("%w: expected '%s' in WHERE clause, but '%s' was provided", ErrInvalidCondition, BooleanType, res.Type())
+		}
+		if bv.val {
+			n++
+		}
+	}
+}
+
 func (r *rawRowReader) parseTxMetadata(txmd *store.TxMetadata) (TypedValue, error) {
 	if txmd == nil {
 		return &NullValue{t: JSONType}, nil

--- a/embedded/sql/stmt.go
+++ b/embedded/sql/stmt.go
@@ -4180,17 +4180,27 @@ func (stmt *SelectStmt) Resolve(ctx context.Context, tx *SQLTx, params map[strin
 		}
 	}
 
-	if effectiveWhere != nil {
-		rowReader = newConditionalRowReader(rowReader, effectiveWhere)
+	// Fast-path: SELECT COUNT(*) FROM tbl [WHERE …] with no JOINs, GROUP BY,
+	// HAVING, DISTINCT, or subqueries. Count index keys directly without
+	// decoding the row payload — the WHERE predicate (if any) is evaluated
+	// against values decoded from the index key, which is sound only when
+	// every column referenced by WHERE belongs to the chosen index.
+	if rawRdr, ok := rowReader.(*rawRowReader); ok {
+		if stmt.isCountStarShape() {
+			agg := stmt.targets[0].Exp.(*AggColSelector)
+			if effectiveWhere == nil {
+				rowReader = newCountingRowReader(rawRdr, agg)
+				goto applyOrderBy
+			}
+			if stmt.canCountWithKeyOnly(rawRdr.scanSpecs.Index, effectiveWhere, rawRdr.tableAlias, params) {
+				rowReader = newKeyFilterCountingRowReader(rawRdr, agg, effectiveWhere)
+				goto applyOrderBy
+			}
+		}
 	}
 
-	// Fast-path: SELECT COUNT(*) FROM tbl with no WHERE, JOINs, GROUP BY, or
-	// HAVING.  Count index keys directly without decoding any column values.
-	if stmt.isBareCountStar() {
-		if rawRdr, ok := rowReader.(*rawRowReader); ok {
-			rowReader = newCountingRowReader(rawRdr, stmt.targets[0].Exp.(*AggColSelector))
-			goto applyOrderBy
-		}
+	if effectiveWhere != nil {
+		rowReader = newConditionalRowReader(rowReader, effectiveWhere)
 	}
 
 	if stmt.containsAggregations() || len(stmt.groupBy) > 0 {
@@ -4525,16 +4535,57 @@ func (stmt *SelectStmt) collectNeededColIDs(table *Table, tableAlias string) (ma
 	return needed, false
 }
 
-// isBareCountStar reports whether the statement is exactly
-// SELECT COUNT(*) FROM tbl with no WHERE, JOINs, GROUP BY, or HAVING.
-// Such queries can be answered by counting index keys without decoding values.
-func (stmt *SelectStmt) isBareCountStar() bool {
-	if len(stmt.targets) != 1 || stmt.where != nil ||
+// isCountStarShape reports whether the statement is `SELECT COUNT(*) FROM tbl
+// [WHERE …]` with no JOINs, GROUP BY, HAVING, or DISTINCT. WHERE is permitted;
+// eligibility for the index-only count path is then narrowed further by
+// canCountWithKeyOnly.
+func (stmt *SelectStmt) isCountStarShape() bool {
+	if len(stmt.targets) != 1 ||
 		len(stmt.groupBy) > 0 || stmt.having != nil || len(stmt.joins) > 0 {
+		return false
+	}
+	if stmt.distinct {
 		return false
 	}
 	agg, ok := stmt.targets[0].Exp.(*AggColSelector)
 	return ok && agg.aggFn == COUNT && agg.col == "*" && !agg.distinct
+}
+
+// canCountWithKeyOnly reports whether `where` can be evaluated against values
+// decoded from `idx`'s key alone, i.e. every selector inside the predicate
+// resolves to a column that is part of `idx`. This is the precondition for
+// rawRowReader.CountAllWithKeyFilter.
+//
+// We rely on ValueExp.selectors() (which recurses through expression trees
+// and function-call arguments) to enumerate every selector the predicate
+// will dereference at reduce-time. Any reference outside `idx.cols`, any
+// aggregate selector, or any unrecognised selector kind disqualifies the
+// fast path.
+func (stmt *SelectStmt) canCountWithKeyOnly(idx *Index, where ValueExp, tableAlias string, params map[string]interface{}) bool {
+	if where == nil || idx == nil {
+		return false
+	}
+
+	indexedCols := make(map[string]struct{}, len(idx.cols))
+	for _, c := range idx.cols {
+		indexedCols[c.colName] = struct{}{}
+	}
+
+	for _, sel := range where.selectors() {
+		switch s := sel.(type) {
+		case *ColSelector:
+			_, _, col := s.resolve(tableAlias)
+			if _, ok := indexedCols[col]; !ok {
+				return false
+			}
+		default:
+			// AggColSelector and any future selector kinds we haven't
+			// vetted: bail to the safe path.
+			_ = s
+			return false
+		}
+	}
+	return true
 }
 
 func evalExpAsInt(tx *SQLTx, exp ValueExp, params map[string]interface{}) (int, error) {

--- a/embedded/store/immustore.go
+++ b/embedded/store/immustore.go
@@ -220,6 +220,12 @@ type ImmuStore struct {
 	_valBs    [DefaultMaxValueLen]byte // pre-allocated buffer to support tx exportation
 	_valBsMux sync.Mutex
 
+	// Pool of maxKeyLen-sized scratch buffers used by tx-metadata read paths
+	// (e.g. ReadTxHeader) where the entry's key slice is throwaway after the
+	// call returns. Stored as *[]byte to avoid per-Get interface boxing of
+	// the slice header.
+	txEntryKeyPool sync.Pool
+
 	aht                  *ahtree.AHtree
 	inmemPrecommitWHub   *watchers.WatchersHub
 	durablePrecommitWHub *watchers.WatchersHub
@@ -710,6 +716,11 @@ func OpenWith(path string, vLogs []appendable.Appendable, txLog, cLog appendable
 		opts: opts,
 
 		compactionDisabled: opts.CompactionDisabled,
+	}
+
+	store.txEntryKeyPool.New = func() any {
+		b := make([]byte, store.maxKeyLen)
+		return &b
 	}
 
 	if store.aht.Size() > precommittedTxID {
@@ -2165,13 +2176,16 @@ func (s *ImmuStore) mayCommit() error {
 	var commitUpToTxID uint64
 	var commitUpToTxAlh [sha256.Size]byte
 
+	// cLog.Append copies the input slice into its own write buffer
+	// (singleapp.AppendableFile.write copies into writeBuffer), so reusing
+	// a single scratch buffer across iterations is safe.
+	cb := make([]byte, s.cLogEntrySize)
 	for i := 0; i < txsCountToBeCommitted; i++ {
 		txID, alh, txOff, txSize, err := s.cLogBuf.readAhead(i)
 		if err != nil {
 			return err
 		}
 
-		cb := make([]byte, s.cLogEntrySize)
 		binary.BigEndian.PutUint64(cb, uint64(txOff))
 		binary.BigEndian.PutUint32(cb[offsetSize:], uint32(txSize))
 
@@ -3140,7 +3154,12 @@ func (s *ImmuStore) ReadTxHeader(txID uint64, allowPrecommitted bool, skipIntegr
 		return nil, err
 	}
 
-	e := &TxEntry{k: make([]byte, s.maxKeyLen)}
+	// The TxEntry's key buffer is scratch — the returned *TxHeader carries
+	// no entries, and the digest funcs only copy from e.k (no retention).
+	// Pull a pre-sized buffer from the pool and return it on exit.
+	kbufPtr := s.txEntryKeyPool.Get().(*[]byte)
+	defer s.txEntryKeyPool.Put(kbufPtr)
+	e := &TxEntry{k: *kbufPtr}
 
 	for i := 0; i < header.NEntries; i++ {
 		err = tdr.readEntry(e)
@@ -3374,18 +3393,21 @@ func (s *ImmuStore) sync() error {
 	}
 
 	for i := range s.vLogs {
-		vLog, err := s.fetchVLog(i + 1)
-		if err != nil {
-			return err
-		}
-		defer s.releaseVLog(i + 1)
+		// Scope each vLog flush+sync in its own block so the per-vLog lock
+		// is released as soon as the work completes, instead of being held
+		// (via defer) until sync() returns.
+		err := func() error {
+			vLog, err := s.fetchVLog(i + 1)
+			if err != nil {
+				return err
+			}
+			defer s.releaseVLog(i + 1)
 
-		err = vLog.Flush()
-		if err != nil {
-			return err
-		}
-
-		err = vLog.Sync()
+			if err := vLog.Flush(); err != nil {
+				return err
+			}
+			return vLog.Sync()
+		}()
 		if err != nil {
 			return err
 		}
@@ -3422,13 +3444,16 @@ func (s *ImmuStore) sync() error {
 	var commitUpToTxID uint64
 	var commitUpToTxAlh [sha256.Size]byte
 
+	// cLog.Append copies the input slice into its own write buffer
+	// (singleapp.AppendableFile.write copies into writeBuffer), so reusing
+	// a single scratch buffer across iterations is safe.
+	cb := make([]byte, s.cLogEntrySize)
 	for i := 0; i < txsCountToBeCommitted; i++ {
 		txID, alh, txOff, txSize, err := s.cLogBuf.readAhead(i)
 		if err != nil {
 			return err
 		}
 
-		cb := make([]byte, s.cLogEntrySize)
 		binary.BigEndian.PutUint64(cb, uint64(txOff))
 		binary.BigEndian.PutUint32(cb[offsetSize:], uint32(txSize))
 

--- a/embedded/store/key_reader.go
+++ b/embedded/store/key_reader.go
@@ -406,6 +406,9 @@ type storeKeyReader struct {
 
 func (r *storeKeyReader) ReadBetween(ctx context.Context, initialTxID, finalTxID uint64) (key []byte, val ValueRef, err error) {
 	for {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
 		key, indexedVal, tx, hc, err := r.reader.ReadBetween(initialTxID, finalTxID)
 		if err != nil {
 			return nil, nil, err
@@ -445,6 +448,9 @@ func (r *storeKeyReader) ReadBetween(ctx context.Context, initialTxID, finalTxID
 
 func (r *storeKeyReader) Read(ctx context.Context) (key []byte, val ValueRef, err error) {
 	for {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
 		key, indexedVal, tx, hc, err := r.reader.Read()
 		if err != nil {
 			return nil, nil, err

--- a/embedded/tbtree/snapshot.go
+++ b/embedded/tbtree/snapshot.go
@@ -125,6 +125,24 @@ func (s *Snapshot) Get(key []byte) (value []byte, ts uint64, hc uint64, err erro
 	return cp(v), ts, hc, err
 }
 
+// GetReadonly is a zero-copy variant of Get. The returned value points into
+// the snapshot's backing storage and MUST NOT be mutated by the caller. The
+// slice is valid for the lifetime of the snapshot.
+func (s *Snapshot) GetReadonly(key []byte) (value []byte, ts uint64, hc uint64, err error) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	if s.closed {
+		return nil, 0, 0, ErrAlreadyClosed
+	}
+
+	if key == nil {
+		return nil, 0, 0, ErrIllegalArguments
+	}
+
+	return s.root.get(key)
+}
+
 func (s *Snapshot) GetBetween(key []byte, initialTs, finalTs uint64) (value []byte, ts uint64, hc uint64, err error) {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()

--- a/embedded/tbtree/tbtree.go
+++ b/embedded/tbtree/tbtree.go
@@ -1041,6 +1041,24 @@ func (t *TBtree) Get(key []byte) (value []byte, ts uint64, hc uint64, err error)
 	return cp(v), ts, hc, err
 }
 
+// GetReadonly is a zero-copy variant of Get. The returned value points into
+// the leaf node's backing buffer and MUST NOT be mutated by the caller. The
+// slice is valid until the next compaction.
+func (t *TBtree) GetReadonly(key []byte) (value []byte, ts uint64, hc uint64, err error) {
+	t.rwmutex.RLock()
+	defer t.rwmutex.RUnlock()
+
+	if t.closed {
+		return nil, 0, 0, ErrAlreadyClosed
+	}
+
+	if key == nil {
+		return nil, 0, 0, ErrIllegalArguments
+	}
+
+	return t.root.get(key)
+}
+
 func (t *TBtree) GetBetween(key []byte, initialTs, finalTs uint64) (value []byte, ts uint64, hc uint64, err error) {
 	t.rwmutex.RLock()
 	defer t.rwmutex.RUnlock()

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.17.0
 	github.com/influxdata/influxdb-client-go/v2 v2.13.0
-	github.com/jackc/pgx/v5 v5.9.1
+	github.com/jackc/pgx/v5 v5.9.2
 	github.com/jaswdr/faker v1.16.0
 	github.com/lib/pq v1.10.9
 	github.com/mattn/goveralls v0.0.11

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	go.uber.org/goleak v1.3.0
 	golang.org/x/crypto v0.48.0
 	golang.org/x/net v0.50.0
+	golang.org/x/sync v0.19.0
 	golang.org/x/sys v0.41.0
 	golang.org/x/tools/cmd/cover v0.1.0-deprecated
 	google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217
@@ -109,7 +110,6 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
 	golang.org/x/mod v0.32.0 // indirect
-	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/term v0.40.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 	golang.org/x/tools v0.41.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -296,8 +296,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.9.1 h1:uwrxJXBnx76nyISkhr33kQLlUqjv7et7b9FjCen/tdc=
-github.com/jackc/pgx/v5 v5.9.1/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
+github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
+github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jaswdr/faker v1.16.0 h1:5ZjusQbqIZwJnUymPirNKJI1yFCuozdSR9oeYPgD5Uk=

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -424,19 +424,25 @@ func (d *db) set(ctx context.Context, req *schema.SetRequest) (*schema.TxHeader,
 	}
 	defer tx.Cancel()
 
-	keys := make(map[[sha256.Size]byte]struct{}, len(req.KVs))
+	// Skip the dedup map and per-key sha256 hash for the common single-KV
+	// case; dedup is only meaningful when there's more than one KV.
+	var keys map[[sha256.Size]byte]struct{}
+	if len(req.KVs) > 1 {
+		keys = make(map[[sha256.Size]byte]struct{}, len(req.KVs))
+	}
 
 	for _, kv := range req.KVs {
 		if len(kv.Key) == 0 {
 			return nil, ErrIllegalArguments
 		}
 
-		kid := sha256.Sum256(kv.Key)
-		_, ok := keys[kid]
-		if ok {
-			return nil, schema.ErrDuplicatedKeysNotSupported
+		if keys != nil {
+			kid := sha256.Sum256(kv.Key)
+			if _, ok := keys[kid]; ok {
+				return nil, schema.ErrDuplicatedKeysNotSupported
+			}
+			keys[kid] = struct{}{}
 		}
-		keys[kid] = struct{}{}
 
 		e := EncodeEntrySpec(
 			kv.Key,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -894,19 +894,26 @@ func (s *ImmuServer) ServerInfo(ctx context.Context, req *schema.ServerInfoReque
 }
 
 func (s *ImmuServer) numTransactions() (uint64, error) {
+	// Snapshot the DB handles under the lock, then release before calling
+	// CurrentState on each. CurrentState reads tx state and must not block
+	// dbList mutations (CreateDatabase, etc.).
 	s.dbListMutex.Lock()
-	defer s.dbListMutex.Unlock()
-
-	var count uint64
+	dbs := make([]database.DB, 0, s.dbList.Length())
 	for i := 0; i < s.dbList.Length(); i++ {
 		db, err := s.dbList.GetByIndex(i)
 		if err == database.ErrDatabaseNotExists {
 			continue
 		}
 		if err != nil {
+			s.dbListMutex.Unlock()
 			return 0, err
 		}
+		dbs = append(dbs, db)
+	}
+	s.dbListMutex.Unlock()
 
+	var count uint64
+	for _, db := range dbs {
 		state, err := db.CurrentState()
 		if err != nil {
 			return 0, err
@@ -917,20 +924,25 @@ func (s *ImmuServer) numTransactions() (uint64, error) {
 }
 
 func (s *ImmuServer) totalDBSize() (int64, error) {
+	// Snapshot the DB names under the lock, then drop it before doing the
+	// recursive directory walk, which can take hundreds of ms on large DBs.
 	s.dbListMutex.Lock()
-	defer s.dbListMutex.Unlock()
-
-	var size int64
+	dbNames := make([]string, 0, s.dbList.Length())
 	for i := 0; i < s.dbList.Length(); i++ {
 		db, err := s.dbList.GetByIndex(i)
 		if err == database.ErrDatabaseNotExists {
 			continue
 		}
 		if err != nil {
+			s.dbListMutex.Unlock()
 			return -1, err
 		}
+		dbNames = append(dbNames, db.GetName())
+	}
+	s.dbListMutex.Unlock()
 
-		dbName := db.GetName()
+	var size int64
+	for _, dbName := range dbNames {
 		dbSize, err := dirSize(filepath.Join(s.Options.Dir, dbName))
 		if err != nil {
 			return -1, err


### PR DESCRIPTION
## Summary

Six commits, all reachable from `origin/master` as a fast-forward. No on-disk format changes.

### S3 / remote-storage waves (5 commits)
- **`090d8edb` Wave 1 — range-fetch `ReadAt`**: reader sliding window (256 KiB default) instead of full-chunk `Get(name, 0, -1)`. 4 MiB chunk + 64 B tail read goes from 4 MiB to one ~256 KiB window on the wire.
- **`0b235dc8` Wave 2 — pipeline next read window**: per-reader background prefetch of the next window, dedicated `prefetchCtx` cancelled on `Close()`. Cache-hit and prefetch-adoption paths share `serveFromCacheLocked`.
- **`be11052d` Wave 4 — drop upload-verify, parallel chunk prefetch, end-to-end compression**:
  - Skip `Exists()`+reopen after `Put` (S3 read-after-write consistent since 2020); legacy two-RTT path behind `WithVerifyUploads(true)`. Inserts a `lazyRemoteReader` so most chunks never re-download.
  - Multiapp detects sequential `appID` access and spawns up to `prefetchAheadDepth` background opens via `singleflight.Group`, keyed by `appID` so foreground misses dedupe with in-flight prefetches.
  - End-to-end compression now flows through `remoteapp` (export `singleapp.MetaCompressionFormat`, drop `ErrCompressionNotSupported`, parse format on open).
  - Wave-3 reader hardening rolled in: 1 MiB default window, depth-4 LRU, window-aligned Gets, `openHeaderSlack` over-fetch.
- **`10e9fa24` docs/benchmarks**: side-by-side legacy-vs-Wave-3 compare bench, in-memory `wave3_bench_test.go` for #1/#2/#3 in isolation, real `rustfs_bench_test.go` (skipped if `RUSTFS_ENDPOINT` unreachable) with WAN-RTT injector. Headline numbers in `docs/perf/s3-read-perf.md`: -32% (upload verify), -34% (parallel prefetch @ 50 ms), 410× wire-bytes (compression on benchmark payload).

### SQL — index-only `COUNT(*)` (1 commit)
- **`f2ee872a` (#2093)**: `SELECT COUNT(*) … WHERE …` previously routed every matched row through `vref.Resolve` and a full payload decode just to discard it. New `DecodeValueFromKey` + `rawRowReader.CountAllWithKeyFilter` evaluate `WHERE` against values decoded from the index key alone when every referenced column is in the chosen index. `where.selectors()` recurses through `FnCall` args so `json_typeof(json_data)` correctly falls back to the slow path. GROUP BY / HAVING / JOIN / DISTINCT / non-indexed WHERE unchanged.

### Hot-path fixes (1 commit)
- **`d3846ef5`**: seven independent fixes from a manual hot-path review.
  - **P1** `sync()` — replace deferred `releaseVLog` (held all per-vLog locks until function return) with per-iteration IIFE; concurrent readers no longer block on `vLogsCond` for the full sync window.
  - **P2** `tbtree`/`snapshot` — additive `GetReadonly` companions to `Get`; existing callers unchanged.
  - **P4** commit-loop scratch buffer hoisted out of the per-tx loop in `commitDurable` / `sync` (cLog input is copied internally).
  - **P6** `pkg/server/server.go` — `numTransactions`/`totalDBSize` snapshot DB handles under `dbListMutex`, then drop the lock before `dirSize` / `CurrentState`.
  - **P7** `storeKeyReader.Read`/`ReadBetween` — honour `ctx.Err()` per loop iteration; cancelled `COUNT` against billion-row tables now exits promptly.
  - **P8** `db.set` — skip the `map[[sha256.Size]byte]struct{}` allocation and per-key sha256 when `len(req.KVs) <= 1`.
  - **P10** `ReadTxHeader` — per-store `sync.Pool` for the throwaway `TxEntry.k` scratch buffer (`maxKeyLen`, typically 1 KiB). `ReadTxEntry` deliberately not converted (entry escapes to caller).

## Test plan
- [x] `go test -race ./embedded/appendable/multiapp/`
- [x] `go test -race ./embedded/appendable/remoteapp/`
- [x] `go test -race ./embedded/appendable/singleapp/`
- [x] `go test -race ./embedded/remotestorage/...`
- [x] `go test       ./embedded/store/...`
- [x] `go test       ./embedded/sql/...`
- [x] `go test       ./pkg/database/...`
- [x] `go test       ./pkg/server/...`
- [x] `go test -bench=. -benchtime=3x ./embedded/appendable/remoteapp/` (bounded Gets/op as expected)
- [ ] Optional rustfs reproduction: `docker run -d --name rustfs-bench -p 9100:9000 -e RUSTFS_ROOT_USER=rustfsadmin -e RUSTFS_ROOT_PASSWORD=rustfsadmin -v /tmp/rustfs-data:/data rustfs/rustfs:latest` then `go test -bench='^BenchmarkRustFS_' -benchtime=3x -run=^$ ./embedded/appendable/remoteapp/` (see `docs/perf/s3-read-perf.md`).

A pre-existing data race in `embedded/store/indexer.go` (resume vs `doIndexing`) surfaces under `-race` in the store suite; it predates this branch and the stack trace touches none of the files here.