### PR TITLE
fix(server): keep the ongoing tx when a statement fails before execution

### DIFF
--- a/pkg/pgsql/server/query_machine.go
+++ b/pkg/pgsql/server/query_machine.go
@@ -1202,7 +1202,13 @@ func (s *session) exec(st sql.SQLStmt, namedParams []*schema.NamedParam, resultC
 	}
 
 	ntx, _, err := s.db.SQLExecPrepared(s.ctx, tx, []sql.SQLStmt{st}, params)
-	s.tx = ntx
+
+	// Same orphaning hazard as the session transaction path: a statement rejected
+	// before execution returns no transaction while leaving the ongoing one open,
+	// so replacing the reference would leak its snapshots.
+	if ntx != nil || tx == nil || tx.Closed() {
+		s.tx = ntx
+	}
 
 	return err
 }

--- a/pkg/server/sessions/internal/transactions/transactions.go
+++ b/pkg/server/sessions/internal/transactions/transactions.go
@@ -121,7 +121,17 @@ func (tx *transaction) SQLExec(ctx context.Context, request *schema.SQLExecReque
 		return sql.ErrNoOngoingTx
 	}
 
-	tx.sqlTx, _, err = tx.db.SQLExec(ctx, tx.sqlTx, request)
+	ntx, _, err := tx.db.SQLExec(ctx, tx.sqlTx, request)
+
+	// A statement rejected before the engine executes it - a parse error, for
+	// instance - returns no transaction while leaving the ongoing one open and
+	// uncancelled. Overwriting the reference in that case orphans it along with
+	// the snapshots it holds, which are then never released. On execution errors
+	// the engine cancels the transaction itself, so the reference is replaced as
+	// usual and the session drops it.
+	if ntx != nil || tx.sqlTx.Closed() {
+		tx.sqlTx = ntx
+	}
 
 	return err
 }

--- a/pkg/server/sessions/internal/transactions/transactions_test.go
+++ b/pkg/server/sessions/internal/transactions/transactions_test.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/codenotary/immudb/embedded/logger"
 	"github.com/codenotary/immudb/embedded/sql"
+	"github.com/codenotary/immudb/embedded/store"
+	"github.com/codenotary/immudb/pkg/api/schema"
 	"github.com/codenotary/immudb/pkg/database"
 	"github.com/stretchr/testify/require"
 )
@@ -54,4 +56,68 @@ func TestNewTx(t *testing.T) {
 
 	_, err = tx.Commit(context.Background())
 	require.ErrorIs(t, err, sql.ErrNoOngoingTx)
+}
+
+// A statement that fails before reaching the engine (a parse error, for example)
+// must leave the ongoing transaction untouched: the engine never got a chance to
+// cancel it, so dropping the reference here would orphan it together with the
+// snapshots it holds. See issue #2127.
+func TestSQLExecPreExecutionErrorKeepsTxOpen(t *testing.T) {
+	db, err := database.NewDB("db1", nil, database.DefaultOptions().WithDBRootPath(t.TempDir()), logger.NewSimpleLogger("logger", os.Stdout))
+	require.NoError(t, err)
+
+	tx, err := NewTransaction(context.Background(), sql.DefaultTxOptions(), db, "session1")
+	require.NoError(t, err)
+
+	err = tx.SQLExec(context.Background(), &schema.SQLExecRequest{Sql: "THIS IS NOT SQL"})
+	require.Error(t, err)
+
+	require.False(t, tx.IsClosed(), "a parse error must not close the transaction")
+
+	// the client can still roll back, which is what releases the snapshots
+	require.NoError(t, tx.Rollback())
+	require.True(t, tx.IsClosed())
+}
+
+// An execution-stage error is cancelled by the engine itself, so the transaction
+// is expected to end up closed. Pinned here so the fix for #2127 does not quietly
+// change this path.
+func TestSQLExecExecutionErrorClosesTx(t *testing.T) {
+	db, err := database.NewDB("db1", nil, database.DefaultOptions().WithDBRootPath(t.TempDir()), logger.NewSimpleLogger("logger", os.Stdout))
+	require.NoError(t, err)
+
+	tx, err := NewTransaction(context.Background(), sql.DefaultTxOptions(), db, "session1")
+	require.NoError(t, err)
+
+	err = tx.SQLExec(context.Background(), &schema.SQLExecRequest{Sql: "INSERT INTO nonexistent(id) VALUES (1);"})
+	require.Error(t, err)
+
+	require.True(t, tx.IsClosed(), "the engine cancels the tx on execution errors")
+	require.ErrorIs(t, tx.Rollback(), sql.ErrNoOngoingTx)
+}
+
+// Repeated pre-execution failures used to leak one tbtree snapshot each, so after
+// maxActiveSnapshots of them no further transaction could be opened until the
+// server was restarted. See issue #2127.
+func TestSQLExecPreExecutionErrorDoesNotLeakSnapshots(t *testing.T) {
+	const maxActiveSnapshots = 4
+
+	storeOpts := store.DefaultOptions().
+		WithIndexOptions(store.DefaultIndexOptions().WithMaxActiveSnapshots(maxActiveSnapshots))
+
+	db, err := database.NewDB("db1", nil,
+		database.DefaultOptions().WithDBRootPath(t.TempDir()).WithStoreOptions(storeOpts),
+		logger.NewSimpleLogger("logger", os.Stdout))
+	require.NoError(t, err)
+
+	// mirrors the reported production cycle: the client submits an invalid
+	// statement, attempts a rollback, and carries on regardless of its outcome
+	for i := 0; i < maxActiveSnapshots*2; i++ {
+		tx, err := NewTransaction(context.Background(), sql.DefaultTxOptions(), db, "session1")
+		require.NoErrorf(t, err, "opening a transaction failed on iteration %d: snapshots are leaking", i)
+
+		require.Error(t, tx.SQLExec(context.Background(), &schema.SQLExecRequest{Sql: "THIS IS NOT SQL"}))
+
+		_ = tx.Rollback()
+	}
 }

--- a/pkg/stdlib/tx_test.go
+++ b/pkg/stdlib/tx_test.go
@@ -24,7 +24,6 @@ import (
 
 	"google.golang.org/grpc/status"
 
-	"github.com/codenotary/immudb/pkg/server/sessions"
 	"github.com/stretchr/testify/require"
 )
 
@@ -105,5 +104,8 @@ func TestTx_Errors(t *testing.T) {
 	require.ErrorContains(t, err, "syntax error: unexpected IDENTIFIER at position 4")
 
 	_, err = tx.QueryContext(context.Background(), "this is also very wrong")
-	require.ErrorIs(t, err, sessions.ErrTransactionNotFound)
+	require.ErrorContains(t, err, "syntax error: unexpected IDENTIFIER at position 4")
+
+	// the tx survived both parse errors and can still be rolled back (#2127)
+	require.NoError(t, tx.Rollback())
 }


### PR DESCRIPTION
Fixes #2127. Also very likely fixes #1998, which hits the same error through the pgsql adapter.

## The bug

A statement rejected **before** the SQL engine executes it — a parse error being the common case — returns no transaction while leaving the caller's ongoing one open and uncancelled. The two callers that hold the *only* reference to that transaction overwrote it with the returned `nil`:

- `pkg/server/sessions/internal/transactions/transactions.go:124` — `tx.sqlTx, _, err = tx.db.SQLExec(...)`
- `pkg/pgsql/server/query_machine.go:1205` — `s.tx = ntx`, assigned even when `err != nil`

That orphans an `OngoingTx` still holding its tbtree snapshots. Snapshots are released only by `Commit`/`Cancel`, and `tbtree.snapshots` shrinks only via `Snapshot.Close()`, so **each failure leaked one permanently**. After `maxActiveSnapshots` (default 100) failures, every new transaction failed with `tbtree: max active snapshots limit reached` until the server was restarted. The reporter hit this four times in production, with a 1:1 correlation between failed statements and leaked snapshots.

On the session path it was unrecoverable: with `sqlTx == nil`, `IsClosed()` reports true, so `TxSQLExec` removed the transaction from the session — after which neither the client's `Rollback` nor `Session.RollbackTransactions()` on close/expiry could reach it. That also explains the reported client signature, where `Rollback` answers `no transaction found`.

## The fix

Guard both assignment sites on what actually happened to the transaction, not on the error:

```go
ntx, _, err := tx.db.SQLExec(ctx, tx.sqlTx, request)
if ntx != nil || tx.sqlTx.Closed() {
    tx.sqlTx = ntx
}
```

- **Pre-execution error** — the engine never touched the tx, so it stays open and owned by the session. `Rollback` now succeeds instead of answering `no transaction found`, and close/expiry can reclaim it. Leak gone.
- **Execution error** — the engine already called `currTx.Cancel()`, so the tx is closed, the reference is replaced and the session drops it. **No behaviour change.**
- **`COMMIT;`** — returns `ntx == nil` with a closed tx, so the assignment still happens.

### Why here and not in the engine

The issue proposed fixing `Engine.Exec`. That would not have fixed it: the session path parses in `db.SQLExec` (`pkg/database/sql.go:364`) and returns before the engine is ever reached. `engine.go:756` is a second, independent instance of the same defect, reachable only by embedded users.

More importantly, the engine returning `nil` is not itself the leak — a caller that passes `tx` in still owns it. The leak is assigning that `nil` over the only reference to a still-open tx. Pre-execution returns that leave the tx open include:

- `pkg/database/sql.go:364` / `:379` / `:386` — parse error, empty statement list, replica
- `embedded/sql/engine.go:756` / `:795` / `:800` / `:809` — parse error, empty list, `normalizeParams` failure, `nil` statement

Guarding the two reference-owning callers closes all of them at once. Patching individual early returns would keep regressing as new ones are added.

## Tests

Three tests in `transactions_test.go`, **written before the fix and confirmed to fail without it**:

| Test | Without the fix |
|---|---|
| `TestSQLExecPreExecutionErrorKeepsTxOpen` | fails — `IsClosed()` true, `Rollback()` returns `ErrNoOngoingTx` |
| `TestSQLExecPreExecutionErrorDoesNotLeakSnapshots` | fails at **iteration 4 of 4** (`maxActiveSnapshots = 4`) with the snapshot-limit error, reproducing the reported 1:1 correlation |
| `TestSQLExecExecutionErrorClosesTx` | passes — pins existing behaviour so this change cannot silently alter the execution-error path |

The leak test mirrors the reported production cycle, including the client carrying on after its rollback fails.

## Verification

- `go build ./...` clean
- `go test ./pkg/server/sessions/... ./pkg/server/ ./pkg/pgsql/server/... ./pkg/database/...` — 10 packages pass
- `go test ./embedded/sql/... ./embedded/tbtree/...` pass
- Commit is GPG-signed

The pgsql suite matters here because the second hunk touches the extended-query path recently changed by `ce64e941` and `c4a5beed`.