### PR TITLE
fix(pgsql): guard extended-query Parse against zero parsed statements + nil row-value-slot hardening

### DIFF
--- a/embedded/document/document_reader.go
+++ b/embedded/document/document_reader.go
@@ -67,8 +67,10 @@ func (r *documentReader) ReadN(ctx context.Context, count int) ([]*protomodel.Do
 			return nil, mayTranslateError(err)
 		}
 
-		docIDBytes := row.ValuesByPosition[0].RawValue().([]byte)
-		docBytes := row.ValuesByPosition[1].RawValue().([]byte)
+		docIDBytes, docBytes, err := docRowBytes(row)
+		if err != nil {
+			return nil, err
+		}
 
 		doc := &structpb.Struct{}
 		err = proto.Unmarshal(docBytes, doc)
@@ -85,6 +87,27 @@ func (r *documentReader) ReadN(ctx context.Context, count int) ([]*protomodel.Do
 	}
 
 	return revisions, err
+}
+
+// docRowBytes extracts the raw document-id and encoded-document bytes from
+// a SQL row. Slots may be nil when an upstream reader skipped decoding
+// unneeded columns (projection pushdown), so guard before dereferencing.
+func docRowBytes(row *sql.Row) (docIDBytes, docBytes []byte, err error) {
+	if len(row.ValuesByPosition) < 2 || row.ValuesByPosition[0] == nil || row.ValuesByPosition[1] == nil {
+		return nil, nil, ErrUnexpectedValue
+	}
+
+	docIDBytes, ok := row.ValuesByPosition[0].RawValue().([]byte)
+	if !ok {
+		return nil, nil, ErrUnexpectedValue
+	}
+
+	docBytes, ok = row.ValuesByPosition[1].RawValue().([]byte)
+	if !ok {
+		return nil, nil, ErrUnexpectedValue
+	}
+
+	return docIDBytes, docBytes, nil
 }
 
 func (r *documentReader) Close() error {
@@ -106,8 +129,10 @@ func (r *documentReader) Read(ctx context.Context) (*protomodel.DocumentAtRevisi
 		return nil, mayTranslateError(err)
 	}
 
-	docIDBytes := row.ValuesByPosition[0].RawValue().([]byte)
-	docBytes := row.ValuesByPosition[1].RawValue().([]byte)
+	docIDBytes, docBytes, err := docRowBytes(row)
+	if err != nil {
+		return nil, err
+	}
 
 	doc := &structpb.Struct{}
 	err = proto.Unmarshal(docBytes, doc)

--- a/embedded/document/engine.go
+++ b/embedded/document/engine.go
@@ -906,7 +906,15 @@ func (e *Engine) ReplaceDocuments(ctx context.Context, username string, query *p
 			return nil, mayTranslateError(err)
 		}
 
-		val := row.ValuesByPosition[0].RawValue().([]byte)
+		if len(row.ValuesByPosition) == 0 || row.ValuesByPosition[0] == nil {
+			return nil, ErrUnexpectedValue
+		}
+
+		val, ok := row.ValuesByPosition[0].RawValue().([]byte)
+		if !ok {
+			return nil, ErrUnexpectedValue
+		}
+
 		docID, err := NewDocumentIDFromRawBytes(val)
 		if err != nil {
 			return nil, err
@@ -1057,7 +1065,16 @@ func (e *Engine) CountDocuments(ctx context.Context, query *protomodel.Query, of
 		return 0, err
 	}
 
-	return row.ValuesByPosition[0].RawValue().(int64), nil
+	if len(row.ValuesByPosition) == 0 || row.ValuesByPosition[0] == nil {
+		return 0, ErrUnexpectedValue
+	}
+
+	count, ok := row.ValuesByPosition[0].RawValue().(int64)
+	if !ok {
+		return 0, ErrUnexpectedValue
+	}
+
+	return count, nil
 }
 
 func (e *Engine) GetEncodedDocument(ctx context.Context, collectionName string, docID DocumentID, txID uint64) (collectionID uint32, documentIdFieldName string, encodedDoc *EncodedDocument, err error) {

--- a/embedded/sql/nil_value_guards_test.go
+++ b/embedded/sql/nil_value_guards_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2026 Codenotary Inc. All rights reserved.
+
+SPDX-License-Identifier: BUSL-1.1
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://mariadb.com/bsl11/
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The projection-pushdown optimization can leave Row.ValuesByPosition[i]
+// nil for columns a query does not reference (see rawRowReader.Read and
+// the fileSorter.encodeRow fix for issue #2100). These tests encode the
+// contract that every row consumer must treat a nil slot as SQL NULL
+// instead of dereferencing it.
+
+func TestRowDigestTreatsNilSlotAsNull(t *testing.T) {
+	cols := []ColDescriptor{
+		{Column: "a", Type: IntegerType},
+		{Column: "b", Type: IntegerType},
+	}
+
+	rowWithNil := &Row{ValuesByPosition: []TypedValue{nil, NewInteger(1)}}
+	rowWithNull := &Row{ValuesByPosition: []TypedValue{NewNull(IntegerType), NewInteger(1)}}
+
+	dNil, err := rowWithNil.digest(cols)
+	require.NoError(t, err)
+
+	dNull, err := rowWithNull.digest(cols)
+	require.NoError(t, err)
+
+	require.Equal(t, dNull, dNil)
+}
+
+func TestSetOpRowDigestTreatsNilSlotAsNull(t *testing.T) {
+	rowWithNil := &Row{ValuesByPosition: []TypedValue{nil, NewVarchar("x")}}
+	rowWithNull := &Row{ValuesByPosition: []TypedValue{NewNull(VarcharType), NewVarchar("x")}}
+
+	require.NotPanics(t, func() {
+		require.Equal(t, rowDigest(rowWithNull), rowDigest(rowWithNil))
+	})
+}
+
+func TestRowValuesToValueExpsSubstitutesTypedNullForNilSlot(t *testing.T) {
+	cols := []ColDescriptor{
+		{Column: "a", Type: IntegerType},
+		{Column: "b", Type: VarcharType},
+	}
+
+	row := &Row{ValuesByPosition: []TypedValue{nil, NewVarchar("x")}}
+
+	exps := rowValuesToValueExps(row, cols)
+	require.Len(t, exps, 2)
+
+	nv, ok := exps[0].(*NullValue)
+	require.True(t, ok)
+	require.Equal(t, IntegerType, nv.Type())
+
+	require.Equal(t, NewVarchar("x"), exps[1])
+}

--- a/embedded/sql/row_reader.go
+++ b/embedded/sql/row_reader.go
@@ -113,6 +113,11 @@ func (row *Row) digest(cols []ColDescriptor) (d [sha256.Size]byte, err error) {
 		binary.BigEndian.PutUint32(b[:], uint32(i))
 		h.Write(b[:])
 
+		// a nil slot (column skipped by projection pushdown) digests as NULL
+		if v == nil {
+			continue
+		}
+
 		_, isNull := v.(*NullValue)
 		if isNull {
 			continue

--- a/embedded/sql/set_op_row_reader.go
+++ b/embedded/sql/set_op_row_reader.go
@@ -97,7 +97,8 @@ func (sr *setOpRowReader) loadRight(ctx context.Context) error {
 func rowDigest(row *Row) string {
 	var b []byte
 	for _, v := range row.ValuesByPosition {
-		if v.IsNull() {
+		// a nil slot (column skipped by projection pushdown) digests as NULL
+		if v == nil || v.IsNull() {
 			b = append(b, 0)
 		} else {
 			b = append(b, 1)

--- a/embedded/sql/stmt.go
+++ b/embedded/sql/stmt.go
@@ -5406,6 +5406,26 @@ func (stmt *CTEStmt) Resolve(ctx context.Context, tx *SQLTx, params map[string]i
 	return mainReader, nil
 }
 
+// rowValuesToValueExps converts a row's positional values into ValueExps
+// for CTE materialization. A slot may be nil when an upstream reader
+// skipped decoding unneeded columns (projection pushdown) — substitute a
+// typed SQL NULL instead of type-asserting on a nil interface.
+func rowValuesToValueExps(row *Row, cols []ColDescriptor) []ValueExp {
+	rowValues := make([]ValueExp, len(row.ValuesByPosition))
+	for i, v := range row.ValuesByPosition {
+		if v == nil {
+			t := AnyType
+			if i < len(cols) {
+				t = cols[i].Type
+			}
+			rowValues[i] = &NullValue{t: t}
+			continue
+		}
+		rowValues[i] = v
+	}
+	return rowValues
+}
+
 func materializeCTE(ctx context.Context, tx *SQLTx, cte *CTEDef, params map[string]interface{}) ([]ColDescriptor, [][]ValueExp, error) {
 	reader, err := cte.query.Resolve(ctx, tx, params, nil)
 	if err != nil {
@@ -5432,10 +5452,7 @@ func materializeCTE(ctx context.Context, tx *SQLTx, cte *CTEDef, params map[stri
 		if err != nil {
 			return nil, nil, fmt.Errorf("error materializing CTE '%s': %w", cte.name, err)
 		}
-		rowValues := make([]ValueExp, len(row.ValuesByPosition))
-		for i, v := range row.ValuesByPosition {
-			rowValues[i] = v.(ValueExp)
-		}
+		rowValues := rowValuesToValueExps(row, cols)
 		rows = append(rows, rowValues)
 	}
 
@@ -5481,10 +5498,7 @@ func materializeRecursiveCTE(ctx context.Context, tx *SQLTx, cte *CTEDef, params
 			baseReader.Close()
 			return nil, nil, fmt.Errorf("error materializing recursive CTE '%s': %w", cte.name, err)
 		}
-		rowValues := make([]ValueExp, len(row.ValuesByPosition))
-		for i, v := range row.ValuesByPosition {
-			rowValues[i] = v.(ValueExp)
-		}
+		rowValues := rowValuesToValueExps(row, cols)
 		allRows = append(allRows, rowValues)
 		newRows = append(newRows, rowValues)
 	}

--- a/pkg/pgsql/server/parse_emptyquery_regression_test.go
+++ b/pkg/pgsql/server/parse_emptyquery_regression_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2026 Codenotary Inc. All rights reserved.
+
+SPDX-License-Identifier: BUSL-1.1
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://mariadb.com/bsl11/
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server_test
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/codenotary/immudb/pkg/server"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPgsqlServer_PrepareEmptyOrCommentOnlyStatement is a regression test
+// for the issue #2100 follow-up: an extended-protocol Parse message whose
+// SQL is empty or comment-only (e.g. a driver liveness probe like
+// `-- ping`) used to panic the whole server with
+// "index out of range [0] with length 0" at query_machine.go, because
+// since 1.11.0 ParseSQL returns zero statements without an error for such
+// input and the Parse handler indexed stmts[0] unguarded.
+func TestPgsqlServer_PrepareEmptyOrCommentOnlyStatement(t *testing.T) {
+	td := t.TempDir()
+
+	options := server.DefaultOptions().
+		WithDir(td).
+		WithPort(0).
+		WithPgsqlServer(true).
+		WithPgsqlServerPort(0).
+		WithMetricsServer(false).
+		WithWebServer(false)
+
+	srv := server.DefaultServer().WithOptions(options).(*server.ImmuServer)
+
+	err := srv.Initialize()
+	require.NoError(t, err)
+
+	go func() {
+		srv.Start()
+	}()
+
+	defer func() {
+		srv.Stop()
+	}()
+
+	defer os.Remove(".state-")
+
+	db, err := sql.Open("postgres", fmt.Sprintf("host=localhost port=%d sslmode=disable user=immudb dbname=defaultdb password=immudb", srv.PgsqlSrv.GetPort()))
+	require.NoError(t, err)
+	defer db.Close()
+
+	for _, q := range []string{"-- ping", ""} {
+		stmt, err := db.Prepare(q)
+		require.NoError(t, err, "Parse of %q must not error", q)
+
+		// Execute answers with EmptyQueryResponse. Some drivers surface
+		// that as an error, which is fine — the regression being guarded
+		// is a server panic that kills the session (and the process).
+		stmt.Exec()
+		stmt.Close()
+	}
+
+	// The connection (and the server) must still be alive and usable.
+	var version string
+	err = db.QueryRow("select version()").Scan(&version)
+	require.NoError(t, err)
+	require.NotEmpty(t, version)
+}

--- a/pkg/pgsql/server/query_machine.go
+++ b/pkg/pgsql/server/query_machine.go
@@ -174,10 +174,20 @@ func (s *session) QueryMachine() error {
 					s.HandleError(pserr.ErrMaxStmtNumberExceeded)
 					continue
 				}
-				if paramCols, resCols, err = s.inferParamAndResultCols(stmts[0]); err != nil {
-					waitForSync = extQueryMode
-					s.HandleError(err)
-					continue
+
+				// Since 1.11.0 the grammar accepts empty/comment-only input
+				// and ParseSQL returns zero statements without an error
+				// (see issue #2100). Parse of an empty query string is valid
+				// in the extended protocol: skip inference (no params, no
+				// result columns) and register the statement; a later
+				// Execute re-parses it in fetchAndWriteResults and answers
+				// with EmptyQueryResponse.
+				if len(stmts) > 0 {
+					if paramCols, resCols, err = s.inferParamAndResultCols(stmts[0]); err != nil {
+						waitForSync = extQueryMode
+						s.HandleError(err)
+						continue
+					}
 				}
 			}
 

--- a/pkg/pgsql/server/query_machine_test.go
+++ b/pkg/pgsql/server/query_machine_test.go
@@ -403,6 +403,26 @@ func TestSession_QueriesMachine(t *testing.T) {
 			},
 			out: nil,
 		},
+		{
+			// Regression for the issue #2100 follow-up: since 1.11.0 the
+			// grammar accepts empty/comment-only input and ParseSQL returns
+			// zero statements without an error, so a Parse message carrying
+			// such SQL panicked on stmts[0] (index out of range [0]).
+			name: "parse empty or comment-only statement does not panic",
+			in: func(c2 net.Conn) {
+				ready4Query := make([]byte, len(bmessages.ReadyForQuery(bmessages.TxStatusIdle)))
+				c2.Read(ready4Query)
+				c2.Write(h.Msg('P', h.Join([][]byte{h.S("st"), h.S("-- ping"), h.I16(1), h.I32(0)})))
+				parseComplete := make([]byte, len(bmessages.ParseComplete()))
+				c2.Read(parseComplete)
+				c2.Write(h.Msg('P', h.Join([][]byte{h.S(""), h.S(""), h.I16(1), h.I32(0)})))
+				parseComplete = make([]byte, len(bmessages.ParseComplete()))
+				c2.Read(parseComplete)
+				// Terminate message
+				c2.Write(h.Msg('X', []byte{0}))
+			},
+			out: nil,
+		},
 	}
 
 	for i, tt := range tests {

--- a/pkg/server/sql.go
+++ b/pkg/server/sql.go
@@ -200,8 +200,9 @@ func sqlRowsToProto(descriptors []sql.ColDescriptor, rows []*sql.Row, outRows []
 			row.Columns[i] = descriptors[i].Selector()
 
 			v := sqlRow.ValuesByPosition[i]
+			// a nil slot (column skipped by projection pushdown) serializes as NULL
 			_, isNull := v.(*sql.NullValue)
-			if isNull {
+			if v == nil || isNull {
 				row.Values[i] = &schema.SQLValue{Value: &schema.SQLValue_Null{}}
 			} else {
 				row.Values[i] = schema.TypedValueToRowValue(v)

--- a/pkg/server/sql_test.go
+++ b/pkg/server/sql_test.go
@@ -206,3 +206,24 @@ func (s *ImmuService_SQLQueryServerMock) Send(res *schema.SQLQueryResult) error 
 func (s *ImmuService_SQLQueryServerMock) Context() context.Context {
 	return s.ctx
 }
+
+// A nil positional value (column skipped by projection pushdown) must
+// serialize as SQL NULL instead of being dereferenced — see issue #2100.
+func TestSQLRowsToProtoTreatsNilSlotAsNull(t *testing.T) {
+	descriptors := []sql.ColDescriptor{
+		{Column: "a", Type: sql.IntegerType},
+		{Column: "b", Type: sql.IntegerType},
+	}
+
+	rows := []*sql.Row{
+		{ValuesByPosition: []sql.TypedValue{nil, sql.NewInteger(5)}},
+	}
+
+	out := sqlRowsToProto(descriptors, rows, make([]*schema.Row, len(rows)))
+	require.Len(t, out, 1)
+
+	_, isNull := out[0].Values[0].Value.(*schema.SQLValue_Null)
+	require.True(t, isNull)
+
+	require.Equal(t, int64(5), out[0].Values[1].GetN())
+}


### PR DESCRIPTION
## Summary

Follow-up to #2100: a third panic of the same regression family was reported [in a comment](https://github.com/codenotary/immudb/issues/2100#issuecomment-4950023827) after the original fix was merged — this time in the pgsql wire-protocol server:

```
panic: runtime error: index out of range [0] with length 0
github.com/codenotary/immudb/pkg/pgsql/server.(*session).QueryMachine
    pkg/pgsql/server/query_machine.go:177
```

### Commit 1 — `fix(pgsql)`: extended-query Parse panic

Since 1.11.0 the SQL grammar accepts empty/comment-only input, so `ParseSQL` returns an empty statement slice with no error. The extended-query `Parse` handler guarded `len(stmts) > 1` but then indexed `stmts[0]` unguarded — any Parse message carrying such SQL (e.g. a driver liveness probe like `-- ping`) crashed the whole server.

Parse of an empty query string is valid in the extended protocol: the handler now skips parameter/result-column inference and registers the statement; a later Execute re-parses it and answers with `EmptyQueryResponse`, matching PostgreSQL behavior.

### Commit 2 — `chore(sql)`: nil row-value-slot hardening

A repo-wide audit for both #2100 bug families found:

- **Empty-statement-slice class: fully closed.** Every `ParseSQL`/`ParseSQLString` call site is now length-guarded, range-based, or parses hardcoded non-empty input. The Parse handler fixed here was the last reachable one.
- **Nil `ValuesByPosition` slot class (projection pushdown): no live panic left**, but five consumers dereference every positional slot and stay safe only because projection currently repopulates rows before they run — the same fragile invariant whose violation caused the `fileSorter.encodeRow` panic. Guards added (nil slot ⇒ SQL NULL, or `ErrUnexpectedValue` for the document readers where the slots are always explicitly projected):
  - CTE materialization (`materializeCTE`/`materializeRecursiveCTE`) — was a hard type-assertion panic on a nil interface
  - `Row.digest` (DISTINCT, diff)
  - `setOpRowReader.rowDigest` (EXCEPT/INTERSECT)
  - `sqlRowsToProto` (gRPC row serialization)
  - `embedded/document` readers (`_id`/`_doc` extraction, count)

## Tests

- Unit regression test in `TestSession_QueriesMachine` reproducing the exact panic at `query_machine.go:177` (fails with the guard reverted).
- End-to-end test driving a real server through lib/pq's extended protocol (`Prepare("-- ping")` → Parse/Describe/Sync → Execute), asserting the session survives and stays usable.
- Unit tests encoding the nil-slot-equals-NULL contract for `Row.digest`, set-op digest, CTE materialization, and gRPC serialization.

`go build ./...`, `go vet`, and full test suites for `embedded/sql`, `embedded/document`, `pkg/pgsql/...`, `pkg/database`, and `pkg/server` all pass.

Fixes the follow-up panic reported in #2100.
