### PR TITLE
golang version needs to match go minimum version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM golang:1.24 as build
+FROM --platform=$BUILDPLATFORM golang:1.25 as build
 ARG TARGETARCH
 ARG BUILD_ARCH=${TARGETARCH:-amd64}
 WORKDIR /src


### PR DESCRIPTION
Was unable to build with docker because of this, but this increment works.

The error I was receiving was:

```
Dockerfile:20
--------------------
  18 |     WORKDIR /src
  19 |     COPY go.mod go.sum /src/
  20 | >>> RUN go mod download -x
  21 |     COPY . .
  22 |     RUN make clean
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c go mod download -x" did not complete successfully: exit code: 1
```