### PR TITLE
docs(embedding): add an in-process embedding guide and runnable examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ immudb is a database with built-in cryptographic proof and verification. It trac
 
 Traditional database transactions and logs are mutable, and therefore there is no way to know for sure if your data has been compromised. immudb is immutable. You can add new versions of existing records, but never change or delete records. This lets you store critical data without fear of it being tampered.
 
-Data stored in immudb is cryptographically coherent and verifiable. Unlike blockchains, immudb can handle millions of transactions per second, and can be used both as a lightweight service or embedded in your application as a library. immudb runs everywhere, on an IoT device, your notebook, a server, on-premise or in the cloud.
+Data stored in immudb is cryptographically coherent and verifiable. Unlike blockchains, immudb can handle millions of transactions per second, and can be used both as a lightweight service or embedded in your application as a library. immudb runs everywhere, on an IoT device, your notebook, a server, on-premise or in the cloud. For running immudb fully in-process as a Go library — no server, no container — see the [embedding guide](docs/EMBEDDING.md).
 
 
 When used as a relational data database, it supports both transactions and blobs, so there are no limits to the use cases. Developers and organizations use immudb to secure and tamper-evident log data, sensor data, sensitive data, transactions, software build recipes, rule-base data, artifacts and even video streams. [Examples of organizations using immudb today.](https://www.immudb.io)

--- a/docs/EMBEDDING.md
+++ b/docs/EMBEDDING.md
@@ -1,0 +1,138 @@
+# Embedding immudb in-process (as a Go library)
+
+immudb can run **entirely inside your Go process** — no server binary, no
+container, no network. You import a package, open a local data directory, and
+call methods directly. This is ideal for embedding immudb into another
+application (a CLI, a desktop app, a plugin, …).
+
+The `immudb` server is just one consumer of these same packages. Everything the
+server does with your data, it does through `pkg/database`, which in turn builds
+on the `embedded/*` engines.
+
+## Choosing a layer
+
+There are two practical ways to embed, depending on how much you want and how
+lean a dependency graph you need.
+
+| Layer | Import | Gives you | gRPC pulled in? |
+|---|---|---|---|
+| **A. `pkg/database`** (recommended) | `github.com/codenotary/immudb/pkg/database` | High-level `DB`: verifiable Set/Get, SQL, documents, transactions, proofs — the exact code path the server uses | Links the gRPC library (for typed `codes`/`status` errors and the `schema` types), but **never starts a server** or opens a socket |
+| **B. `embedded/store` (+ `embedded/sql`)** (leanest) | `github.com/codenotary/immudb/embedded/store`, `.../embedded/sql` | Append-only key-value store and SQL engine; you build your own API and call the stateless `store.Verify*` proof helpers | **No gRPC at all**, no protobuf — just `google/uuid` and Prometheus |
+
+**Recommendation:** start with **Layer A (`pkg/database`)**. It gives you
+immudb's core value — tamper-evident, cryptographically verifiable KV + SQL —
+with the least code. Drop to **Layer B** only if you want the absolute minimum
+dependency footprint and are happy to define your own API surface.
+
+> A third option exists for tests — `pkg/server/servertest.NewBufconnServer`
+> runs the full server (auth, sessions, multi-DB) over an in-memory buffer and
+> talks to it with the standard `pkg/client`. It links the entire server stack,
+> so it is **not** recommended for embedding; it is listed here only for
+> completeness.
+
+## Layer A — `pkg/database` (recommended)
+
+```go
+log := logger.NewSimpleLoggerWithLevel("embedded", os.Stdout, logger.LogError)
+opts := database.DefaultOptions().WithDBRootPath("./data")
+
+// NewDB creates the directory + files; OpenDB opens an existing one.
+// Pass a nil sql.MultiDBHandler for a single, self-contained database.
+db, err := database.NewDB("mydb", nil, opts, log)
+// ...
+defer db.Close()
+
+ctx := context.Background()
+
+// verifiable write + read
+db.VerifiableSet(ctx, &schema.VerifiableSetRequest{
+    SetRequest: &schema.SetRequest{
+        KVs: []*schema.KeyValue{{Key: []byte("k"), Value: []byte("v")}},
+    },
+})
+entry, _ := db.VerifiableGet(ctx, &schema.VerifiableGetRequest{
+    KeyRequest: &schema.KeyRequest{Key: []byte("k")},
+})
+
+// embedded SQL
+db.SQLExec(ctx, nil, &schema.SQLExecRequest{Sql: "CREATE TABLE t (id INTEGER, PRIMARY KEY id)"})
+reader, _ := db.SQLQuery(ctx, nil, &schema.SQLQueryRequest{Sql: "SELECT id FROM t"})
+defer reader.Close()
+```
+
+`DB` methods take `schema.*` request structs — the same messages the gRPC API
+uses — which makes them verbose but complete. Full runnable program:
+[`examples/embedded/main.go`](../examples/embedded/main.go).
+
+Key constructors: `database.NewDB` / `database.OpenDB`
+(`pkg/database/database.go`), options via `database.DefaultOptions()`
+(`pkg/database/dboptions.go`).
+
+## Layer B — `embedded/store` + `embedded/sql` (leanest)
+
+```go
+st, _ := store.Open("./data", store.DefaultOptions())
+defer st.Close()
+
+tx, _ := st.NewWriteOnlyTx(ctx)
+tx.Set([]byte("k"), nil, []byte("v"))
+tx.Commit(ctx)
+
+valRef, _ := st.Get(ctx, []byte("k"))
+val, _ := valRef.Resolve()
+```
+
+Verifiable, runnable examples live next to the packages as Go example tests:
+
+- Key-value + dual-proof verification: [`embedded/store/example_test.go`](../embedded/store/example_test.go)
+- SQL engine: [`embedded/sql/example_test.go`](../embedded/sql/example_test.go)
+
+### SQL requires multi-indexing
+
+`sql.NewEngine` needs the store opened with multi-indexing enabled, otherwise it
+returns `ErrMultiIndexingNotEnabled`:
+
+```go
+st, _ := store.Open("./data", store.DefaultOptions().WithMultiIndexing(true))
+engine, _ := sql.NewEngine(st, sql.DefaultOptions().WithPrefix([]byte("sql")))
+```
+
+(Layer A's `NewDB`/`OpenDB` already sets this for you.)
+
+## Important: single-writer — immudb does not lock the data directory
+
+A data directory must be opened by **one process at a time**. Within that process
+the store is safe for concurrent use by multiple goroutines.
+
+**immudb does not enforce this for you.** There is no lock file and no `flock`:
+calling `store.Open` (or `NewDB`/`OpenDB`) on a directory another live process
+already has open **succeeds**, and both processes will then append to the same
+transaction log and index. The result is silent corruption — the very failure
+this constraint exists to prevent. Nothing will warn you.
+
+Mutual exclusion is the embedder's responsibility. Either:
+
+- give each process its own directory;
+- funnel all access through a single long-lived process; or
+- take your own cross-process lock around opening the store.
+
+For a worked example of the last option, see
+[`contrib/immuledger/internal/ledger/lock_unix.go`](../contrib/immuledger/internal/ledger/lock_unix.go),
+which takes an advisory `flock` on a sidecar lock file before opening the store
+and releases it on close.
+
+## Data directory layout
+
+Point the store at any path via `WithDBRootPath` (Layer A) or the first argument
+to `store.Open` (Layer B). immudb creates its append-only logs, index, and
+hash-tree files under that directory. Back it up by copying the directory while
+the process is stopped (or use immudb's export/replication APIs for online
+copies).
+
+## Verifying it links no server
+
+To prove an embed does not pull in the gRPC server:
+
+```sh
+go list -deps ./yourpkg | grep immudb/pkg/server   # should print nothing
+```

--- a/embedded/sql/example_test.go
+++ b/embedded/sql/example_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2026 Codenotary Inc. All rights reserved.
+
+SPDX-License-Identifier: BUSL-1.1
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://mariadb.com/bsl11/
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sql_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/codenotary/immudb/embedded/sql"
+	"github.com/codenotary/immudb/embedded/store"
+)
+
+// ExampleNewEngine runs the embedded SQL engine in-process on top of a local
+// key-value store: no server, no container. Note the store MUST be opened with
+// WithMultiIndexing(true), otherwise NewEngine returns ErrMultiIndexingNotEnabled.
+func ExampleNewEngine() {
+	dir, err := os.MkdirTemp("", "immudb-embedded-sql")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(dir)
+
+	st, err := store.Open(dir, store.DefaultOptions().WithMultiIndexing(true))
+	if err != nil {
+		panic(err)
+	}
+	defer st.Close()
+
+	engine, err := sql.NewEngine(st, sql.DefaultOptions().WithPrefix([]byte("sql")))
+	if err != nil {
+		panic(err)
+	}
+
+	ctx := context.Background()
+
+	_, _, err = engine.Exec(ctx, nil,
+		"CREATE TABLE users (id INTEGER, name VARCHAR, PRIMARY KEY id)", nil)
+	if err != nil {
+		panic(err)
+	}
+
+	_, _, err = engine.Exec(ctx, nil,
+		"INSERT INTO users (id, name) VALUES (1, 'Alice'), (2, 'Bob')", nil)
+	if err != nil {
+		panic(err)
+	}
+
+	reader, err := engine.Query(ctx, nil, "SELECT id, name FROM users ORDER BY id", nil)
+	if err != nil {
+		panic(err)
+	}
+	defer reader.Close()
+
+	for {
+		row, err := reader.Read(ctx)
+		if errors.Is(err, sql.ErrNoMoreRows) {
+			break
+		}
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("%v %v\n",
+			row.ValuesByPosition[0].RawValue(),
+			row.ValuesByPosition[1].RawValue(),
+		)
+	}
+
+	// Output:
+	// 1 Alice
+	// 2 Bob
+}

--- a/embedded/store/example_test.go
+++ b/embedded/store/example_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2026 Codenotary Inc. All rights reserved.
+
+SPDX-License-Identifier: BUSL-1.1
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://mariadb.com/bsl11/
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package store_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/codenotary/immudb/embedded/store"
+)
+
+// ExampleOpen embeds the immudb key-value store directly in-process: no server
+// and no container, just a local data directory opened as a library.
+func ExampleOpen() {
+	dir, err := os.MkdirTemp("", "immudb-embedded-kv")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(dir)
+
+	st, err := store.Open(dir, store.DefaultOptions())
+	if err != nil {
+		panic(err)
+	}
+	defer st.Close()
+
+	ctx := context.Background()
+
+	// write a key within a transaction
+	tx, err := st.NewWriteOnlyTx(ctx)
+	if err != nil {
+		panic(err)
+	}
+	if err := tx.Set([]byte("hello"), nil, []byte("immutable world")); err != nil {
+		panic(err)
+	}
+	if _, err := tx.Commit(ctx); err != nil {
+		panic(err)
+	}
+
+	// read it back from the index
+	valRef, err := st.Get(ctx, []byte("hello"))
+	if err != nil {
+		panic(err)
+	}
+	val, err := valRef.Resolve()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%s\n", val)
+
+	// Output: immutable world
+}
+
+// ExampleVerifyDualProof shows immudb's tamper-evidence: after committing two
+// transactions, a dual proof cryptographically links them, and VerifyDualProof
+// checks that link with no server involved. The same proof primitives back the
+// verifiable client of the full immudb server.
+func ExampleVerifyDualProof() {
+	dir, err := os.MkdirTemp("", "immudb-embedded-proof")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(dir)
+
+	st, err := store.Open(dir, store.DefaultOptions())
+	if err != nil {
+		panic(err)
+	}
+	defer st.Close()
+
+	ctx := context.Background()
+
+	commit := func(key, value []byte) *store.TxHeader {
+		tx, err := st.NewWriteOnlyTx(ctx)
+		if err != nil {
+			panic(err)
+		}
+		if err := tx.Set(key, nil, value); err != nil {
+			panic(err)
+		}
+		hdr, err := tx.Commit(ctx)
+		if err != nil {
+			panic(err)
+		}
+		return hdr
+	}
+
+	sourceHdr := commit([]byte("k1"), []byte("v1"))
+	targetHdr := commit([]byte("k2"), []byte("v2"))
+
+	// generate a proof that the store's state at targetHdr is consistent with,
+	// and includes, the state at sourceHdr
+	proof, err := st.DualProof(sourceHdr, targetHdr)
+	if err != nil {
+		panic(err)
+	}
+
+	verified := store.VerifyDualProof(
+		proof,
+		sourceHdr.ID, targetHdr.ID,
+		sourceHdr.Alh(), targetHdr.Alh(),
+	)
+
+	fmt.Println(verified)
+
+	// Output: true
+}

--- a/examples/embedded/main.go
+++ b/examples/embedded/main.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2026 Codenotary Inc. All rights reserved.
+
+SPDX-License-Identifier: BUSL-1.1
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://mariadb.com/bsl11/
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Command embedded shows how to use immudb fully in-process, as a library,
+// with no server and no container. It opens (or creates) a database directly on
+// disk through pkg/database, then exercises verifiable key-value writes and the
+// embedded SQL engine. This is the recommended starting point for embedding
+// immudb into a Go application.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/codenotary/immudb/embedded/logger"
+	"github.com/codenotary/immudb/embedded/sql"
+	"github.com/codenotary/immudb/pkg/api/schema"
+	"github.com/codenotary/immudb/pkg/database"
+)
+
+const (
+	dbName   = "plugindb"
+	dataRoot = "./data-embedded"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	ctx := context.Background()
+
+	db, err := openOrCreate()
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	if err := verifiableKV(ctx, db); err != nil {
+		return err
+	}
+	return embeddedSQL(ctx, db)
+}
+
+// openOrCreate opens the database if its directory already exists, otherwise it
+// creates a fresh one. Passing a nil sql.MultiDBHandler keeps this to a single,
+// self-contained database (no cross-database "USE DATABASE" support needed).
+func openOrCreate() (database.DB, error) {
+	// keep logs quiet for the example; use logger.LogInfo to see engine startup
+	log := logger.NewSimpleLoggerWithLevel("embedded", os.Stdout, logger.LogError)
+	opts := database.DefaultOptions().WithDBRootPath(dataRoot)
+
+	if _, err := os.Stat(filepath.Join(dataRoot, dbName)); errors.Is(err, os.ErrNotExist) {
+		return database.NewDB(dbName, nil, opts, log)
+	}
+	return database.OpenDB(dbName, nil, opts, log)
+}
+
+// verifiableKV writes a key with a cryptographic proof and reads it back
+// verifiably. VerifiableGet returns the entry together with the proof material
+// the immudb client would use to check tamper-evidence.
+func verifiableKV(ctx context.Context, db database.DB) error {
+	key := []byte("audit:1")
+
+	_, err := db.VerifiableSet(ctx, &schema.VerifiableSetRequest{
+		SetRequest: &schema.SetRequest{
+			KVs: []*schema.KeyValue{{Key: key, Value: []byte("record-A")}},
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	ventry, err := db.VerifiableGet(ctx, &schema.VerifiableGetRequest{
+		KeyRequest: &schema.KeyRequest{Key: key},
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("verifiable KV: %s = %s (tx %d)\n",
+		ventry.Entry.Key, ventry.Entry.Value, ventry.Entry.Tx)
+	return nil
+}
+
+// embeddedSQL runs the SQL engine in the same process. The statements are
+// idempotent (CREATE TABLE IF NOT EXISTS + UPSERT) so this example can be run
+// repeatedly against the same data directory.
+func embeddedSQL(ctx context.Context, db database.DB) error {
+	stmts := []string{
+		"CREATE TABLE IF NOT EXISTS items (id INTEGER, name VARCHAR, PRIMARY KEY id)",
+		"UPSERT INTO items (id, name) VALUES (1, 'widget'), (2, 'gadget')",
+	}
+	for _, stmt := range stmts {
+		if _, _, err := db.SQLExec(ctx, nil, &schema.SQLExecRequest{Sql: stmt}); err != nil {
+			return err
+		}
+	}
+
+	reader, err := db.SQLQuery(ctx, nil, &schema.SQLQueryRequest{
+		Sql: "SELECT id, name FROM items ORDER BY id",
+	})
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+
+	for {
+		row, err := reader.Read(ctx)
+		if errors.Is(err, sql.ErrNoMoreRows) {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		fmt.Printf("row: id=%v name=%v\n",
+			row.ValuesByPosition[0].RawValue(),
+			row.ValuesByPosition[1].RawValue(),
+		)
+	}
+	return nil
+}


### PR DESCRIPTION
immudb can run fully in-process as a Go library — no server, no container — but nothing in the repository explained how. Readers had to infer the approach from the test suite and guess which layer to build against.

## What this adds

**`docs/EMBEDDING.md`** — covers:

- choosing between `pkg/database` and `embedded/store` + `embedded/sql`
- why the SQL engine needs a multi-indexing store
- the single-writer constraint: immudb does not lock its data directory, so concurrent processes over one directory need external coordination
- the on-disk layout
- how to confirm a build links no server code

**Three runnable companions**, so the guide cannot drift from working code:

| File | Covers |
|---|---|
| `examples/embedded/main.go` | end-to-end `pkg/database` walkthrough |
| `embedded/store/example_test.go` | verifiable KV against the raw store |
| `embedded/sql/example_test.go` | embedded SQL against the raw engine |

The two `example_test.go` files are Go `Example` tests with expected output, so `go test` fails if the documented behaviour ever changes.

**README** — links the guide from the paragraph that already describes immudb as embeddable.

## Verification

Against this branch:

```
go vet ./embedded/sql/... ./embedded/store/... ./examples/embedded/...   # clean
go build ./examples/embedded                                            # ok
go test -run Example ./embedded/sql/... ./embedded/store/...
  ok  github.com/codenotary/immudb/embedded/sql    0.019s
  ok  github.com/codenotary/immudb/embedded/store  0.047s
gofmt -l   # clean
```

Documentation and examples only — no library code changes.