### PR TITLE
fix(sql): prevent two SQL engine panics introduced in 1.11.0 (#2100)

### DIFF
--- a/embedded/sql/file_sort.go
+++ b/embedded/sql/file_sort.go
@@ -412,7 +412,7 @@ func (s *fileSorter) flushBuffer() error {
 
 	var chunkSize uint64
 	for _, row := range s.sortBuf[:s.nextIdx] {
-		data, err := encodeRow(row)
+		data, err := s.encodeRow(row)
 		if err != nil {
 			return err
 		}
@@ -447,11 +447,18 @@ func (s *fileSorter) tempFileWriter() (*bufio.Writer, error) {
 	return s.writer, nil
 }
 
-func encodeRow(r *Row) ([]byte, error) {
+func (s *fileSorter) encodeRow(r *Row) ([]byte, error) {
 	var buf bytes.Buffer
 	buf.Write([]byte{0, 0}) // make room for size field
 
-	for _, v := range r.ValuesByPosition {
+	for i, v := range r.ValuesByPosition {
+		// Projection pushdown (rawRowReader.Read) leaves nil slots for table
+		// columns the query does not need; the nil zero-value is semantically
+		// NULL. Substitute a typed NULL so encoding never dereferences nil and
+		// the slot round-trips through the temp file as NULL.
+		if v == nil {
+			v = &NullValue{t: s.colTypes[i]}
+		}
 		rawValue, err := EncodeNullableValue(v, v.Type(), -1)
 		if err != nil {
 			return nil, err

--- a/embedded/sql/file_sort_pushdown_regression_test.go
+++ b/embedded/sql/file_sort_pushdown_regression_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2026 Codenotary Inc. All rights reserved.
+
+SPDX-License-Identifier: BUSL-1.1
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://mariadb.com/bsl11/
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sql
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSortSpillWithProjectionPushdownDoesNotPanic reproduces issue #2100
+// (panic #1): a SELECT that does NOT reference every table column, over a
+// result set large enough to spill the sort buffer to a temp file, used to
+// panic with a nil pointer dereference in encodeRow.
+//
+// Projection pushdown (rawRowReader.Read) leaves row.ValuesByPosition[i] == nil
+// for columns excluded by neededColIDs. The disk-spill sort path
+// (fileSorter.flushBuffer -> encodeRow) iterates every position and called
+// v.Type() on those nil slots, crashing the whole server.
+//
+// The reproduction query shape from the issue is:
+//
+//	SELECT a, b FROM t WHERE ... ORDER BY id LIMIT n OFFSET m
+//
+// The OFFSET clause disables the top-N heap optimisation (it requires
+// offset == nil), forcing the full file-sort path; a small sortBufferSize plus
+// enough rows forces the spill where the panic lived.
+func TestSortSpillWithProjectionPushdownDoesNotPanic(t *testing.T) {
+	engine := setupCommonTest(t)
+	engine.sortBufferSize = 8
+
+	ctx := context.Background()
+	mustExec := func(stmt string) {
+		t.Helper()
+		_, _, err := engine.Exec(ctx, nil, stmt, nil)
+		require.NoError(t, err, stmt)
+	}
+
+	// "unused" is NOT referenced by the query below, so projection pushdown
+	// excludes it from neededColIDs and leaves its position nil on every row.
+	mustExec(`CREATE TABLE events (
+		id INTEGER NOT NULL AUTO_INCREMENT,
+		grp INTEGER NOT NULL,
+		payload VARCHAR[256] NOT NULL,
+		unused VARCHAR[256] NOT NULL,
+		PRIMARY KEY(id)
+	);`)
+
+	const nRows = 50
+	for i := 1; i <= nRows; i++ {
+		mustExec(fmt.Sprintf(
+			`INSERT INTO events (grp, payload, unused) VALUES (%d, 'payload_%d', 'unused_%d');`,
+			i, i, i,
+		))
+	}
+
+	// SELECT references id, grp and payload but NOT "unused" => the unused
+	// column is nil in ValuesByPosition. OFFSET forces the full file-sort and
+	// the small buffer forces a disk spill.
+	rows, err := engine.queryAll(ctx, nil,
+		`SELECT id, payload FROM events ORDER BY grp ASC LIMIT 20 OFFSET 0;`,
+		nil,
+	)
+	require.NoError(t, err, "#2100: sort spill with projection pushdown must not panic/error")
+	require.Len(t, rows, 20)
+
+	for i, r := range rows {
+		idVal, ok := r.ValuesByPosition[0].RawValue().(int64)
+		require.Truef(t, ok, "row %d: id should be int64, got %T", i, r.ValuesByPosition[0].RawValue())
+		// grp == id in this dataset, and ORDER BY grp ASC LIMIT 20 returns the
+		// first 20 inserted rows in order.
+		require.Equalf(t, int64(i+1), idVal, "row %d: rows must be in ORDER BY grp order", i)
+
+		field := r.ValuesByPosition[1]
+		require.NotNilf(t, field, "row %d: payload must not be nil (id=%d)", i, idVal)
+		require.Falsef(t, field.IsNull(), "row %d: payload must not be NULL (id=%d)", i, idVal)
+		require.Equalf(t, fmt.Sprintf("payload_%d", idVal), field.RawValue().(string),
+			"row %d: payload must round-trip through sort spill for id=%d", i, idVal)
+	}
+}

--- a/pkg/database/sql.go
+++ b/pkg/database/sql.go
@@ -400,6 +400,10 @@ func (d *db) SQLQuery(ctx context.Context, tx *sql.SQLTx, req *schema.SQLQueryRe
 		return nil, err
 	}
 
+	if len(stmts) == 0 {
+		return nil, sql.ErrExpectingDQLStmt
+	}
+
 	stmt, ok := stmts[0].(sql.DataSource)
 	if !ok {
 		return nil, sql.ErrExpectingDQLStmt

--- a/pkg/database/sql_emptyquery_regression_test.go
+++ b/pkg/database/sql_emptyquery_regression_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2026 Codenotary Inc. All rights reserved.
+
+SPDX-License-Identifier: BUSL-1.1
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://mariadb.com/bsl11/
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package database
+
+import (
+	"context"
+	"testing"
+
+	"github.com/codenotary/immudb/embedded/sql"
+	"github.com/codenotary/immudb/pkg/api/schema"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSQLQueryEmptyStatementDoesNotPanic reproduces issue #2100 (panic #2):
+// db.SQLQuery indexed stmts[0] without a length guard. Since 1.11.0 the SQL
+// grammar accepts empty / comment-only input and ParseSQL returns an empty
+// statement slice with no error, so an empty query (routine probe traffic from
+// drivers) panicked with "index out of range [0] with length 0", crashing the
+// server. It must return ErrExpectingDQLStmt instead.
+func TestSQLQueryEmptyStatementDoesNotPanic(t *testing.T) {
+	db := makeDb(t)
+
+	for _, q := range []string{"", "   ", "\n\t ", "-- just a comment", "/* nothing here */"} {
+		_, err := db.SQLQuery(context.Background(), nil, &schema.SQLQueryRequest{Sql: q})
+		require.ErrorIs(t, err, sql.ErrExpectingDQLStmt, "empty query %q must not panic", q)
+
+		_, err = db.SQLQueryAll(context.Background(), nil, &schema.SQLQueryRequest{Sql: q})
+		require.ErrorIs(t, err, sql.ErrExpectingDQLStmt, "empty query %q must not panic", q)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes two server-crashing panics reported in #2100, both regressions introduced in 1.11.0 and reachable from ordinary, valid client traffic. 1.10.0 was unaffected on the same dataset.

### 1. nil pointer dereference in the disk-spill sort path
`embedded/sql/file_sort.go` — The 1.11.0 projection-pushdown optimization leaves `Row.ValuesByPosition[i]` nil for columns a query doesn't reference, assuming those slots are never accessed. The new file-sort encode path (`fileSorter.encodeRow`) walked **every** position and called `v.Type()` on the nil slots, crashing on large `ORDER BY ... OFFSET` result sets that spill to a temp file. (`OFFSET` disables the in-memory top-N optimization, forcing the full file sort — which is why the crash depended on result-set size, matching the reporter's "later-inserted / large single-country" observation.)

**Fix:** `encodeRow` is now a `*fileSorter` method that substitutes a typed NULL (`&NullValue{t: s.colTypes[i]}`) for nil slots, which round-trips through the temp file as SQL NULL.

### 2. index out of range `[0]` in `db.SQLQuery`
`pkg/database/sql.go` — Since 1.11.0 the grammar accepts empty/comment-only input and `ParseSQL` returns an empty statement slice with no error, so empty probe queries from drivers panicked on `stmts[0]`.

**Fix:** added a `len(stmts) == 0` guard returning `ErrExpectingDQLStmt`, matching the guard `db.SQLExec` already uses.

## Tests
- New regression tests reproduce both panics (each was verified to crash with the exact panic string when its fix is reverted):
  - `embedded/sql/file_sort_pushdown_regression_test.go`
  - `pkg/database/sql_emptyquery_regression_test.go`
- Full `embedded/sql` and `pkg/database` suites pass.
- Verified end-to-end against a locally built 1.11.x server: empty/comment queries now return a normal SQL error, and the large filtered `ORDER BY ... LIMIT ... OFFSET ...` spill query returns correct rows — neither crashes the server.

Closes #2100