### PR TITLE
fix: prevent integer overflow on 32-bit architectures in helper.size

### DIFF
--- a/cmd/helper/size.go
+++ b/cmd/helper/size.go
@@ -15,7 +15,7 @@ const (
 	ExaByte
 )
 
-var unitMap = map[int]string{
+var unitMap = map[int64]string{
 	Byte:     "B",
 	KiloByte: "KB",
 	MegaByte: "MB",
@@ -36,7 +36,7 @@ func FormatByteSize(size uint64) string {
 	return strings.TrimSuffix(strconv.FormatFloat(fsize, 'f', 1, 64), ".0") + " " + unitMap[u]
 }
 
-func getUnit(size uint64) int {
+func getUnit(size uint64) int64 {
 	switch {
 	case size >= ExaByte:
 		return ExaByte


### PR DESCRIPTION
## Description
This PR fixes a compilation issue that prevents `immudb` from being built on 32-bit architectures (such as `linux/arm/v6` or `linux/arm/v7` used in IoT devices like the Raspberry Pi Zero).

### The Issue
In `cmd/helper/size.go`, `unitMap` and `getUnit()` were using the standard `int` type. In Go, the `int` type is architecture-dependent (32 bits on 32-bit operating systems). 
Since constants like `ExaByte` (1,152,921,504,606,846,976) heavily exceed `math.MaxInt32`, the Go compiler catches an overflow and throws a fatal error during the build process:
```text
cannot use ExaByte (untyped int constant 1152921504606846976) as int value in map literal (overflows)
