### PR TITLE
fix(database): guard nil db in DBManager.CloseAll to avoid shutdown panic

### DIFF
--- a/pkg/database/db_manager.go
+++ b/pkg/database/db_manager.go
@@ -485,14 +485,22 @@ func (m *DBManager) CloseAll(ctx context.Context) error {
 
 		busyDBs := 0
 		m.dbCache.Apply(func(_, value interface{}) error {
-			ref := value.(*dbRef)
+			ref, _ := value.(*dbRef)
+			if ref == nil {
+				return nil
+			}
 
 			if atomic.LoadUint32(&ref.count) > 0 {
 				busyDBs++
 				return nil
 			}
 
-			ref.db.Close()
+			// ref.db may be nil if the database was never successfully opened
+			// (e.g. openDB failed in Get and left a db-less ref in the cache).
+			// Guard here as every other close site in this file does.
+			if ref.db != nil {
+				ref.db.Close()
+			}
 			return nil
 		})
 		tryClose = busyDBs > 0

--- a/pkg/database/db_manager_test.go
+++ b/pkg/database/db_manager_test.go
@@ -491,3 +491,32 @@ func TestDBManagerPutUpdate(t *testing.T) {
 	require.Equal(t, idx1, idx2, "re-putting same name should return same index")
 	require.Equal(t, 1, manager.Length(), "should not create duplicate entry")
 }
+
+func TestDBManagerCloseAllAfterFailedOpen(t *testing.T) {
+	// A database whose open fails leaves a db-less ref in the cache: Get() has
+	// allocDB Put() a &dbRef{count: 1}, openDB then fails and Release() only
+	// decrements the count without removing the entry. CloseAll must skip such a
+	// ref instead of dereferencing its nil db.
+	openErr := fmt.Errorf("open failed")
+	openDB := func(name string, opts *Options) (DB, error) {
+		return nil, openErr
+	}
+
+	manager := NewDBManager(openDB, 5, logger.NewMemoryLogger())
+	manager.Put("testdb", DefaultOptions(), false)
+
+	_, err := manager.Get(0)
+	require.ErrorIs(t, err, openErr)
+
+	// The failed open must have left a ref with a nil db in the cache.
+	v, err := manager.dbCache.Get(0)
+	require.NoError(t, err)
+	ref, _ := v.(*dbRef)
+	require.NotNil(t, ref)
+	require.Nil(t, ref.db)
+	require.Zero(t, atomic.LoadUint32(&ref.count))
+
+	require.NotPanics(t, func() {
+		require.NoError(t, manager.CloseAll(context.Background()))
+	})
+}


### PR DESCRIPTION
## What

Guard `ref.db != nil` in `DBManager.CloseAll` (`pkg/database/db_manager.go`) so a
db-less cache ref no longer causes a nil pointer dereference on shutdown.

Fixes #2108.

## Why

On `SIGTERM`, `Stop()` → `CloseDatabases()` → `DBManager.CloseAll` can panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38]
github.com/codenotary/immudb/pkg/database.(*DBManager).CloseAll.func1
        pkg/database/db_manager.go:467
...
github.com/codenotary/immudb/pkg/server.(*ImmuServer).Stop
github.com/codenotary/immudb/pkg/server.(*ImmuServer).installShutdownHandler.func1
```

The `dbCache.Apply` closure in `CloseAll` called `ref.db.Close()` without checking
`ref.db != nil`. It is the only close site in the file that didn't guard — `OnEvict`,
`Close` and `Release` all check `ref.db != nil`.

A db-less ref ends up in the cache whenever a database **fails to open**: `Get()` has
`allocDB` `Put()` a `&dbRef{count: 1}` (its `db` is still nil), then `openDB` fails and
`Get()` calls `Release()`, which only decrements the ref count — it never removes the
entry from the cache. On shutdown `CloseAll` iterates that `{count: 0, db: nil}` ref and
dereferences the nil `db`.

Observed in production on a replica whose replicated database could not fetch state from
its primary (`openDB` kept failing): successfully-opened databases closed cleanly, then
the panic hit on the failed one, so `Stop()` never completed and the graceful shutdown /
final flush was truncated.

## How

```go
m.dbCache.Apply(func(_, value interface{}) error {
    ref, _ := value.(*dbRef)
    if ref == nil {
        return nil
    }

    if atomic.LoadUint32(&ref.count) > 0 {
        busyDBs++
        return nil
    }

    // ref.db may be nil if the database was never successfully opened.
    if ref.db != nil {
        ref.db.Close()
    }
    return nil
})
```

## Test

Added `TestDBManagerCloseAllAfterFailedOpen`, which drives the failed-open-then-shutdown
path. It panics on the current code and passes with the fix:

- before: `--- FAIL … Panic value: runtime error: invalid memory address or nil pointer dereference`
- after: `ok  github.com/codenotary/immudb/pkg/database`

`go test ./pkg/database/ -run TestDBManager` passes.